### PR TITLE
AIGRP: peer-mesh endpoints + EIGRP-style P2P bootstrap

### DIFF
--- a/server/backend/src/cq_server/aigrp.py
+++ b/server/backend/src/cq_server/aigrp.py
@@ -1,0 +1,157 @@
+"""AIGRP — peer-to-peer mesh inside an Enterprise (EIGRP-shaped).
+
+Each L2 in an Enterprise establishes peer relationships directly with its
+sibling L2s and exchanges *signatures* (centroid + domain Bloom filter),
+never raw KU bytes. New L2s join via a seed-peer URL + shared Enterprise
+key; the seed floods the new L2's existence to its known peers, converging
+to a full mesh over a few polling intervals.
+
+This module owns:
+- Peer-key auth dependency (Bearer EnterprisePeerKey)
+- Signature computation (centroid of approved KU embeddings + Bloom of domains)
+- Peer-table persistence helpers (against the shared SQLite store)
+
+The /aigrp/* HTTP endpoints live in app.py and call into this module.
+
+Cross-Enterprise mesh is intentionally out of scope here; that's the AI-BGP
+protocol (separate spec, future work).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import struct
+from datetime import UTC, datetime
+from typing import Iterable
+
+from fastapi import HTTPException, Request
+
+logger = logging.getLogger(__name__)
+
+
+# Bloom filter parameters — tuned for ~1000 distinct domain tags per L2 with
+# < 1% false positive rate. 8192 bits = 1 KB; cheap to ship.
+BLOOM_BITS = 8192
+BLOOM_HASHES = 5
+
+
+def is_first_deploy() -> bool:
+    """Return True iff this L2 is the genesis node for its Enterprise."""
+    return os.environ.get("CQ_AIGRP_IS_FIRST_DEPLOY", "false").lower() == "true"
+
+
+def seed_peer_url() -> str:
+    """The peer URL we should bootstrap from. Empty when first-deploy."""
+    return os.environ.get("CQ_AIGRP_SEED_PEER_URL", "").rstrip("/")
+
+
+def self_url() -> str:
+    """Externally reachable URL of *this* L2 — included in /aigrp/hello so
+    the seed can call us back / record us in its peer table."""
+    return os.environ.get("CQ_AIGRP_SELF_URL", "").rstrip("/")
+
+
+def enterprise() -> str:
+    return os.environ.get("CQ_ENTERPRISE", "default-enterprise")
+
+
+def group() -> str:
+    return os.environ.get("CQ_GROUP", "default")
+
+
+def self_l2_id() -> str:
+    """Canonical L2 identity — Enterprise/Group."""
+    return f"{enterprise()}/{group()}"
+
+
+def aigrp_enabled() -> bool:
+    """Disable AIGRP entirely when no peer key is configured.
+
+    Lets the cq Remote run in legacy single-L2 mode (e.g., the existing
+    `mvp` stack with no AIGRP wiring) without crashing or hammering /aigrp
+    against itself."""
+    return bool(os.environ.get("CQ_AIGRP_PEER_KEY"))
+
+
+def require_peer_key(request: Request) -> None:
+    """FastAPI dependency: validate the shared EnterprisePeerKey on /aigrp/* calls."""
+    expected = os.environ.get("CQ_AIGRP_PEER_KEY", "")
+    if not expected:
+        raise HTTPException(status_code=503, detail="AIGRP not configured on this L2")
+    auth = request.headers.get("authorization", "")
+    if not auth.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="missing peer key")
+    presented = auth[7:]
+    # constant-time compare
+    if len(presented) != len(expected):
+        raise HTTPException(status_code=401, detail="invalid peer key")
+    diff = 0
+    for a, b in zip(presented, expected, strict=True):
+        diff |= ord(a) ^ ord(b)
+    if diff != 0:
+        raise HTTPException(status_code=401, detail="invalid peer key")
+
+
+def _bloom_hashes(domain: str) -> list[int]:
+    """Return BLOOM_HASHES bit indices for a domain string."""
+    digest = hashlib.sha256(domain.encode()).digest()
+    return [int.from_bytes(digest[i * 4 : i * 4 + 4], "little") % BLOOM_BITS for i in range(BLOOM_HASHES)]
+
+
+def compute_domain_bloom(domains: Iterable[str]) -> bytes:
+    """Build a fixed-size Bloom filter over the given domain set.
+
+    Returns BLOOM_BITS / 8 bytes. Stable, deterministic — same input yields
+    same output, so a peer's bloom can be diffed across polls to detect
+    growth.
+    """
+    bitmap = bytearray(BLOOM_BITS // 8)
+    for d in domains:
+        if not d:
+            continue
+        for h in _bloom_hashes(d.strip().lower()):
+            byte_idx = h // 8
+            bit_idx = h % 8
+            bitmap[byte_idx] |= 1 << bit_idx
+    return bytes(bitmap)
+
+
+def compute_centroid(embeddings_iter: Iterable[bytes]) -> bytes | None:
+    """Compute the L2-normalized centroid of an iterable of packed-float32 LE
+    embedding blobs. Returns packed-float32 LE bytes, or None if no embeddings.
+
+    Centroid is the average direction of the corpus — semantic match against
+    a query gives a coarse "does this L2 know about this topic?" signal.
+    """
+    import numpy as np
+
+    total = None
+    count = 0
+    for blob in embeddings_iter:
+        if not blob:
+            continue
+        vec = np.frombuffer(blob, dtype=np.float32)
+        if vec.size == 0:
+            continue
+        norm = np.linalg.norm(vec)
+        if norm == 0:
+            continue
+        vec = vec / norm
+        if total is None:
+            total = vec.copy()
+        else:
+            total += vec
+        count += 1
+    if count == 0 or total is None:
+        return None
+    centroid = total / count
+    norm = np.linalg.norm(centroid)
+    if norm > 0:
+        centroid = centroid / norm
+    return struct.pack(f"<{len(centroid)}f", *centroid.astype(np.float32))
+
+
+def now_iso() -> str:
+    return datetime.now(UTC).isoformat()

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -1,5 +1,6 @@
 """cq knowledge store API."""
 
+import json
 import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -20,9 +21,11 @@ from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 from starlette.responses import FileResponse
 
+from . import aigrp
 from .auth import router as auth_router
 from .deps import API_KEY_PEPPER_ENV, require_api_key
 from .embed import compose_text, embed_text
+from .embed import model_id as embed_model_id
 from .quality import check_propose_quality
 from .review import router as review_router
 from .scoring import apply_confirmation, apply_flag
@@ -64,9 +67,107 @@ def _get_store() -> RemoteStore:
     return _store
 
 
+async def _aigrp_bootstrap_and_poll(store: RemoteStore) -> None:
+    """Bootstrap into the Enterprise mesh on first start, then poll
+    every known peer's /aigrp/signature on a 5-min interval forever.
+
+    Best-effort: any individual call failure is logged and skipped;
+    convergence happens on the next poll. This task lives for the
+    lifetime of the FastAPI process.
+    """
+    import asyncio
+    import logging
+    import urllib.request
+
+    log = logging.getLogger("aigrp")
+    poll_interval = int(os.environ.get("CQ_AIGRP_POLL_INTERVAL_SEC", "300"))
+
+    # 1. If not first deploy, hit the seed peer's /aigrp/hello once.
+    if not aigrp.is_first_deploy() and aigrp.seed_peer_url():
+        try:
+            hello_payload = json.dumps({
+                "l2_id": aigrp.self_l2_id(),
+                "enterprise": aigrp.enterprise(),
+                "group": aigrp.group(),
+                "endpoint_url": aigrp.self_url(),
+            }).encode()
+            req = urllib.request.Request(
+                f"{aigrp.seed_peer_url()}/api/v1/aigrp/hello",
+                method="POST",
+                data=hello_payload,
+                headers={
+                    "content-type": "application/json",
+                    "authorization": f"Bearer {os.environ.get('CQ_AIGRP_PEER_KEY', '')}",
+                },
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                body = json.loads(resp.read())
+            for p in body.get("peers", []):
+                if p.get("l2_id") == aigrp.self_l2_id():
+                    continue
+                store.upsert_aigrp_peer(
+                    l2_id=p["l2_id"],
+                    enterprise=p["enterprise"],
+                    group=p["group"],
+                    endpoint_url=p["endpoint_url"],
+                    embedding_centroid=None,
+                    domain_bloom=None,
+                    ku_count=p.get("ku_count", 0),
+                    domain_count=p.get("domain_count", 0),
+                    embedding_model=p.get("embedding_model"),
+                    signature_received=False,
+                )
+            log.info("aigrp bootstrap: seed=%s peers=%d", aigrp.seed_peer_url(), len(body.get("peers", [])))
+        except Exception:
+            log.exception("aigrp bootstrap to seed=%s failed; will retry via poll loop", aigrp.seed_peer_url())
+
+    # 2. Periodic peer-poll loop — fetch each peer's /aigrp/signature.
+    import base64
+
+    while True:
+        try:
+            await asyncio.sleep(poll_interval)
+            peers = store.list_aigrp_peers(aigrp.enterprise())
+            for p in peers:
+                if p["l2_id"] == aigrp.self_l2_id():
+                    continue
+                if not p["endpoint_url"]:
+                    continue
+                try:
+                    req = urllib.request.Request(
+                        f"{p['endpoint_url'].rstrip('/')}/api/v1/aigrp/signature",
+                        method="GET",
+                        headers={"authorization": f"Bearer {os.environ.get('CQ_AIGRP_PEER_KEY', '')}"},
+                    )
+                    with urllib.request.urlopen(req, timeout=10) as resp:
+                        sig = json.loads(resp.read())
+                    centroid = base64.b64decode(sig["embedding_centroid_b64"]) if sig.get("embedding_centroid_b64") else None
+                    bloom = base64.b64decode(sig["domain_bloom_b64"]) if sig.get("domain_bloom_b64") else None
+                    store.upsert_aigrp_peer(
+                        l2_id=sig["l2_id"],
+                        enterprise=sig["enterprise"],
+                        group=sig["group"],
+                        endpoint_url=sig.get("endpoint_url") or p["endpoint_url"],
+                        embedding_centroid=centroid,
+                        domain_bloom=bloom,
+                        ku_count=sig.get("ku_count", 0),
+                        domain_count=sig.get("domain_count", 0),
+                        embedding_model=sig.get("embedding_model"),
+                        signature_received=True,
+                    )
+                except Exception:
+                    log.warning("aigrp poll of peer %s failed", p["l2_id"])
+        except asyncio.CancelledError:
+            return
+        except Exception:
+            log.exception("aigrp poll loop iteration crashed; continuing")
+
+
 @asynccontextmanager
 async def lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
-    """Manage the store lifecycle."""
+    """Manage the store lifecycle + AIGRP background task."""
+    import asyncio
+
     global _store  # noqa: PLW0603
     jwt_secret = os.environ.get("CQ_JWT_SECRET")
     if not jwt_secret:
@@ -78,7 +179,19 @@ async def lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
     _store = RemoteStore(db_path=db_path)
     app_instance.state.store = _store
     app_instance.state.api_key_pepper = pepper
+
+    aigrp_task = None
+    if aigrp.aigrp_enabled():
+        aigrp_task = asyncio.create_task(_aigrp_bootstrap_and_poll(_store))
+
     yield
+
+    if aigrp_task is not None:
+        aigrp_task.cancel()
+        try:
+            await aigrp_task
+        except (asyncio.CancelledError, Exception):
+            pass
     _store.close()
 
 
@@ -206,6 +319,221 @@ def aigrp_lookup(
         elapsed_ms=elapsed_ms,
         filtered_count=dropped,
     )
+
+
+class AigrpHelloRequest(BaseModel):
+    """A new L2 introducing itself to a seed peer."""
+
+    l2_id: str = Field(min_length=1, description="canonical Enterprise/Group identity")
+    enterprise: str = Field(min_length=1)
+    group: str = Field(min_length=1)
+    endpoint_url: str = Field(min_length=1, description="how peers should reach me")
+
+
+class AigrpAnnounceRequest(BaseModel):
+    """A peer flooding the existence of another L2 to its sibling peers."""
+
+    l2_id: str = Field(min_length=1)
+    enterprise: str = Field(min_length=1)
+    group: str = Field(min_length=1)
+    endpoint_url: str = Field(min_length=1)
+    announced_by: str = Field(default="", description="l2_id of the peer doing the flooding")
+
+
+class AigrpPeer(BaseModel):
+    """One row from the peer table — wire shape."""
+
+    l2_id: str
+    enterprise: str
+    group: str
+    endpoint_url: str
+    ku_count: int
+    domain_count: int
+    embedding_model: str | None = None
+    first_seen_at: str
+    last_seen_at: str
+    last_signature_at: str | None = None
+
+
+class AigrpPeersResponse(BaseModel):
+    enterprise: str
+    self_l2_id: str
+    peer_count: int
+    peers: list[AigrpPeer]
+
+
+class AigrpSignatureResponse(BaseModel):
+    """This L2's current corpus signature."""
+
+    l2_id: str
+    enterprise: str
+    group: str
+    endpoint_url: str
+    ku_count: int
+    domain_count: int
+    embedding_model: str | None = None
+    embedding_centroid_b64: str | None = None
+    domain_bloom_b64: str | None = None
+    computed_at: str
+
+
+def _build_self_signature(store: RemoteStore) -> AigrpSignatureResponse:
+    """Walk the local approved corpus and produce this L2's signature."""
+    import base64
+
+    embeddings = store.approved_embeddings_iter()
+    centroid = aigrp.compute_centroid(embeddings)
+    domains = store.approved_domains()
+    bloom = aigrp.compute_domain_bloom(domains)
+    return AigrpSignatureResponse(
+        l2_id=aigrp.self_l2_id(),
+        enterprise=aigrp.enterprise(),
+        group=aigrp.group(),
+        endpoint_url=aigrp.self_url(),
+        ku_count=len(embeddings),
+        domain_count=len(domains),
+        embedding_model=embed_model_id() if embeddings else None,
+        embedding_centroid_b64=base64.b64encode(centroid).decode("ascii") if centroid else None,
+        domain_bloom_b64=base64.b64encode(bloom).decode("ascii"),
+        computed_at=aigrp.now_iso(),
+    )
+
+
+@api_router.post("/aigrp/hello", status_code=201)
+def aigrp_hello(
+    body: AigrpHelloRequest,
+    _peer: None = Depends(aigrp.require_peer_key),
+) -> AigrpPeersResponse:
+    """A new L2 announces itself to this seed peer.
+
+    Validates the shared EnterprisePeerKey, refuses if the new L2 claims
+    a different Enterprise. Records the new peer in our local table,
+    then fans out /aigrp/announce to every other known peer (best-effort,
+    background — does not block the hello response).
+    """
+    if body.enterprise != aigrp.enterprise():
+        raise HTTPException(
+            status_code=403,
+            detail=f"this L2 belongs to enterprise={aigrp.enterprise()!r}; refusing hello from {body.enterprise!r}",
+        )
+
+    store = _get_store()
+    store.upsert_aigrp_peer(
+        l2_id=body.l2_id,
+        enterprise=body.enterprise,
+        group=body.group,
+        endpoint_url=body.endpoint_url,
+        embedding_centroid=None,
+        domain_bloom=None,
+        ku_count=0,
+        domain_count=0,
+        embedding_model=None,
+        signature_received=False,
+    )
+
+    # Compose the response — current peer table from this L2's POV.
+    peers = store.list_aigrp_peers(aigrp.enterprise())
+
+    # Fan out the new peer's existence to every other known peer
+    # asynchronously. Failures are best-effort; convergence is via
+    # subsequent polls.
+    import asyncio
+
+    async def _flood() -> None:
+        try:
+            import urllib.request
+
+            announce_payload = json.dumps({
+                "l2_id": body.l2_id,
+                "enterprise": body.enterprise,
+                "group": body.group,
+                "endpoint_url": body.endpoint_url,
+                "announced_by": aigrp.self_l2_id(),
+            }).encode()
+            for p in peers:
+                if p["l2_id"] == body.l2_id or p["l2_id"] == aigrp.self_l2_id():
+                    continue
+                if not p["endpoint_url"]:
+                    continue
+                req = urllib.request.Request(
+                    f"{p['endpoint_url'].rstrip('/')}/api/v1/aigrp/announce",
+                    method="POST",
+                    data=announce_payload,
+                    headers={
+                        "content-type": "application/json",
+                        "authorization": f"Bearer {os.environ.get('CQ_AIGRP_PEER_KEY', '')}",
+                    },
+                )
+                try:
+                    with urllib.request.urlopen(req, timeout=5):
+                        pass
+                except Exception:
+                    pass  # best-effort flood
+
+        except Exception:
+            pass
+
+    asyncio.create_task(_flood())
+
+    return AigrpPeersResponse(
+        enterprise=aigrp.enterprise(),
+        self_l2_id=aigrp.self_l2_id(),
+        peer_count=len(peers),
+        peers=[AigrpPeer(**{k: v for k, v in p.items() if k in AigrpPeer.model_fields}) for p in peers],
+    )
+
+
+@api_router.post("/aigrp/announce", status_code=201)
+def aigrp_announce(
+    body: AigrpAnnounceRequest,
+    _peer: None = Depends(aigrp.require_peer_key),
+) -> dict[str, str]:
+    """A sibling L2 is informing us that a new peer has joined the mesh."""
+    if body.enterprise != aigrp.enterprise():
+        raise HTTPException(
+            status_code=403,
+            detail=f"this L2 belongs to enterprise={aigrp.enterprise()!r}; refusing announce for {body.enterprise!r}",
+        )
+
+    store = _get_store()
+    store.upsert_aigrp_peer(
+        l2_id=body.l2_id,
+        enterprise=body.enterprise,
+        group=body.group,
+        endpoint_url=body.endpoint_url,
+        embedding_centroid=None,
+        domain_bloom=None,
+        ku_count=0,
+        domain_count=0,
+        embedding_model=None,
+        signature_received=False,
+    )
+    return {"recorded": body.l2_id, "by": aigrp.self_l2_id()}
+
+
+@api_router.get("/aigrp/peers")
+def aigrp_peers(
+    _peer: None = Depends(aigrp.require_peer_key),
+) -> AigrpPeersResponse:
+    """Return our current view of the Enterprise's peer mesh."""
+    store = _get_store()
+    peers = store.list_aigrp_peers(aigrp.enterprise())
+    return AigrpPeersResponse(
+        enterprise=aigrp.enterprise(),
+        self_l2_id=aigrp.self_l2_id(),
+        peer_count=len(peers),
+        peers=[AigrpPeer(**{k: v for k, v in p.items() if k in AigrpPeer.model_fields}) for p in peers],
+    )
+
+
+@api_router.get("/aigrp/signature")
+def aigrp_signature(
+    _peer: None = Depends(aigrp.require_peer_key),
+) -> AigrpSignatureResponse:
+    """Return this L2's current corpus signature — centroid + Bloom filter
+    + counts. Polled by every peer on the AIGRP polling interval."""
+    store = _get_store()
+    return _build_self_signature(store)
 
 
 @api_router.get("/query/semantic")

--- a/server/backend/src/cq_server/store/__init__.py
+++ b/server/backend/src/cq_server/store/__init__.py
@@ -17,7 +17,13 @@ from typing import Any
 from cq.models import KnowledgeUnit
 
 from ..scoring import calculate_relevance
-from ..tables import ensure_api_keys_table, ensure_embedding_columns, ensure_review_columns, ensure_users_table
+from ..tables import (
+    ensure_aigrp_peers_table,
+    ensure_api_keys_table,
+    ensure_embedding_columns,
+    ensure_review_columns,
+    ensure_users_table,
+)
 from ._protocol import Store
 
 __all__ = ["DEFAULT_DB_PATH", "RemoteStore", "Store", "normalize_domains"]
@@ -87,6 +93,7 @@ class RemoteStore:
         ensure_embedding_columns(self._conn)
         ensure_users_table(self._conn)
         ensure_api_keys_table(self._conn)
+        ensure_aigrp_peers_table(self._conn)
 
     def _check_open(self) -> None:
         """Raise if the store has been closed."""
@@ -835,6 +842,139 @@ class RemoteStore:
                 )
         except sqlite3.Error:
             _logger.exception("Failed to update last_used_at for api key %s", key_id)
+
+    # -- AIGRP peer mesh -------------------------------------------------
+
+    def upsert_aigrp_peer(
+        self,
+        *,
+        l2_id: str,
+        enterprise: str,
+        group: str,
+        endpoint_url: str,
+        embedding_centroid: bytes | None,
+        domain_bloom: bytes | None,
+        ku_count: int,
+        domain_count: int,
+        embedding_model: str | None,
+        signature_received: bool,
+    ) -> None:
+        """Insert or update an AIGRP peer record.
+
+        signature_received=True means the caller is supplying a fresh
+        signature; we update last_signature_at. signature_received=False
+        means the caller is just announcing the peer's existence (e.g.
+        from /aigrp/hello before the peer's signature is fetched); we
+        leave the signature columns alone if the row already exists.
+        """
+        self._check_open()
+        now = datetime.now(UTC).isoformat()
+        with self._lock, self._conn:
+            existing = self._conn.execute(
+                "SELECT 1 FROM aigrp_peers WHERE l2_id = ?", (l2_id,)
+            ).fetchone()
+            if existing is None:
+                self._conn.execute(
+                    """
+                    INSERT INTO aigrp_peers (
+                        l2_id, enterprise, "group", endpoint_url,
+                        embedding_centroid, domain_bloom, ku_count, domain_count,
+                        embedding_model, first_seen_at, last_seen_at, last_signature_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        l2_id, enterprise, group, endpoint_url,
+                        embedding_centroid, domain_bloom, ku_count, domain_count,
+                        embedding_model, now, now, now if signature_received else None,
+                    ),
+                )
+            elif signature_received:
+                self._conn.execute(
+                    """
+                    UPDATE aigrp_peers SET
+                        enterprise = ?, "group" = ?, endpoint_url = ?,
+                        embedding_centroid = ?, domain_bloom = ?,
+                        ku_count = ?, domain_count = ?, embedding_model = ?,
+                        last_seen_at = ?, last_signature_at = ?
+                    WHERE l2_id = ?
+                    """,
+                    (
+                        enterprise, group, endpoint_url,
+                        embedding_centroid, domain_bloom,
+                        ku_count, domain_count, embedding_model,
+                        now, now, l2_id,
+                    ),
+                )
+            else:
+                # touch last_seen but keep cached signature
+                self._conn.execute(
+                    """
+                    UPDATE aigrp_peers SET
+                        enterprise = ?, "group" = ?, endpoint_url = ?,
+                        last_seen_at = ?
+                    WHERE l2_id = ?
+                    """,
+                    (enterprise, group, endpoint_url, now, l2_id),
+                )
+
+    def list_aigrp_peers(self, enterprise: str) -> list[dict[str, Any]]:
+        """Return every known peer in the given Enterprise (no TTL filter —
+        peers age out via the periodic poll task overwriting last_seen).
+        """
+        self._check_open()
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT l2_id, enterprise, "group", endpoint_url,
+                       embedding_centroid, domain_bloom,
+                       ku_count, domain_count, embedding_model,
+                       first_seen_at, last_seen_at, last_signature_at
+                FROM aigrp_peers
+                WHERE enterprise = ?
+                ORDER BY last_seen_at DESC
+                """,
+                (enterprise,),
+            ).fetchall()
+        return [
+            {
+                "l2_id": r[0],
+                "enterprise": r[1],
+                "group": r[2],
+                "endpoint_url": r[3],
+                "embedding_centroid": r[4],
+                "domain_bloom": r[5],
+                "ku_count": r[6],
+                "domain_count": r[7],
+                "embedding_model": r[8],
+                "first_seen_at": r[9],
+                "last_seen_at": r[10],
+                "last_signature_at": r[11],
+            }
+            for r in rows
+        ]
+
+    def approved_embeddings_iter(self) -> list[bytes]:
+        """Return all non-null approved KU embedding blobs — used to compute
+        this L2's signature centroid."""
+        self._check_open()
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT embedding FROM knowledge_units "
+                "WHERE status = 'approved' AND embedding IS NOT NULL"
+            ).fetchall()
+        return [r[0] for r in rows if r[0]]
+
+    def approved_domains(self) -> set[str]:
+        """Return distinct domains across approved KUs — for the Bloom filter."""
+        self._check_open()
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT DISTINCT d.domain "
+                "FROM knowledge_unit_domains d "
+                "JOIN knowledge_units ku ON ku.id = d.unit_id "
+                "WHERE ku.status = 'approved'"
+            ).fetchall()
+        return {r[0] for r in rows if r[0]}
 
     def confidence_distribution(self) -> dict[str, int]:
         """Return confidence distribution buckets for approved KUs."""

--- a/server/backend/src/cq_server/tables.py
+++ b/server/backend/src/cq_server/tables.py
@@ -15,6 +15,24 @@ _EMBEDDING_COLUMN_STATEMENTS = [
     "ALTER TABLE knowledge_units ADD COLUMN embedding_model TEXT",
 ]
 
+AIGRP_PEERS_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS aigrp_peers (
+    l2_id TEXT PRIMARY KEY,
+    enterprise TEXT NOT NULL,
+    "group" TEXT NOT NULL,
+    endpoint_url TEXT NOT NULL,
+    embedding_centroid BLOB,
+    domain_bloom BLOB,
+    ku_count INTEGER NOT NULL DEFAULT 0,
+    domain_count INTEGER NOT NULL DEFAULT 0,
+    embedding_model TEXT,
+    first_seen_at TEXT NOT NULL,
+    last_seen_at TEXT NOT NULL,
+    last_signature_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_aigrp_peers_enterprise ON aigrp_peers(enterprise);
+"""
+
 USERS_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS users (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -67,6 +85,17 @@ def ensure_embedding_columns(conn: sqlite3.Connection) -> None:
         if col not in existing:
             conn.execute(statement)
     conn.commit()
+
+
+def ensure_aigrp_peers_table(conn: sqlite3.Connection) -> None:
+    """Create the AIGRP peer table if it does not exist.
+
+    Holds this L2's view of every other L2 it knows about in the same
+    Enterprise, including their last-published signature (centroid +
+    Bloom). Built up via /aigrp/hello flooding at deploy time and
+    refreshed by the periodic peer-poll task.
+    """
+    conn.executescript(AIGRP_PEERS_TABLE_SQL)
 
 
 def ensure_users_table(conn: sqlite3.Connection) -> None:


### PR DESCRIPTION
EIGRP-shaped peer mesh inside an Enterprise, replacing the rejected hub-and-spoke gossip-registry design. New L2s join by hitting any existing peer's /aigrp/hello with the shared EnterprisePeerKey; seed floods to siblings; periodic poll converges the mesh. Cross-Enterprise stays out of scope for AI-BGP. See crosstalk-enterprise/docs/decisions/07-l2-sizing-and-replication.md.