### PR TITLE
[server] Propose-time content quality guards

### DIFF
--- a/FORK_DELTA.md
+++ b/FORK_DELTA.md
@@ -27,11 +27,19 @@ See [`docs/decisions/08-agent-side-fork.md`](https://github.com/OneZero1ai/8th-l
 
 These are the open protocol; they stay open and we want full interoperability with vanilla cq remotes and other cq-protocol-compatible clients.
 
+## Server-side additions (provisional, candidates to upstream)
+
+These DO touch the server, which the policy above said we wouldn't. Each is a deliberate exception, narrow in scope, and should be proposed upstream as a PR after we've battle-tested them in our deployment:
+
+- **`server/backend/src/cq_server/quality.py`** — propose-time content quality guards. Rejects KU shapes that are clearly placeholder (`domains:['test']`, summary=='test', summary==detail, sub-threshold lengths). The `/propose` endpoint is the choke-point because cq's PoC has no admin-side delete, so junk has to be stopped at intake. Generic content-quality, not 8L-specific — should upstream once stable. Tracked as `OneZero1ai/crosstalk-enterprise#24`.
+
+  *Why this is a justified deviation from the "do not modify server" policy:* a forking project that deploys cq Remote in production needs intake-time integrity guards that the upstream PoC doesn't yet have. Without them, smoke-test garbage and project-internal manifesto KUs accumulate and pollute the queryable commons. The fix is general (any cq deployment benefits) so the right long-term home is upstream — but we need it deployed today.
+
 ## Sync discipline
 
 - **Fork base**: pinned at the cq commit at the time of fork creation (2026-04-26).
 - **Upstream sync cadence**: monthly, or on cq-tagged release.
-- **Contribution back**: bug fixes + perf + protocol clarifications get pushed upstream as PRs to `mozilla-ai/cq`.
+- **Contribution back**: bug fixes + perf + protocol clarifications get pushed upstream as PRs to `mozilla-ai/cq`. The `quality.py` module above is on this list.
 - **Stays in fork**: enterprise-specific capabilities (AIGRP routing, DID-KMS bridge, multi-tenancy, FIPS hooks) — not relevant to upstream's open-standard project scope.
 
 ## Mozilla.AI partnership

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -22,6 +22,7 @@ from starlette.responses import FileResponse
 
 from .auth import router as auth_router
 from .deps import API_KEY_PEPPER_ENV, require_api_key
+from .quality import check_propose_quality
 from .review import router as review_router
 from .scoring import apply_confirmation, apply_flag
 from .store import RemoteStore, normalize_domains
@@ -126,6 +127,9 @@ def propose_unit(
     normalized = normalize_domains(request.domains)
     if not normalized:
         raise HTTPException(status_code=422, detail="At least one non-empty domain is required")
+    quality_reason = check_propose_quality(normalized, request.insight)
+    if quality_reason is not None:
+        raise HTTPException(status_code=422, detail=f"propose quality guard: {quality_reason}")
     unit = create_knowledge_unit(
         domains=normalized,
         insight=request.insight,

--- a/server/backend/src/cq_server/quality.py
+++ b/server/backend/src/cq_server/quality.py
@@ -1,0 +1,99 @@
+"""Propose-time content quality guards.
+
+Reject KU shapes that are clearly placeholder, smoke-test, or internal-status
+content before they pollute the commons. The /propose endpoint is the
+choke-point — once a KU lands and is approved, removal requires admin DB
+access (no public delete endpoint in cq's PoC).
+
+These guards are intentionally narrow and conservative: only obvious junk
+patterns. Real content-quality judgment lives client-side in /cq:reflect's
+skill instructions; this is the server-side last-line-of-defense for
+degenerate inputs that no honest agent should be sending.
+
+Each guard returns a `(reject, reason)` tuple. None means accept; a string
+means reject with that explanation.
+"""
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+from cq.models import Insight
+
+# Domain sets that indicate placeholder content. Comparison is order-insensitive.
+PLACEHOLDER_DOMAIN_SETS: tuple[frozenset[str], ...] = (
+    frozenset({"test"}),
+    frozenset({"placeholder"}),
+    frozenset({"foo"}),
+    frozenset({"bar"}),
+    frozenset({"example"}),
+    frozenset({"sample"}),
+)
+
+# Summary text that's clearly a placeholder.
+_PLACEHOLDER_SUMMARY_RE = re.compile(
+    r"^(test|placeholder|sample|foo|bar|baz|example|lorem|todo)\.?\s*$",
+    re.IGNORECASE,
+)
+
+# Hard minimum lengths. These bars are intentionally low — narrow enough to
+# catch pure-junk inputs (summary='ok') without rejecting legitimately terse
+# insights. The placeholder regex above handles the obvious one-word junk;
+# these handle the general "too short to mean anything" case.
+_MIN_SUMMARY_LEN = 20
+_MIN_DETAIL_LEN = 30
+_MIN_ACTION_LEN = 15
+
+
+def _normalize(s: str) -> str:
+    return (s or "").strip().lower()
+
+
+def _placeholder_domains(domains: Iterable[str]) -> bool:
+    """True if the domain set is a known placeholder shape."""
+    norm = frozenset(_normalize(d) for d in domains if d.strip())
+    if not norm:
+        return False
+    return any(norm == placeholder for placeholder in PLACEHOLDER_DOMAIN_SETS)
+
+
+def _placeholder_summary(summary: str) -> bool:
+    return bool(_PLACEHOLDER_SUMMARY_RE.match((summary or "").strip()))
+
+
+def _too_short(insight: Insight) -> str | None:
+    if len(insight.summary.strip()) < _MIN_SUMMARY_LEN:
+        return f"summary must be at least {_MIN_SUMMARY_LEN} chars"
+    if len(insight.detail.strip()) < _MIN_DETAIL_LEN:
+        return f"detail must be at least {_MIN_DETAIL_LEN} chars"
+    if len(insight.action.strip()) < _MIN_ACTION_LEN:
+        return f"action must be at least {_MIN_ACTION_LEN} chars"
+    return None
+
+
+def _summary_equals_detail(insight: Insight) -> bool:
+    """Degenerate input where summary and detail say the same thing."""
+    return _normalize(insight.summary) == _normalize(insight.detail)
+
+
+def check_propose_quality(domains: list[str], insight: Insight) -> str | None:
+    """Run all quality guards on a proposed KU.
+
+    Returns None if the unit passes all guards; a human-readable rejection
+    reason otherwise. Callers (e.g. the /propose endpoint) should map a
+    non-None return to HTTP 422 with the reason as the detail.
+    """
+    if _placeholder_domains(domains):
+        return "domain set is a placeholder shape (e.g. ['test']); use real domain tags"
+
+    if _placeholder_summary(insight.summary):
+        return "summary is a placeholder word; describe a specific insight"
+
+    too_short = _too_short(insight)
+    if too_short is not None:
+        return too_short
+
+    if _summary_equals_detail(insight):
+        return "summary and detail are identical; detail must add context the summary doesn't"
+
+    return None

--- a/server/backend/tests/test_app.py
+++ b/server/backend/tests/test_app.py
@@ -122,6 +122,33 @@ class TestPropose:
         assert resp.status_code == 201
         assert resp.json()["domains"] == ["api", "databases"]
 
+    def test_propose_with_test_only_domain_rejected(self, client: TestClient) -> None:
+        # Reproduces the ranger smoke-test garbage pattern that polluted the
+        # commons before quality guards landed.
+        payload = _propose_payload(domains=["test"])
+        resp = client.post("/propose", json=payload)
+        assert resp.status_code == 422
+        assert "placeholder" in resp.json()["detail"].lower()
+
+    def test_propose_with_placeholder_summary_rejected(self, client: TestClient) -> None:
+        payload = _propose_payload(insight={
+            "summary": "test",
+            "detail": "this is a long enough detail that it would normally pass length checks",
+            "action": "do the thing",
+        })
+        resp = client.post("/propose", json=payload)
+        assert resp.status_code == 422
+        assert "placeholder" in resp.json()["detail"].lower()
+
+    def test_propose_with_summary_eq_detail_rejected(self, client: TestClient) -> None:
+        payload = _propose_payload(insight={
+            "summary": "Connections are expensive to create at request time",
+            "detail": "Connections are expensive to create at request time",
+            "action": "Use a connection pool with max size 10.",
+        })
+        resp = client.post("/propose", json=payload)
+        assert resp.status_code == 422
+
 
 class TestQuery:
     def _insert_unit(self, client: TestClient, **overrides: Any) -> dict[str, Any]:

--- a/server/backend/tests/test_quality.py
+++ b/server/backend/tests/test_quality.py
@@ -1,0 +1,130 @@
+"""Tests for the propose-time content quality guards."""
+from __future__ import annotations
+
+from typing import Any
+
+from cq.models import Insight
+from cq_server.quality import check_propose_quality
+
+
+def _good_insight() -> Insight:
+    return Insight(
+        summary="Use connection pooling for DB clients",
+        detail="Database connections are expensive to create at request time.",
+        action="Configure a connection pool with a max size of 10.",
+    )
+
+
+def _good_domains() -> list[str]:
+    return ["databases", "performance"]
+
+
+class TestPlaceholderDomains:
+    def test_test_only_domain_rejected(self) -> None:
+        reason = check_propose_quality(["test"], _good_insight())
+        assert reason is not None
+        assert "placeholder" in reason
+
+    def test_foo_only_domain_rejected(self) -> None:
+        reason = check_propose_quality(["foo"], _good_insight())
+        assert reason is not None
+
+    def test_example_only_domain_rejected(self) -> None:
+        reason = check_propose_quality(["example"], _good_insight())
+        assert reason is not None
+
+    def test_test_with_other_domain_accepted(self) -> None:
+        # If the agent mixes 'test' with a real tag (e.g. 'pytest', 'testing'),
+        # we accept — the placeholder check is on the entire set being trivial.
+        reason = check_propose_quality(["test", "pytest"], _good_insight())
+        assert reason is None
+
+
+class TestPlaceholderSummary:
+    def test_summary_test_rejected(self) -> None:
+        ins = _good_insight()
+        ins.summary = "test"
+        reason = check_propose_quality(_good_domains(), ins)
+        assert reason is not None
+
+    def test_summary_test_with_punctuation_rejected(self) -> None:
+        ins = _good_insight()
+        ins.summary = "Test."
+        reason = check_propose_quality(_good_domains(), ins)
+        assert reason is not None
+
+    def test_summary_lorem_rejected(self) -> None:
+        ins = _good_insight()
+        ins.summary = "lorem"
+        reason = check_propose_quality(_good_domains(), ins)
+        assert reason is not None
+
+    def test_summary_todo_rejected(self) -> None:
+        ins = _good_insight()
+        ins.summary = "todo"
+        reason = check_propose_quality(_good_domains(), ins)
+        assert reason is not None
+
+
+class TestLengthGuards:
+    def test_too_short_summary_rejected(self) -> None:
+        ins = _good_insight()
+        ins.summary = "ok"
+        reason = check_propose_quality(_good_domains(), ins)
+        assert reason is not None
+        assert "summary" in reason.lower()
+
+    def test_too_short_detail_rejected(self) -> None:
+        ins = _good_insight()
+        ins.detail = "yes"
+        reason = check_propose_quality(_good_domains(), ins)
+        assert reason is not None
+        assert "detail" in reason.lower()
+
+    def test_too_short_action_rejected(self) -> None:
+        ins = _good_insight()
+        ins.action = "fix"
+        reason = check_propose_quality(_good_domains(), ins)
+        assert reason is not None
+        assert "action" in reason.lower()
+
+
+class TestSummaryEqualsDetail:
+    def test_identical_strings_rejected(self) -> None:
+        ins = _good_insight()
+        ins.summary = "Use connection pooling for the database client"
+        ins.detail = "Use connection pooling for the database client"
+        reason = check_propose_quality(_good_domains(), ins)
+        assert reason is not None
+        assert "identical" in reason.lower()
+
+    def test_case_only_difference_rejected(self) -> None:
+        ins = _good_insight()
+        ins.summary = "Use Connection Pooling for the database client"
+        ins.detail = "use connection pooling for the database client"
+        reason = check_propose_quality(_good_domains(), ins)
+        assert reason is not None
+
+
+class TestAcceptanceCases:
+    def test_well_formed_insight_accepted(self) -> None:
+        reason = check_propose_quality(_good_domains(), _good_insight())
+        assert reason is None
+
+    def test_long_summary_accepted(self) -> None:
+        ins = _good_insight()
+        ins.summary = "A very specific gotcha that took an hour to debug and is worth sharing"
+        reason = check_propose_quality(_good_domains(), ins)
+        assert reason is None
+
+    def test_real_world_propose_shape_accepted(self) -> None:
+        # Mirror the shape Strands probes produce in production.
+        reason = check_propose_quality(
+            ["lambda", "vpc", "cold-start"],
+            Insight(
+                summary="VPC-attached Lambda functions cannot reach public APIs by default",
+                detail="When a Lambda is configured with a VPC, outbound traffic routes through the VPC. Without a NAT gateway or VPC endpoint, public APIs are unreachable. The error appears as a generic timeout, not a network-error, masking the cause.",
+                action="Add a NAT gateway in a public subnet and route the Lambda's private subnet through it, OR add VPC endpoints for the specific AWS services the Lambda calls.",
+            ),
+        )
+        assert reason is None


### PR DESCRIPTION
## Why

cq's PoC has no admin-side delete endpoint. Once a KU is approved, it stays in the commons forever (only `flag` lowers confidence). So intake-time integrity guards are the only real path to prevent junk from polluting the queryable surface.

This branch adds a propose-time content quality guard that rejects shapes that are clearly placeholder, smoke-test, or degenerate input.

## What gets rejected (HTTP 422)

| Pattern | Example | Reason |
|---|---|---|
| placeholder domain set | `domains: ["test"]` | not a real topic |
| placeholder summary word | `summary: "test"`, `"todo"` | not a real insight |
| sub-threshold length | `summary: "ok"` (< 20 chars) | too short to carry knowledge |
| summary equals detail | both lines say the same thing | degenerate; detail must add context |

## What does NOT get rejected

- Mixed domains: `["test", "pytest"]` is fine — the placeholder check is on the entire set being trivial
- Project-internal naming patterns: operator-policy territory, not protocol-level. Relies on `/cq:reflect` skill instructions for that layer.
- Slightly terse but meaningful insights — length thresholds (20/30/15) are intentionally conservative.

## Why this is in the fork (and a FORK_DELTA exception)

Per `FORK_DELTA.md`, policy was "don't modify server-side REST contracts." This is a deliberate exception: cq deployments in production need intake guards the PoC doesn't ship, and we need it deployed today. The change is generic, so the right long-term home is `mozilla-ai/cq` upstream.

`FORK_DELTA.md` updated to record this exception and mark it as a candidate to upstream once battle-tested.

## Tests

24 affected tests pass:
- `tests/test_quality.py` — 16 unit tests covering each guard + acceptance cases
- `tests/test_app.py::TestPropose` — 3 HTTP-level integration tests reproducing the actual junk patterns we saw today

```
============================== 24 passed in 1.20s ==============================
```

## Tracking

- 8L incident: OneZero1ai/crosstalk-enterprise#24
- Today's pollution: 4 ranger smoke-test KUs (`domains:['test']`), 4 internal-status KUs — all rejected/flagged manually before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)