### PR TITLE
[local-demo] init-env: pin runtime AWS_PROFILE to infra account

### DIFF
--- a/server/local-demo/bin/init-env.sh
+++ b/server/local-demo/bin/init-env.sh
@@ -36,9 +36,14 @@ ORION_AWS_SEED_URL=$(aws --profile "$AWS_PROFILE_FOR_LOOKUP" --region us-east-1 
     cloudformation describe-stacks --stack-name test-orion-eng-l2 \
     --query "Stacks[0].Outputs[?OutputKey=='CqEndpoint'].OutputValue|[0]" \
     --output text 2>/dev/null || echo "")
-# AWS_PROFILE for the *runtime* containers (Bedrock embed) is separate;
-# defaults to the same lookup profile but can differ.
-AWS_PROFILE_USE="${AWS_PROFILE:-$AWS_PROFILE_FOR_LOOKUP}"
+# AWS_PROFILE for the *runtime* containers (Bedrock embed). Defaults to the
+# same account that hosts the test stack so cost attribution + audit trail
+# stay consistent. Operator can override via AWS_PROFILE_FOR_RUNTIME if they
+# want to point Bedrock calls at a different account. Note: we deliberately
+# do NOT track the operator's shell $AWS_PROFILE here — that's almost always
+# wrong (e.g. shell set to `orion` from another project leaks Bedrock cost
+# into the wrong account).
+AWS_PROFILE_USE="${AWS_PROFILE_FOR_RUNTIME:-$AWS_PROFILE_FOR_LOOKUP}"
 
 cat > .env <<EOF
 # Generated $(date -u +%Y-%m-%dT%H:%M:%SZ) by bin/init-env.sh


### PR DESCRIPTION
## Summary

- Default the local-demo's runtime `AWS_PROFILE` to `AWS_PROFILE_FOR_LOOKUP` (`8th-layer-app`, account 124074140789) instead of inheriting from the operator's shell `$AWS_PROFILE`.
- Override via new `AWS_PROFILE_FOR_RUNTIME` env var if a different runtime account is genuinely wanted.

## Why

`init-env.sh` previously set `AWS_PROFILE=${AWS_PROFILE:-$AWS_PROFILE_FOR_LOOKUP}`. If the operator's shell had `AWS_PROFILE` exported from another project (e.g. `orion`), the bridge container's Bedrock embedding calls would silently route to the wrong account. Calls succeed (Titan v2 is enabled there), but cost and audit trail land in the wrong place.

Found while re-validating Shapes A/B/C post-reboot — `.env` had `AWS_PROFILE=orion` because that's what my shell had set; embeddings consumed by the 8th-Layer test mesh were billing back to my old Orion-tenant account (571015476446) instead of 8th-layer-app (124074140789).

## Test plan

- [x] Shape A/B/C all converge under the corrected AWS_PROFILE (re-validated after .env patch + container recreate)
- [ ] Re-run bin/init-env.sh with no env vars set and confirm .env writes AWS_PROFILE=8th-layer-app
- [ ] AWS_PROFILE_FOR_RUNTIME=foo bash bin/init-env.sh and confirm .env writes AWS_PROFILE=foo (override path works)