### PR TITLE
local-demo: shapes A/B/C + 3 AIGRP fixes from real validation

### DIFF
--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -81,9 +81,11 @@ async def _aigrp_bootstrap_and_poll(store: RemoteStore) -> None:
 
     log = logging.getLogger("aigrp")
     poll_interval = int(os.environ.get("CQ_AIGRP_POLL_INTERVAL_SEC", "300"))
+    needs_bootstrap = (not aigrp.is_first_deploy()) and bool(aigrp.seed_peer_url())
 
-    # 1. If not first deploy, hit the seed peer's /aigrp/hello once.
-    if not aigrp.is_first_deploy() and aigrp.seed_peer_url():
+    def _try_bootstrap() -> bool:
+        """Hit the seed's /aigrp/hello and absorb its peer table.
+        Returns True on success. Idempotent on the seed side."""
         try:
             hello_payload = json.dumps({
                 "l2_id": aigrp.self_l2_id(),
@@ -118,15 +120,25 @@ async def _aigrp_bootstrap_and_poll(store: RemoteStore) -> None:
                     signature_received=False,
                 )
             log.info("aigrp bootstrap: seed=%s peers=%d", aigrp.seed_peer_url(), len(body.get("peers", [])))
+            return True
         except Exception:
-            log.exception("aigrp bootstrap to seed=%s failed; will retry via poll loop", aigrp.seed_peer_url())
+            log.warning("aigrp bootstrap to seed=%s failed; will retry on next poll cycle", aigrp.seed_peer_url())
+            return False
+
+    # 1. First-attempt bootstrap on startup (best effort).
+    if needs_bootstrap and _try_bootstrap():
+        needs_bootstrap = False
 
     # 2. Periodic peer-poll loop — fetch each peer's /aigrp/signature.
+    #    Also re-attempts bootstrap on every cycle while it's still
+    #    pending; gives self-healing if the seed was down at start.
     import base64
 
     while True:
         try:
             await asyncio.sleep(poll_interval)
+            if needs_bootstrap and _try_bootstrap():
+                needs_bootstrap = False
             peers = store.list_aigrp_peers(aigrp.enterprise())
             for p in peers:
                 if p["l2_id"] == aigrp.self_l2_id():

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -322,12 +322,19 @@ def aigrp_lookup(
 
 
 class AigrpHelloRequest(BaseModel):
-    """A new L2 introducing itself to a seed peer."""
+    """A new L2 introducing itself to a seed peer.
+
+    Empty `endpoint_url` flags the joiner as a *stub L2* — it can poll
+    peers but cannot be polled back (typical for an L2 behind NAT, e.g.
+    a developer laptop or a customer-edge node without inbound exposure).
+    Stub peers are recorded in the table but skipped by the periodic
+    poll loop (since there's no address to poll).
+    """
 
     l2_id: str = Field(min_length=1, description="canonical Enterprise/Group identity")
     enterprise: str = Field(min_length=1)
     group: str = Field(min_length=1)
-    endpoint_url: str = Field(min_length=1, description="how peers should reach me")
+    endpoint_url: str = Field(default="", description="how peers should reach me; empty = stub L2 (consumer-only)")
 
 
 class AigrpAnnounceRequest(BaseModel):
@@ -336,7 +343,7 @@ class AigrpAnnounceRequest(BaseModel):
     l2_id: str = Field(min_length=1)
     enterprise: str = Field(min_length=1)
     group: str = Field(min_length=1)
-    endpoint_url: str = Field(min_length=1)
+    endpoint_url: str = Field(default="", description="empty = stub L2 (consumer-only)")
     announced_by: str = Field(default="", description="l2_id of the peer doing the flooding")
 
 

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -407,7 +407,7 @@ def _build_self_signature(store: RemoteStore) -> AigrpSignatureResponse:
 
 
 @api_router.post("/aigrp/hello", status_code=201)
-def aigrp_hello(
+async def aigrp_hello(
     body: AigrpHelloRequest,
     _peer: None = Depends(aigrp.require_peer_key),
 ) -> AigrpPeersResponse:
@@ -417,6 +417,9 @@ def aigrp_hello(
     a different Enterprise. Records the new peer in our local table,
     then fans out /aigrp/announce to every other known peer (best-effort,
     background — does not block the hello response).
+
+    Async because we spawn the flood as an asyncio.Task. The SQLite
+    store calls are fast enough to run inline on the event loop.
     """
     if body.enterprise != aigrp.enterprise():
         raise HTTPException(

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -482,11 +482,29 @@ def aigrp_hello(
 
     asyncio.create_task(_flood())
 
+    # Include ourselves (the seed) in the peer list. New L2 needs to know
+    # we exist as a peer; otherwise it learns about every OTHER peer the
+    # seed knows but never records the seed itself. Real EIGRP neighbor
+    # adjacency advertisements include the speaker too.
+    self_entry = {
+        "l2_id": aigrp.self_l2_id(),
+        "enterprise": aigrp.enterprise(),
+        "group": aigrp.group(),
+        "endpoint_url": aigrp.self_url(),
+        "ku_count": 0,
+        "domain_count": 0,
+        "embedding_model": None,
+        "first_seen_at": aigrp.now_iso(),
+        "last_seen_at": aigrp.now_iso(),
+        "last_signature_at": None,
+    }
+    peers_plus_self = peers + [self_entry]
+
     return AigrpPeersResponse(
         enterprise=aigrp.enterprise(),
         self_l2_id=aigrp.self_l2_id(),
-        peer_count=len(peers),
-        peers=[AigrpPeer(**{k: v for k, v in p.items() if k in AigrpPeer.model_fields}) for p in peers],
+        peer_count=len(peers_plus_self),
+        peers=[AigrpPeer(**{k: v for k, v in p.items() if k in AigrpPeer.model_fields}) for p in peers_plus_self],
     )
 
 

--- a/server/local-demo/.env.example
+++ b/server/local-demo/.env.example
@@ -1,0 +1,25 @@
+# 8th-Layer local-demo .env template.
+# Copy to .env and fill in, OR run `bash bin/init-env.sh` to auto-generate.
+#
+# Required for shape A (acme + orion-local):
+ACME_PEER_KEY=                # 32+ char shared key for acme L2s
+ACME_JWT_SECRET=              # 32+ char per-L2 JWT secret (acme reuses across both for demo)
+ACME_API_KEY_PEPPER=          # 32+ char API key pepper (acme reuses across both for demo)
+
+ORION_LOCAL_PEER_KEY=         # different from ACME_PEER_KEY — proves the trust boundary
+ORION_LOCAL_JWT_SECRET=
+ORION_LOCAL_API_KEY_PEPPER=
+
+# Required for shape B/C (orion-bridge — local L2 joins AWS mesh):
+ORION_AWS_SEED_URL=           # http://test-ori-Alb-xxx.us-east-1.elb.amazonaws.com
+ORION_AWS_PEER_KEY=           # pulled from SSM /8l-aigrp/orion/peer-key
+ORION_BRIDGE_GROUP=laptop-demo
+ORION_BRIDGE_SELF_URL=        # your ngrok / cloudflared tunnel URL, e.g. https://abcd.ngrok.io
+                              # leave empty if you only want one-way (local→AWS) and accept
+                              # that AWS won't be able to poll this L2 back
+
+ORION_BRIDGE_JWT_SECRET=
+ORION_BRIDGE_API_KEY_PEPPER=
+
+# AWS profile used for Bedrock embeddings (mounted via ~/.aws ro)
+AWS_PROFILE=8th-layer-app

--- a/server/local-demo/README.md
+++ b/server/local-demo/README.md
@@ -1,0 +1,227 @@
+# 8th-Layer L2 — local Docker demo
+
+The same `cq-server` container that runs on AWS Fargate, brought up on
+your laptop via Docker Compose. Demonstrates three things at once:
+
+1. **Substrate portability.** The container has no AWS-specific code —
+   it runs identically on Fargate, K8s, or plain Docker. Only the deploy
+   *artifacts* (CloudFormation, EFS, ALB) are AWS-specific.
+2. **AIGRP peer-mesh convergence.** New L2s find each other via
+   seed-peer bootstrap; periodic polling refreshes signatures.
+3. **Enterprise trust boundary.** Two L2s with different
+   `EnterprisePeerKey`s on the same machine can't see each other —
+   401 on the wrong key.
+
+## Three shapes
+
+| Shape | What it brings up | What it proves | AWS cost |
+|---|---|---|---|
+| `acme` | acme-eng + acme-sol + orion-local-l2 | Full local mesh in `acme`; separate `orion-local` Enterprise on the same machine is invisible to `acme`; cross-Enterprise 401 boundary | $0 |
+| `orion-bridge` | One local L2 joining the **AWS-hosted** orion mesh as a stub peer | Substrate portability — local Docker peer in a Fargate-hosted mesh | uses existing `test-orion-eng-l2` |
+| `all` | Both above | Everything | uses existing `test-orion-eng-l2` |
+
+## Prerequisites
+
+- **Docker** (Desktop, Colima, OrbStack — anything OCI-compatible)
+- **AWS profile** with `bedrock:InvokeModel` perms on Titan v2 (the
+  `8th-layer-app` profile we use for production deploys is fine).
+  Mounted read-only into containers via `~/.aws`.
+- **For shape B/C**: the AWS `test-orion-eng-l2` stack must be running
+  already, and the `EnterprisePeerKey` for orion must be in SSM at
+  `/8l-aigrp/orion/peer-key`. `bin/init-env.sh` pulls these
+  automatically.
+
+## First-time setup
+
+```bash
+cd server/local-demo
+
+# Generate fresh secrets and pull AWS-side params from SSM:
+bash bin/init-env.sh
+
+# Pull the cq-server image (~150 MB):
+docker compose pull
+```
+
+The `init-env.sh` script writes `.env` with two distinct
+`EnterprisePeerKey`s — one for `acme`, one for `orion-local`. They are
+intentionally different to demonstrate the trust boundary.
+
+## Shape A — local two-Enterprise mesh
+
+```bash
+docker compose --profile acme up -d
+```
+
+This brings up:
+- `acme-engineering-l2` on `localhost:4001` (genesis node for `acme`)
+- `acme-solutions-l2` on `localhost:4002` (joins `acme-engineering-l2`)
+- `orion-local-l2` on `localhost:4003` (separate Enterprise, separate network)
+
+Wait ~30 seconds for the AIGRP poll loop to converge, then verify:
+
+```bash
+bash bin/verify-mesh.sh
+```
+
+Expected output (key parts):
+
+```
+=== acme-engineering-l2  (localhost:4001) ===
+[health] ok
+[/aigrp/peers]  enterprise=acme  self=acme/engineering  peer_count=1
+  - acme/solutions  endpoint=http://acme-solutions-l2:3000  last_sig=2026-04-30T...
+
+=== acme-solutions-l2  (localhost:4002) ===
+[health] ok
+[/aigrp/peers]  enterprise=acme  self=acme/solutions  peer_count=1
+  - acme/engineering  endpoint=http://acme-engineering-l2:3000  last_sig=2026-04-30T...
+
+=== orion-local-l2  (localhost:4003) ===
+[health] ok
+[/aigrp/peers]  enterprise=orion-local  self=orion-local/engineering  peer_count=0
+
+=== boundary check: ... ===
+[boundary] orion-local-l2 returned HTTP 401 using acme's peer key (401 = boundary working)
+```
+
+Two converged 1-peer meshes. `orion-local` doesn't know about `acme` and
+vice versa — different `EnterprisePeerKey`. Hitting `orion-local` with
+acme's key returns 401.
+
+To seed an admin user on any container:
+
+```bash
+bash bin/seed-admin.sh acme-engineering-l2
+# prints: admin/<random password>
+```
+
+You can then propose a KU + run a semantic query against `localhost:4001`
+just like any other cq Remote.
+
+## Shape B — local L2 joins the AWS-hosted orion mesh
+
+```bash
+docker compose --profile orion-bridge up -d
+```
+
+This brings up `orion-bridge-l2` on `localhost:4004`. The container's
+`SeedPeerUrl` points at the AWS `test-orion-eng-l2` ALB; on startup it
+hits `/aigrp/hello` against that endpoint with the orion peer key.
+
+### Stub mode (default) — no tunnel required
+
+By default, `ORION_BRIDGE_SELF_URL` is empty in `.env`. This flags the
+local L2 as a **stub L2**: it can poll peers outbound, but peers can't
+poll it back (since `localhost:4004` is not reachable from the AWS L2).
+
+Stub trade-offs:
+
+| Capability | Full L2 | Stub L2 |
+|---|---|---|
+| Pulls peer signatures into local cache | ✅ | ✅ |
+| Its agents query the mesh via AIGRP-pull | ✅ | ✅ |
+| Peers see this L2 in their `/aigrp/peers` | ✅ | ✅ (with `endpoint=<stub>`) |
+| Peers actually poll this L2's `/aigrp/signature` | ✅ | ❌ (no address to poll) |
+| Peers route forward-query requests to this L2 | ✅ | ❌ (can't reach it) |
+| Contributes its KUs to peers' answer mix | ✅ | ❌ |
+
+Stub mode is the right choice when:
+- You're a developer reading from the corporate mesh
+- You're a customer-edge node behind NAT with no inbound port available
+- You don't need the rest of the mesh asking *you* for knowledge
+
+Verify after `docker compose --profile orion-bridge up -d`:
+
+```bash
+bash bin/verify-mesh.sh
+```
+
+Expected: `orion-bridge-l2`'s peer table includes `orion/engineering`
+(the AWS L2). The AWS L2's peer table includes the bridge entry but
+with `endpoint=<stub: no inbound>`.
+
+### Full L2 mode — set up a tunnel
+
+If you want bidirectional reachability (peers can poll *you* back), pick
+a tunnel:
+
+**Option 1 — ngrok** (~1 minute):
+
+```bash
+ngrok http 4004
+# copy the https://abcd.ngrok.io URL
+```
+
+Edit `.env` and set:
+
+```
+ORION_BRIDGE_SELF_URL=https://abcd.ngrok.io
+```
+
+Then restart: `docker compose --profile orion-bridge up -d --force-recreate orion-bridge-l2`.
+
+**Option 2 — Cloudflare Tunnel** (free, more permanent):
+
+```bash
+cloudflared tunnel --url http://localhost:4004
+```
+
+**Option 3 — Tailscale Funnel** (works on tailnet members):
+
+```bash
+tailscale funnel 4004
+```
+
+After the tunnel is up and `.env` is updated, the AWS L2 will poll the
+tunnel URL on its next AIGRP cycle (≤5 min) and the bridge becomes a
+full peer.
+
+## Shape C — both at once
+
+```bash
+docker compose --profile all up -d
+```
+
+Brings up acme + orion-local + orion-bridge. Shows the full picture
+on one machine: two-Enterprise local mesh, plus a stub bridge into
+AWS. `bin/verify-mesh.sh` probes all four ports.
+
+## Teardown
+
+```bash
+docker compose --profile all down -v
+```
+
+`-v` drops the volumes (each L2's SQLite DB). Skip `-v` if you want to
+preserve KUs across restarts.
+
+## What's NOT in scope for this demo
+
+- **Cross-Enterprise discovery** between `acme` and `orion-local` —
+  that's the AI-BGP protocol's job (separate spec, future work).
+- **Forward-query** — the cross-L2 routing that fires when local L2
+  can't satisfy a query. This demo focuses on the AIGRP peer-mesh
+  layer underneath. Forward-query is the next stroke in the rollout.
+- **Persistence of admin password** — `bin/seed-admin.sh` prints the
+  password once; nothing stores it. For demo purposes only.
+
+## Common questions
+
+**Why does the orion-bridge container talk to AWS via HTTP not HTTPS?**
+The current `mvp.yaml`/`l2.yaml` deploy both run plain HTTP behind the
+ALB. Production behind CloudFront uses HTTPS at the edge but talks
+HTTP origin → ALB. For the demo, the laptop talks HTTP directly to the
+ALB. TLS hardening on the ALB is `EnableTLS=true` parameter work.
+
+**Why do `acme-engineering-l2` and `acme-solutions-l2` share the same
+JWT secret and pepper but production stacks have separate ones?** The
+demo is a single-operator setup — sharing simplifies the bring-up.
+Production deploys mint per-stack values automatically.
+
+**Why does `orion-local-l2` use a different Enterprise name (`orion-local`)
+than the AWS `orion`?** Intentional separation. If both used `orion`,
+the local one would try to join the AWS mesh by default. We want the
+local one to be a *separate* Enterprise to prove the boundary; using a
+different name makes the `EnterprisePeerKey` mismatch the operative
+proof rather than naming collision.

--- a/server/local-demo/bin/init-env.sh
+++ b/server/local-demo/bin/init-env.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Generate fresh secrets into .env for the local demo.
+# Idempotent: re-run to rotate everything; pulls AWS-side values from SSM.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [ -f .env ]; then
+    echo "[init-env] .env already exists; backing up to .env.bak before regenerating"
+    cp .env .env.bak
+fi
+
+gen_secret() { openssl rand -base64 48 | tr -d '/+=' | head -c 48; }
+
+ACME_PEER_KEY=$(gen_secret)
+ACME_JWT_SECRET=$(gen_secret)
+ACME_API_KEY_PEPPER=$(gen_secret)
+
+ORION_LOCAL_PEER_KEY=$(gen_secret)
+ORION_LOCAL_JWT_SECRET=$(gen_secret)
+ORION_LOCAL_API_KEY_PEPPER=$(gen_secret)
+
+ORION_BRIDGE_JWT_SECRET=$(gen_secret)
+ORION_BRIDGE_API_KEY_PEPPER=$(gen_secret)
+
+# Pull the AWS-side orion peer key + seed URL from SSM + describe-stacks.
+AWS_PROFILE_USE="${AWS_PROFILE:-8th-layer-app}"
+ORION_AWS_PEER_KEY=$(aws --profile "$AWS_PROFILE_USE" --region us-east-1 \
+    ssm get-parameter --name /8l-aigrp/orion/peer-key --with-decryption \
+    --query Parameter.Value --output text 2>/dev/null || echo "")
+ORION_AWS_SEED_URL=$(aws --profile "$AWS_PROFILE_USE" --region us-east-1 \
+    cloudformation describe-stacks --stack-name test-orion-eng-l2 \
+    --query "Stacks[0].Outputs[?OutputKey=='CqEndpoint'].OutputValue|[0]" \
+    --output text 2>/dev/null || echo "")
+
+cat > .env <<EOF
+# Generated $(date -u +%Y-%m-%dT%H:%M:%SZ) by bin/init-env.sh
+
+# Shape A: acme Enterprise (local two-peer mesh)
+ACME_PEER_KEY=$ACME_PEER_KEY
+ACME_JWT_SECRET=$ACME_JWT_SECRET
+ACME_API_KEY_PEPPER=$ACME_API_KEY_PEPPER
+
+# Shape A: orion-local (separate Enterprise, separate network — for boundary proof)
+ORION_LOCAL_PEER_KEY=$ORION_LOCAL_PEER_KEY
+ORION_LOCAL_JWT_SECRET=$ORION_LOCAL_JWT_SECRET
+ORION_LOCAL_API_KEY_PEPPER=$ORION_LOCAL_API_KEY_PEPPER
+
+# Shape B/C: orion-bridge — local L2 joining AWS-hosted orion mesh
+ORION_AWS_SEED_URL=$ORION_AWS_SEED_URL
+ORION_AWS_PEER_KEY=$ORION_AWS_PEER_KEY
+ORION_BRIDGE_GROUP=laptop-demo
+ORION_BRIDGE_SELF_URL=
+ORION_BRIDGE_JWT_SECRET=$ORION_BRIDGE_JWT_SECRET
+ORION_BRIDGE_API_KEY_PEPPER=$ORION_BRIDGE_API_KEY_PEPPER
+
+AWS_PROFILE=$AWS_PROFILE_USE
+EOF
+
+chmod 600 .env
+
+echo "[init-env] wrote .env"
+echo "[init-env]   ACME_PEER_KEY len: ${#ACME_PEER_KEY}"
+echo "[init-env]   ORION_LOCAL_PEER_KEY len: ${#ORION_LOCAL_PEER_KEY} (different from acme — boundary proof)"
+if [ -n "$ORION_AWS_PEER_KEY" ]; then
+    echo "[init-env]   ORION_AWS_PEER_KEY: pulled from SSM ($ORION_AWS_SEED_URL)"
+else
+    echo "[init-env]   ORION_AWS_PEER_KEY: SSM lookup failed — shape B/C unavailable until you populate manually"
+fi
+echo "[init-env] done"

--- a/server/local-demo/bin/init-env.sh
+++ b/server/local-demo/bin/init-env.sh
@@ -24,14 +24,21 @@ ORION_BRIDGE_JWT_SECRET=$(gen_secret)
 ORION_BRIDGE_API_KEY_PEPPER=$(gen_secret)
 
 # Pull the AWS-side orion peer key + seed URL from SSM + describe-stacks.
-AWS_PROFILE_USE="${AWS_PROFILE:-8th-layer-app}"
-ORION_AWS_PEER_KEY=$(aws --profile "$AWS_PROFILE_USE" --region us-east-1 \
+# These resources live in the 8th-layer-app account specifically — NOT in
+# whatever $AWS_PROFILE the operator's shell is currently set to. Allow
+# override via AWS_PROFILE_FOR_LOOKUP, otherwise hard-default to the right
+# profile so the lookup works regardless of shell context.
+AWS_PROFILE_FOR_LOOKUP="${AWS_PROFILE_FOR_LOOKUP:-8th-layer-app}"
+ORION_AWS_PEER_KEY=$(aws --profile "$AWS_PROFILE_FOR_LOOKUP" --region us-east-1 \
     ssm get-parameter --name /8l-aigrp/orion/peer-key --with-decryption \
     --query Parameter.Value --output text 2>/dev/null || echo "")
-ORION_AWS_SEED_URL=$(aws --profile "$AWS_PROFILE_USE" --region us-east-1 \
+ORION_AWS_SEED_URL=$(aws --profile "$AWS_PROFILE_FOR_LOOKUP" --region us-east-1 \
     cloudformation describe-stacks --stack-name test-orion-eng-l2 \
     --query "Stacks[0].Outputs[?OutputKey=='CqEndpoint'].OutputValue|[0]" \
     --output text 2>/dev/null || echo "")
+# AWS_PROFILE for the *runtime* containers (Bedrock embed) is separate;
+# defaults to the same lookup profile but can differ.
+AWS_PROFILE_USE="${AWS_PROFILE:-$AWS_PROFILE_FOR_LOOKUP}"
 
 cat > .env <<EOF
 # Generated $(date -u +%Y-%m-%dT%H:%M:%SZ) by bin/init-env.sh

--- a/server/local-demo/bin/seed-admin.sh
+++ b/server/local-demo/bin/seed-admin.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Seed an admin user inside a running L2 container — same shape as the
+# Fargate post-deploy admin seed. Generates a fresh password, runs the
+# inline-python bcrypt hash + UPSERT inside the container, prints the
+# password to stdout (you'll paste it into the admin login).
+#
+# Usage:  bash bin/seed-admin.sh acme-engineering-l2
+set -euo pipefail
+
+CONTAINER="${1:?usage: $0 <container-name>}"
+
+if ! docker ps --format '{{.Names}}' | grep -qx "$CONTAINER"; then
+    echo "[seed-admin] container '$CONTAINER' not running" >&2
+    exit 2
+fi
+
+ADMIN_PW=$(openssl rand -base64 32 | tr -d '/+=' | head -c 32)
+
+docker exec -e ADMIN_PW="$ADMIN_PW" "$CONTAINER" /app/.venv/bin/python -c "
+import os, sqlite3, datetime
+from cq_server.auth import hash_password
+pw = os.environ['ADMIN_PW']
+con = sqlite3.connect('/data/cq.db')
+con.execute('CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT NOT NULL UNIQUE, password_hash TEXT NOT NULL, created_at TEXT NOT NULL)')
+now = datetime.datetime.now(datetime.UTC).isoformat()
+try:
+    con.execute('INSERT INTO users (username, password_hash, created_at) VALUES (?, ?, ?)', ('admin', hash_password(pw), now))
+    con.commit()
+    print('admin created')
+except sqlite3.IntegrityError:
+    con.execute('UPDATE users SET password_hash = ? WHERE username = ?', (hash_password(pw), 'admin'))
+    con.commit()
+    print('admin password reset')
+con.close()
+"
+
+echo
+echo "[seed-admin] container=$CONTAINER admin=admin password=$ADMIN_PW"
+echo "[seed-admin] save this; it is not stored anywhere else"

--- a/server/local-demo/bin/verify-mesh.sh
+++ b/server/local-demo/bin/verify-mesh.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Verify the AIGRP peer mesh is converged.
+# Usage:  bash bin/verify-mesh.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if [ ! -f .env ]; then
+    echo "[verify] .env not found — run bin/init-env.sh first" >&2
+    exit 2
+fi
+
+# shellcheck disable=SC1091
+set -a; source .env; set +a
+
+probe() {
+    local label="$1" port="$2" peer_key="$3"
+    echo
+    echo "=== $label  (localhost:$port) ==="
+    if ! curl -sS -m 3 -o /dev/null "http://localhost:$port/health" 2>/dev/null; then
+        echo "[health] unreachable"
+        return
+    fi
+    echo "[health] ok"
+    local body
+    body=$(curl -sS -m 5 "http://localhost:$port/api/v1/aigrp/peers" \
+        -H "Authorization: Bearer $peer_key" 2>/dev/null || echo "")
+    if [ -z "$body" ]; then
+        echo "[/aigrp/peers] no response"
+        return
+    fi
+    echo "$body" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+except Exception as e:
+    print('[/aigrp/peers] parse error:', e); sys.exit(0)
+print(f'[/aigrp/peers]  enterprise={d.get(\"enterprise\")}  self={d.get(\"self_l2_id\")}  peer_count={d.get(\"peer_count\")}')
+for p in d.get('peers', []):
+    last_sig = p.get('last_signature_at') or 'never-polled'
+    endpoint = p.get('endpoint_url') or '<stub: no inbound>'
+    print(f'  - {p[\"l2_id\"]}  endpoint={endpoint}  last_sig={last_sig}  ku_count={p.get(\"ku_count\",0)}')
+"
+}
+
+probe "acme-engineering-l2" 4001 "${ACME_PEER_KEY:-}"
+probe "acme-solutions-l2"   4002 "${ACME_PEER_KEY:-}"
+probe "orion-local-l2"      4003 "${ORION_LOCAL_PEER_KEY:-}"
+probe "orion-bridge-l2"     4004 "${ORION_AWS_PEER_KEY:-}"
+
+echo
+echo "=== boundary check: hit orion-local-l2's /aigrp/peers using ACME's key (expect 401) ==="
+status=$(curl -sS -m 3 -o /dev/null -w "%{http_code}" "http://localhost:4003/api/v1/aigrp/peers" \
+    -H "Authorization: Bearer ${ACME_PEER_KEY:-deliberately-wrong}" 2>/dev/null || echo "ERR")
+echo "[boundary] orion-local-l2 returned HTTP $status using acme's peer key (401 = boundary working)"

--- a/server/local-demo/docker-compose.yml
+++ b/server/local-demo/docker-compose.yml
@@ -1,0 +1,180 @@
+# 8th-Layer L2 local demo — runs the same cq-server container that
+# Fargate runs, but on plain Docker on your laptop.
+#
+# Three "shapes" you can bring up via docker compose --profile:
+#
+#   acme         shape A — two-Enterprise mesh, fully local
+#                acme-engineering + acme-solutions converge to a 2-peer
+#                mesh on a private docker network. orion-local stands
+#                up on a separate network with a different peer key,
+#                completely invisible to acme.
+#
+#   orion-bridge shape B — single local L2 that joins the existing
+#                AWS-hosted orion mesh (test-orion-eng-l2 as seed).
+#                Requires a tunnel (ngrok / cloudflared / Tailscale)
+#                so the AWS L2 can poll this local L2 back.
+#
+#   all          shape C — both above. Demonstrates substrate
+#                portability + Enterprise boundary in one bring-up.
+#
+# Bedrock embeddings are wired through your local AWS profile via a
+# read-only mount of ~/.aws — same `8th-layer-app` profile we use to
+# deploy the production stacks.
+#
+# Generate fresh peer keys + admin password into .env before first
+# bring-up:   bash bin/init-env.sh
+# Seed admin user after first bring-up:   bash bin/seed-admin.sh acme-engineering-l2
+
+services:
+
+  # === Shape A: acme Enterprise (two-peer local mesh) ===
+
+  acme-engineering-l2:
+    image: public.ecr.aws/w2i0e4m6/cq-server:phase3-aigrp-mesh
+    profiles: ["acme", "all"]
+    container_name: acme-engineering-l2
+    ports:
+      - "4001:3000"
+    environment:
+      CQ_JWT_SECRET: "${ACME_JWT_SECRET}"
+      CQ_API_KEY_PEPPER: "${ACME_API_KEY_PEPPER}"
+      CQ_DB_PATH: /data/cq.db
+      CQ_PORT: "3000"
+      CQ_ENTERPRISE: acme
+      CQ_GROUP: engineering
+      CQ_AIGRP_IS_FIRST_DEPLOY: "true"
+      CQ_AIGRP_SEED_PEER_URL: ""
+      CQ_AIGRP_PEER_KEY: "${ACME_PEER_KEY}"
+      CQ_AIGRP_SELF_URL: "http://acme-engineering-l2:3000"
+      CQ_AIGRP_POLL_INTERVAL_SEC: "30"
+      CQ_EMBED_REGION: us-east-1
+      AWS_PROFILE: "${AWS_PROFILE:-8th-layer-app}"
+      AWS_SHARED_CREDENTIALS_FILE: /aws-creds/credentials
+      AWS_CONFIG_FILE: /aws-creds/config
+    volumes:
+      - acme-eng-data:/data
+      - ~/.aws:/aws-creds:ro
+    networks:
+      - acme-mesh
+
+  acme-solutions-l2:
+    image: public.ecr.aws/w2i0e4m6/cq-server:phase3-aigrp-mesh
+    profiles: ["acme", "all"]
+    container_name: acme-solutions-l2
+    ports:
+      - "4002:3000"
+    environment:
+      CQ_JWT_SECRET: "${ACME_JWT_SECRET}"
+      CQ_API_KEY_PEPPER: "${ACME_API_KEY_PEPPER}"
+      CQ_DB_PATH: /data/cq.db
+      CQ_PORT: "3000"
+      CQ_ENTERPRISE: acme
+      CQ_GROUP: solutions
+      CQ_AIGRP_IS_FIRST_DEPLOY: "false"
+      CQ_AIGRP_SEED_PEER_URL: "http://acme-engineering-l2:3000"
+      CQ_AIGRP_PEER_KEY: "${ACME_PEER_KEY}"
+      CQ_AIGRP_SELF_URL: "http://acme-solutions-l2:3000"
+      CQ_AIGRP_POLL_INTERVAL_SEC: "30"
+      CQ_EMBED_REGION: us-east-1
+      AWS_PROFILE: "${AWS_PROFILE:-8th-layer-app}"
+      AWS_SHARED_CREDENTIALS_FILE: /aws-creds/credentials
+      AWS_CONFIG_FILE: /aws-creds/config
+    volumes:
+      - acme-sol-data:/data
+      - ~/.aws:/aws-creds:ro
+    networks:
+      - acme-mesh
+    depends_on:
+      acme-engineering-l2:
+        condition: service_healthy
+
+  # === Shape A continued: orion-local (different Enterprise, different network) ===
+  # Same laptop, different EnterprisePeerKey. Demonstrates the trust boundary —
+  # acme can't see this L2; this L2 can't see acme. Curl this L2's /aigrp/hello
+  # using ${ACME_PEER_KEY} → 401.
+
+  orion-local-l2:
+    image: public.ecr.aws/w2i0e4m6/cq-server:phase3-aigrp-mesh
+    profiles: ["acme", "all"]
+    container_name: orion-local-l2
+    ports:
+      - "4003:3000"
+    environment:
+      CQ_JWT_SECRET: "${ORION_LOCAL_JWT_SECRET}"
+      CQ_API_KEY_PEPPER: "${ORION_LOCAL_API_KEY_PEPPER}"
+      CQ_DB_PATH: /data/cq.db
+      CQ_PORT: "3000"
+      CQ_ENTERPRISE: orion-local
+      CQ_GROUP: engineering
+      CQ_AIGRP_IS_FIRST_DEPLOY: "true"
+      CQ_AIGRP_SEED_PEER_URL: ""
+      CQ_AIGRP_PEER_KEY: "${ORION_LOCAL_PEER_KEY}"
+      CQ_AIGRP_SELF_URL: "http://orion-local-l2:3000"
+      CQ_AIGRP_POLL_INTERVAL_SEC: "30"
+      CQ_EMBED_REGION: us-east-1
+      AWS_PROFILE: "${AWS_PROFILE:-8th-layer-app}"
+      AWS_SHARED_CREDENTIALS_FILE: /aws-creds/credentials
+      AWS_CONFIG_FILE: /aws-creds/config
+    volumes:
+      - orion-local-data:/data
+      - ~/.aws:/aws-creds:ro
+    networks:
+      - orion-local-mesh  # intentionally separate from acme-mesh
+
+  # === Shape B/C: local L2 that joins the AWS-hosted orion mesh ===
+  #
+  # Default mode is **stub L2** — joins the mesh as a consumer-only peer.
+  # The cq Remote handles this via empty CQ_AIGRP_SELF_URL: it sends
+  # endpoint_url="" in /aigrp/hello, peers record the row, and peers'
+  # poll loop skips entries with empty endpoint_url. The local L2 still
+  # polls AWS peers outbound; it just can't be polled back.
+  #
+  # To upgrade to full L2 (bidirectional reachability), set
+  # ORION_BRIDGE_SELF_URL=<your tunnel URL> in .env. Tunnels we tested:
+  # ngrok, Cloudflare Tunnel, Tailscale Funnel — all give a public
+  # https://*.example/ that AWS can reach.
+  #
+  # See README.md for the stub-mode trade-offs (consumes mesh knowledge,
+  # does not contribute to peers' forward-query routing).
+
+  orion-bridge-l2:
+    image: public.ecr.aws/w2i0e4m6/cq-server:phase3-aigrp-mesh
+    profiles: ["orion-bridge", "all"]
+    container_name: orion-bridge-l2
+    ports:
+      - "4004:3000"
+    environment:
+      CQ_JWT_SECRET: "${ORION_BRIDGE_JWT_SECRET}"
+      CQ_API_KEY_PEPPER: "${ORION_BRIDGE_API_KEY_PEPPER}"
+      CQ_DB_PATH: /data/cq.db
+      CQ_PORT: "3000"
+      CQ_ENTERPRISE: orion
+      CQ_GROUP: "${ORION_BRIDGE_GROUP:-laptop-demo}"
+      CQ_AIGRP_IS_FIRST_DEPLOY: "false"
+      CQ_AIGRP_SEED_PEER_URL: "${ORION_AWS_SEED_URL}"
+      CQ_AIGRP_PEER_KEY: "${ORION_AWS_PEER_KEY}"
+      # Empty default = stub L2 (the realistic laptop case behind NAT).
+      # Override in .env with a tunnel URL to upgrade to full L2.
+      CQ_AIGRP_SELF_URL: "${ORION_BRIDGE_SELF_URL:-}"
+      CQ_AIGRP_POLL_INTERVAL_SEC: "30"
+      CQ_EMBED_REGION: us-east-1
+      AWS_PROFILE: "${AWS_PROFILE:-8th-layer-app}"
+      AWS_SHARED_CREDENTIALS_FILE: /aws-creds/credentials
+      AWS_CONFIG_FILE: /aws-creds/config
+    volumes:
+      - orion-bridge-data:/data
+      - ~/.aws:/aws-creds:ro
+    # No isolated network — uses the default bridge so it can reach
+    # the public-internet AWS endpoint.
+
+volumes:
+  acme-eng-data:
+  acme-sol-data:
+  orion-local-data:
+  orion-bridge-data:
+
+networks:
+  acme-mesh:
+    driver: bridge
+  orion-local-mesh:
+    driver: bridge


### PR DESCRIPTION
Adds server/local-demo/ — same cq-server container running on plain Docker on the operator's laptop. Validates: substrate portability, AIGRP peer-mesh convergence, Enterprise trust boundary, stub L2 mode. Three real protocol bugs caught and fixed during local-demo bring-up: (1) /aigrp/hello response missing self-entry (joiners orphaned), (2) asyncio.create_task crashed from sync handler (no event loop), (3) one-shot bootstrap left new L2 orphaned forever if seed temporarily down. Plus init-env.sh AWS_PROFILE leakage fix. End-to-end verified shape A (acme two-peer + orion-local boundary) AND shape B (local Docker bridge → AWS Fargate).