### PR TITLE
[server] Admin DELETE /review/{ku_id} for hard-removing approved KUs + test cleanup

### DIFF
--- a/server/backend/src/cq_server/review.py
+++ b/server/backend/src/cq_server/review.py
@@ -182,6 +182,39 @@ def reject_unit(
     return _build_decision(unit_id, updated)
 
 
+@router.delete("/{unit_id}", status_code=204)
+def delete_unit(
+    unit_id: str,
+    username: str = Depends(get_current_user),
+    store: RemoteStore = Depends(get_store),
+) -> None:
+    """Hard-delete a knowledge unit (admin-only — already enforced by JWT).
+
+    Used to remove KUs that should never have been approved (smoke-test garbage,
+    pre-quality-guard pollution, etc.). Confidence-flagging via /flag is the
+    soft path; this is the irreversible nuclear option.
+
+    Args:
+        unit_id: The knowledge unit identifier.
+        username: The authenticated reviewer's username (audit only).
+        store: The remote store dependency.
+
+    Returns:
+        204 No Content on successful delete.
+
+    Raises:
+        HTTPException: With status 404 if the unit does not exist.
+    """
+    deleted = store.delete(unit_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Knowledge unit not found")
+    # Audit context: username is captured implicitly via FastAPI logs;
+    # the review_records table (if populated) preserves prior approve/reject
+    # decisions. We deliberately do not insert a synthetic delete-record;
+    # the absence of the KU + the surviving review trail is the audit shape.
+    return None
+
+
 @router.get("/stats")
 def review_stats(
     _user: str = Depends(get_current_user),

--- a/server/backend/src/cq_server/store/__init__.py
+++ b/server/backend/src/cq_server/store/__init__.py
@@ -146,6 +146,28 @@ class RemoteStore:
                 [(unit.id, d) for d in domains],
             )
 
+    def delete(self, unit_id: str) -> bool:
+        """Hard-delete a knowledge unit by ID.
+
+        Removes the row from knowledge_units and cascades to
+        knowledge_unit_domains. Does NOT touch review_records — the audit
+        trail of why each KU was approved/rejected/now-deleted should
+        survive the deletion of the underlying KU.
+
+        Returns True if a row was deleted, False if no such ID existed.
+        """
+        self._check_open()
+        with self._lock, self._conn:
+            cur = self._conn.execute(
+                "DELETE FROM knowledge_unit_domains WHERE unit_id = ?",
+                (unit_id,),
+            )
+            cur = self._conn.execute(
+                "DELETE FROM knowledge_units WHERE id = ?",
+                (unit_id,),
+            )
+            return cur.rowcount > 0
+
     def get(self, unit_id: str) -> KnowledgeUnit | None:
         """Retrieve an approved knowledge unit by ID.
 

--- a/server/backend/tests/test_admin_delete.py
+++ b/server/backend/tests/test_admin_delete.py
@@ -1,0 +1,105 @@
+"""Tests for the admin DELETE /review/{ku_id} endpoint."""
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import bcrypt
+import pytest
+from fastapi.testclient import TestClient
+
+from cq_server.app import app
+from cq_server.deps import require_api_key
+
+TEST_USERNAME = "test-user"
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "test.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    app.dependency_overrides[require_api_key] = lambda: TEST_USERNAME
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.pop(require_api_key, None)
+
+
+def _propose_payload(**overrides: Any) -> dict[str, Any]:
+    defaults: dict[str, Any] = {
+        "domains": ["databases", "performance"],
+        "insight": {
+            "summary": "Use connection pooling for DB clients",
+            "detail": "Database connections are expensive to create at request time.",
+            "action": "Configure a connection pool with a max size of 10.",
+        },
+    }
+    return {**defaults, **overrides}
+
+
+def _admin_jwt(client: TestClient) -> str:
+    """Bootstrap an admin user + return a JWT for /review/* endpoints."""
+    from cq_server.app import _get_store
+
+    store = _get_store()
+    pw_hash = bcrypt.hashpw(b"admin", bcrypt.gensalt()).decode()
+    try:
+        store.create_user("admin", pw_hash)
+    except Exception:
+        pass  # already exists
+    resp = client.post("/auth/login", json={"username": "admin", "password": "admin"})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+class TestAdminDelete:
+    def test_delete_existing_unit_returns_204(self, client: TestClient) -> None:
+        proposed = client.post("/propose", json=_propose_payload()).json()
+        ku_id = proposed["id"]
+        jwt = _admin_jwt(client)
+        resp = client.delete(f"/review/{ku_id}", headers={"Authorization": f"Bearer {jwt}"})
+        assert resp.status_code == 204
+
+    def test_delete_makes_unit_unreachable_via_review(self, client: TestClient) -> None:
+        proposed = client.post("/propose", json=_propose_payload()).json()
+        ku_id = proposed["id"]
+        jwt = _admin_jwt(client)
+        client.delete(f"/review/{ku_id}", headers={"Authorization": f"Bearer {jwt}"})
+        resp = client.get(f"/review/{ku_id}", headers={"Authorization": f"Bearer {jwt}"})
+        assert resp.status_code == 404
+
+    def test_delete_nonexistent_unit_returns_404(self, client: TestClient) -> None:
+        jwt = _admin_jwt(client)
+        resp = client.delete(
+            "/review/ku_doesnotexist",
+            headers={"Authorization": f"Bearer {jwt}"},
+        )
+        assert resp.status_code == 404
+
+    def test_delete_without_jwt_rejected(self, client: TestClient) -> None:
+        proposed = client.post("/propose", json=_propose_payload()).json()
+        ku_id = proposed["id"]
+        resp = client.delete(f"/review/{ku_id}")
+        assert resp.status_code in (401, 403)
+
+    def test_delete_removes_from_underlying_store(self, client: TestClient) -> None:
+        from cq_server.app import _get_store
+
+        proposed = client.post("/propose", json=_propose_payload()).json()
+        ku_id = proposed["id"]
+        store = _get_store()
+        assert store.get_any(ku_id) is not None
+
+        jwt = _admin_jwt(client)
+        client.delete(f"/review/{ku_id}", headers={"Authorization": f"Bearer {jwt}"})
+        assert store.get_any(ku_id) is None
+
+    def test_store_delete_returns_false_for_missing_id(self, client: TestClient) -> None:
+        # The fixture initializes the store via app startup; need it to exist
+        # before calling _get_store().
+        from cq_server.app import _get_store
+
+        _ = client  # pull fixture so app is initialized
+        store = _get_store()
+        assert store.delete("ku_definitelynotreal") is False

--- a/server/backend/tests/test_review.py
+++ b/server/backend/tests/test_review.py
@@ -44,9 +44,9 @@ def _propose(client: TestClient, **overrides: Any) -> dict[str, Any]:
     defaults: dict[str, Any] = {
         "domains": ["api", "testing"],
         "insight": {
-            "summary": "Test insight",
-            "detail": "Detail here.",
-            "action": "Do the thing.",
+            "summary": "An API testing insight worth sharing",
+            "detail": "When testing API endpoints, validate response shape against the schema, not just status codes.",
+            "action": "Use schema-aware assertions in API tests.",
         },
     }
     resp = client.post("/propose", json={**defaults, **overrides})
@@ -206,7 +206,7 @@ class TestGetUnit:
         assert resp.status_code == 200
         body = resp.json()
         assert body["knowledge_unit"]["id"] == unit["id"]
-        assert body["knowledge_unit"]["insight"]["summary"] == "Test insight"
+        assert body["knowledge_unit"]["insight"]["summary"] == "An API testing insight worth sharing"
         assert body["status"] == "pending"
         assert body["reviewed_by"] is None
 


### PR DESCRIPTION
Tracks OneZero1ai/crosstalk-enterprise#25.

## What

`DELETE /review/{ku_id}` admin endpoint. Hard-removes a KU from the store. PoC currently has no delete; only `flag` lowers confidence. Needed to clean up KUs that should never have been approved (smoke-test garbage, pre-quality-guard pollution, operator-error-causing-bad-approve scenarios).

## Behavior

- Admin JWT only (existing /review/* middleware enforces this)
- 204 No Content on success
- 404 if unit_id doesn't exist
- 401/403 without admin auth
- Hard-deletes from `knowledge_units`, cascades to `knowledge_unit_domains`
- Does NOT cascade to `review_records` — preserves audit trail

## Tests

- `tests/test_admin_delete.py` — 6 cases
- Also fixed 21 tests in `tests/test_review.py` that were broken by #1's quality guard (default propose payload was below new minimum lengths)
- All 231 tests pass

## After deploy

Cleanup pass on the live commons:
- `ku_fd21f346…` 'claude-mux 8l-cq integration end-to-end verified'
- `ku_eb225a5c…` 'Per-persona attribution smoke-test'
- `ku_f07cc8f0…` '8th-Layer.ai Phase 1 MVP deployed end-to-end'
- `ku_c3f48880…` 'test' / domains:['test']

🤖 Generated with [Claude Code](https://claude.com/claude-code)