### PR TITLE
[server] Phase 6 step 1: additive tenancy columns (default scope)

### DIFF
--- a/server/backend/alembic/versions/0001_phase6_step1_additive_tenancy_columns.py
+++ b/server/backend/alembic/versions/0001_phase6_step1_additive_tenancy_columns.py
@@ -1,0 +1,155 @@
+"""Phase 6 step 1: additive tenancy columns on knowledge_units and users.
+
+Revision ID: 0001_phase6_step1
+Revises:
+Create Date: 2026-04-30
+
+Adds ``enterprise_id`` and ``group_id`` to ``knowledge_units`` and
+``users``. Both default to ``default-enterprise`` / ``default-group`` and
+are marked NOT NULL after a backfill of any pre-existing rows.
+
+This is the first Alembic migration in the project. The runtime store
+still creates its schema directly via ``_ensure_schema`` (see
+``cq_server/store/__init__.py``), so this migration does **not** define a
+full baseline of every existing table — it ALTERs the two tables that
+gain columns in this step. Both legacy runtime-created DBs and any DB
+that gets a baseline migration in a future step will end up with the
+same ``enterprise_id``/``group_id`` shape.
+
+What this migration does NOT do (deferred):
+
+  - Read-path filtering by enterprise_id / group_id.
+  - JWT or API-key claim-based scope assignment.
+  - New ``tenants`` / ``enterprises`` / ``groups`` / ``humans`` /
+    ``personas`` / ``teams`` tables.
+
+See ``docs/plans/06-gap-analysis-deployed-vs-target.md`` (Section A and
+step 2 of the Recommended build order) for the full plan.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0001_phase6_step1"
+down_revision: str | Sequence[str] | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+DEFAULT_ENTERPRISE_ID = "default-enterprise"
+DEFAULT_GROUP_ID = "default-group"
+
+
+def _table_exists(bind: sa.engine.Connection, table_name: str) -> bool:
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def _column_names(bind: sa.engine.Connection, table_name: str) -> set[str]:
+    inspector = sa.inspect(bind)
+    if table_name not in inspector.get_table_names():
+        return set()
+    return {col["name"] for col in inspector.get_columns(table_name)}
+
+
+def _add_tenancy_columns(table_name: str) -> None:
+    """Add enterprise_id and group_id to ``table_name`` if missing.
+
+    Add as nullable, backfill, then enforce NOT NULL. SQLite needs the
+    batch context to do the NOT NULL ALTER (it rebuilds the table).
+    Postgres can do it in place; ``render_as_batch=True`` in env.py
+    handles both.
+    """
+    bind = op.get_bind()
+    if not _table_exists(bind, table_name):
+        # The runtime store creates each table lazily on first use.
+        # If the migration runs against a DB where this table doesn't
+        # exist yet, there's nothing to alter — the runtime will create
+        # it with the new columns already in place via _SCHEMA_SQL /
+        # USERS_TABLE_SQL.
+        return
+
+    existing = _column_names(bind, table_name)
+
+    if "enterprise_id" not in existing:
+        op.add_column(
+            table_name,
+            sa.Column(
+                "enterprise_id",
+                sa.Text(),
+                nullable=True,
+                server_default=DEFAULT_ENTERPRISE_ID,
+            ),
+        )
+    if "group_id" not in existing:
+        op.add_column(
+            table_name,
+            sa.Column(
+                "group_id",
+                sa.Text(),
+                nullable=True,
+                server_default=DEFAULT_GROUP_ID,
+            ),
+        )
+
+    # Inline backfill — required for SQLite, where ALTER TABLE ADD COLUMN
+    # ... DEFAULT only stamps the default on subsequent inserts and
+    # leaves pre-existing rows NULL. Postgres backfills automatically
+    # but the UPDATE is a no-op in that case.
+    op.execute(
+        sa.text(
+            f"UPDATE {table_name} SET enterprise_id = :ent "
+            "WHERE enterprise_id IS NULL"
+        ).bindparams(ent=DEFAULT_ENTERPRISE_ID)
+    )
+    op.execute(
+        sa.text(
+            f"UPDATE {table_name} SET group_id = :grp WHERE group_id IS NULL"
+        ).bindparams(grp=DEFAULT_GROUP_ID)
+    )
+
+    # Promote to NOT NULL now that every row has a value.
+    with op.batch_alter_table(table_name) as batch:
+        batch.alter_column(
+            "enterprise_id",
+            existing_type=sa.Text(),
+            nullable=False,
+            existing_server_default=DEFAULT_ENTERPRISE_ID,
+        )
+        batch.alter_column(
+            "group_id",
+            existing_type=sa.Text(),
+            nullable=False,
+            existing_server_default=DEFAULT_GROUP_ID,
+        )
+
+
+def _drop_tenancy_columns(table_name: str) -> None:
+    bind = op.get_bind()
+    if not _table_exists(bind, table_name):
+        return
+    existing = _column_names(bind, table_name)
+    with op.batch_alter_table(table_name) as batch:
+        if "group_id" in existing:
+            batch.drop_column("group_id")
+        if "enterprise_id" in existing:
+            batch.drop_column("enterprise_id")
+
+
+def upgrade() -> None:
+    """Add additive tenancy columns + backfill defaults."""
+    _add_tenancy_columns("knowledge_units")
+    _add_tenancy_columns("users")
+
+
+def downgrade() -> None:
+    """Drop tenancy columns.
+
+    Used for migration tests; production rollbacks should prefer leaving
+    the columns in place since they are additive.
+    """
+    _drop_tenancy_columns("users")
+    _drop_tenancy_columns("knowledge_units")

--- a/server/backend/src/cq_server/store/__init__.py
+++ b/server/backend/src/cq_server/store/__init__.py
@@ -18,10 +18,13 @@ from cq.models import KnowledgeUnit
 
 from ..scoring import calculate_relevance
 from ..tables import (
+    DEFAULT_ENTERPRISE_ID,
+    DEFAULT_GROUP_ID,
     ensure_aigrp_peers_table,
     ensure_api_keys_table,
     ensure_embedding_columns,
     ensure_review_columns,
+    ensure_tenancy_columns,
     ensure_users_table,
 )
 from ._protocol import Store
@@ -32,10 +35,12 @@ _logger = logging.getLogger(__name__)
 
 DEFAULT_DB_PATH = Path("/data/cq.db")
 
-_SCHEMA_SQL = """
+_SCHEMA_SQL = f"""
 CREATE TABLE IF NOT EXISTS knowledge_units (
     id TEXT PRIMARY KEY,
-    data TEXT NOT NULL
+    data TEXT NOT NULL,
+    enterprise_id TEXT NOT NULL DEFAULT '{DEFAULT_ENTERPRISE_ID}',
+    group_id TEXT NOT NULL DEFAULT '{DEFAULT_GROUP_ID}'
 );
 
 CREATE TABLE IF NOT EXISTS knowledge_unit_domains (
@@ -94,6 +99,10 @@ class RemoteStore:
         ensure_users_table(self._conn)
         ensure_api_keys_table(self._conn)
         ensure_aigrp_peers_table(self._conn)
+        # Phase 6 step 1 — additive tenancy columns. Idempotent; safe to
+        # run on every startup. Backfills legacy rows so the columns can
+        # be queried without NULL handling once enforcement lands.
+        ensure_tenancy_columns(self._conn)
 
     def _check_open(self) -> None:
         """Raise if the store has been closed."""
@@ -153,10 +162,25 @@ class RemoteStore:
             unit.evidence.first_observed.isoformat() if unit.evidence.first_observed else datetime.now(UTC).isoformat()
         )
         with self._lock, self._conn:
+            # Phase 6 step 1: stamp default tenancy scope on every new
+            # row. Future PRs will pull these from JWT claims (and an
+            # API-key payload extension); for now the columns are
+            # additive and every row lands in the default scope.
             self._conn.execute(
-                "INSERT INTO knowledge_units (id, data, created_at, tier, embedding, embedding_model) "
-                "VALUES (?, ?, ?, ?, ?, ?)",
-                (unit.id, data, created_at, unit.tier.value, embedding, embedding_model),
+                "INSERT INTO knowledge_units "
+                "(id, data, created_at, tier, embedding, embedding_model, "
+                "enterprise_id, group_id) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    unit.id,
+                    data,
+                    created_at,
+                    unit.tier.value,
+                    embedding,
+                    embedding_model,
+                    DEFAULT_ENTERPRISE_ID,
+                    DEFAULT_GROUP_ID,
+                ),
             )
             self._conn.executemany(
                 "INSERT INTO knowledge_unit_domains (unit_id, domain) VALUES (?, ?)",
@@ -595,9 +619,18 @@ class RemoteStore:
         self._check_open()
         now = datetime.now(UTC).isoformat()
         with self._lock, self._conn:
+            # Phase 6 step 1: stamp default tenancy scope on every new user.
             self._conn.execute(
-                "INSERT INTO users (username, password_hash, created_at) VALUES (?, ?, ?)",
-                (username, password_hash, now),
+                "INSERT INTO users "
+                "(username, password_hash, created_at, enterprise_id, group_id) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (
+                    username,
+                    password_hash,
+                    now,
+                    DEFAULT_ENTERPRISE_ID,
+                    DEFAULT_GROUP_ID,
+                ),
             )
 
     def get_user(self, username: str) -> dict[str, Any] | None:
@@ -955,7 +988,8 @@ class RemoteStore:
 
     def approved_embeddings_iter(self) -> list[bytes]:
         """Return all non-null approved KU embedding blobs — used to compute
-        this L2's signature centroid."""
+        this L2's signature centroid.
+        """
         self._check_open()
         with self._lock:
             rows = self._conn.execute(

--- a/server/backend/src/cq_server/tables.py
+++ b/server/backend/src/cq_server/tables.py
@@ -2,6 +2,13 @@
 
 import sqlite3
 
+# Phase 6 step 1 — additive tenancy columns. Defaults defined here so that
+# both runtime-created DBs (via _ensure_schema) and Alembic-migrated DBs
+# converge on the same scope for legacy rows. See
+# docs/plans/06-gap-analysis-deployed-vs-target.md (Section A).
+DEFAULT_ENTERPRISE_ID = "default-enterprise"
+DEFAULT_GROUP_ID = "default-group"
+
 _REVIEW_COLUMN_STATEMENTS = [
     "ALTER TABLE knowledge_units ADD COLUMN status TEXT NOT NULL DEFAULT 'pending'",
     "ALTER TABLE knowledge_units ADD COLUMN reviewed_by TEXT",
@@ -13,6 +20,16 @@ _REVIEW_COLUMN_STATEMENTS = [
 _EMBEDDING_COLUMN_STATEMENTS = [
     "ALTER TABLE knowledge_units ADD COLUMN embedding BLOB",
     "ALTER TABLE knowledge_units ADD COLUMN embedding_model TEXT",
+]
+
+_TENANCY_COLUMN_STATEMENTS_KU = [
+    f"ALTER TABLE knowledge_units ADD COLUMN enterprise_id TEXT NOT NULL DEFAULT '{DEFAULT_ENTERPRISE_ID}'",
+    f"ALTER TABLE knowledge_units ADD COLUMN group_id TEXT NOT NULL DEFAULT '{DEFAULT_GROUP_ID}'",
+]
+
+_TENANCY_COLUMN_STATEMENTS_USERS = [
+    f"ALTER TABLE users ADD COLUMN enterprise_id TEXT NOT NULL DEFAULT '{DEFAULT_ENTERPRISE_ID}'",
+    f"ALTER TABLE users ADD COLUMN group_id TEXT NOT NULL DEFAULT '{DEFAULT_GROUP_ID}'",
 ]
 
 AIGRP_PEERS_TABLE_SQL = """
@@ -33,12 +50,14 @@ CREATE TABLE IF NOT EXISTS aigrp_peers (
 CREATE INDEX IF NOT EXISTS idx_aigrp_peers_enterprise ON aigrp_peers(enterprise);
 """
 
-USERS_TABLE_SQL = """
+USERS_TABLE_SQL = f"""
 CREATE TABLE IF NOT EXISTS users (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     username TEXT NOT NULL UNIQUE,
     password_hash TEXT NOT NULL,
-    created_at TEXT NOT NULL
+    created_at TEXT NOT NULL,
+    enterprise_id TEXT NOT NULL DEFAULT '{DEFAULT_ENTERPRISE_ID}',
+    group_id TEXT NOT NULL DEFAULT '{DEFAULT_GROUP_ID}'
 );
 """
 
@@ -101,3 +120,43 @@ def ensure_aigrp_peers_table(conn: sqlite3.Connection) -> None:
 def ensure_users_table(conn: sqlite3.Connection) -> None:
     """Create the users table if it does not exist."""
     conn.executescript(USERS_TABLE_SQL)
+
+
+def ensure_tenancy_columns(conn: sqlite3.Connection) -> None:
+    """Add enterprise_id / group_id columns to knowledge_units and users.
+
+    Phase 6 step 1 — additive only. Backfills any pre-existing rows with
+    the project-wide defaults so the columns can be NOT NULL without a
+    sentinel value showing up. Idempotent: skips columns that already
+    exist (so this is safe to call on every server startup, mirroring
+    the existing ensure_review_columns / ensure_embedding_columns
+    pattern).
+
+    The same backfill happens inside the Alembic baseline migration so
+    DBs created the new way (Alembic-first) and the legacy way (runtime
+    _ensure_schema) end up with the same shape.
+    """
+    cursor = conn.execute("PRAGMA table_info(knowledge_units)")
+    existing_ku = {row[1] for row in cursor.fetchall()}
+    for statement in _TENANCY_COLUMN_STATEMENTS_KU:
+        col = statement.split("COLUMN ")[1].split()[0]
+        if col not in existing_ku:
+            conn.execute(statement)
+
+    cursor = conn.execute("PRAGMA table_info(users)")
+    existing_users = {row[1] for row in cursor.fetchall()}
+    for statement in _TENANCY_COLUMN_STATEMENTS_USERS:
+        col = statement.split("COLUMN ")[1].split()[0]
+        if col not in existing_users:
+            conn.execute(statement)
+
+    # Backfill any rows that pre-date the column add. SQLite's ALTER TABLE
+    # ADD COLUMN ... DEFAULT only stamps the default on rows inserted after
+    # the alter; existing rows get NULL despite the NOT NULL on the column
+    # spec (this is an old SQLite quirk — see the SQLite docs on ALTER
+    # TABLE). Run an explicit UPDATE so legacy rows pick up the default.
+    conn.execute(f"UPDATE knowledge_units SET enterprise_id = '{DEFAULT_ENTERPRISE_ID}' WHERE enterprise_id IS NULL")
+    conn.execute(f"UPDATE knowledge_units SET group_id = '{DEFAULT_GROUP_ID}' WHERE group_id IS NULL")
+    conn.execute(f"UPDATE users SET enterprise_id = '{DEFAULT_ENTERPRISE_ID}' WHERE enterprise_id IS NULL")
+    conn.execute(f"UPDATE users SET group_id = '{DEFAULT_GROUP_ID}' WHERE group_id IS NULL")
+    conn.commit()

--- a/server/backend/tests/test_tenancy_columns.py
+++ b/server/backend/tests/test_tenancy_columns.py
@@ -1,0 +1,245 @@
+"""Phase 6 step 1: regression tests for additive tenancy columns.
+
+These tests pin two invariants:
+
+  1. New rows written through the propose-time path land in the
+     ``default-enterprise`` / ``default-group`` scope.
+  2. Pre-existing rows on a "legacy" DB (the shape that production looks
+     like at https://8thlayer.onezero1.ai right now — no tenancy
+     columns) get backfilled to the same defaults when the migration /
+     the runtime ``ensure_tenancy_columns`` helper runs.
+
+Read-path filtering is intentionally NOT tested here — that work lands
+in a follow-up PR. This PR only ships the columns.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import subprocess
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from cq.models import Insight, KnowledgeUnit, create_knowledge_unit
+
+from cq_server.store import RemoteStore
+from cq_server.tables import (
+    DEFAULT_ENTERPRISE_ID,
+    DEFAULT_GROUP_ID,
+    ensure_tenancy_columns,
+)
+
+# --- helpers ------------------------------------------------------------
+
+
+def _make_unit(**overrides: Any) -> KnowledgeUnit:
+    defaults = {
+        "domains": ["test-fleet", "tenancy"],
+        "insight": Insight(
+            summary="Tenancy columns smoke",
+            detail="Phase 6 step 1 regression fixture.",
+            action="Assert default scope on new and legacy rows.",
+        ),
+    }
+    return create_knowledge_unit(**{**defaults, **overrides})
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> Iterator[RemoteStore]:
+    s = RemoteStore(db_path=tmp_path / "tenancy.db")
+    yield s
+    s.close()
+
+
+def _scope(conn: sqlite3.Connection, table: str, key_col: str, key: str) -> tuple[str, str]:
+    row = conn.execute(
+        f"SELECT enterprise_id, group_id FROM {table} WHERE {key_col} = ?",
+        (key,),
+    ).fetchone()
+    assert row is not None, f"no row in {table} for {key_col}={key!r}"
+    return row[0], row[1]
+
+
+# --- new-row defaults ---------------------------------------------------
+
+
+class TestNewRowDefaults:
+    def test_inserted_ku_lands_in_default_scope(self, store: RemoteStore) -> None:
+        unit = _make_unit()
+        store.insert(unit)
+        ent, grp = _scope(store._conn, "knowledge_units", "id", unit.id)
+        assert ent == DEFAULT_ENTERPRISE_ID
+        assert grp == DEFAULT_GROUP_ID
+
+    def test_created_user_lands_in_default_scope(self, store: RemoteStore) -> None:
+        store.create_user("alice", "pwhash")
+        ent, grp = _scope(store._conn, "users", "username", "alice")
+        assert ent == DEFAULT_ENTERPRISE_ID
+        assert grp == DEFAULT_GROUP_ID
+
+    def test_columns_are_not_null(self, store: RemoteStore) -> None:
+        # Prove the schema rejects an explicit NULL.
+        with pytest.raises(sqlite3.IntegrityError):
+            store._conn.execute(
+                "INSERT INTO knowledge_units (id, data, enterprise_id, group_id) "
+                "VALUES (?, ?, ?, ?)",
+                ("ku_null", "{}", None, "default-group"),
+            )
+
+
+# --- legacy-row backfill ------------------------------------------------
+
+
+class TestLegacyBackfill:
+    """Simulate the production DB shape (pre-migration) and confirm that
+    ``ensure_tenancy_columns`` adds the columns AND backfills the rows.
+
+    This mirrors what RemoteStore() does on startup (via _ensure_schema),
+    and is also what the Alembic migration achieves through its own
+    backfill path. Both code paths converge on the same default scope.
+    """
+
+    def test_pre_existing_rows_get_backfilled(self, tmp_path: Path) -> None:
+        db = tmp_path / "legacy.db"
+
+        # Create a "legacy" DB without the tenancy columns.
+        conn = sqlite3.connect(str(db))
+        conn.executescript(
+            """
+            CREATE TABLE knowledge_units (id TEXT PRIMARY KEY, data TEXT NOT NULL);
+            CREATE TABLE users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT NOT NULL UNIQUE,
+                password_hash TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO knowledge_units (id, data) VALUES (?, ?)",
+            ("legacy_ku_1", "{}"),
+        )
+        conn.execute(
+            "INSERT INTO users (username, password_hash, created_at) VALUES (?, ?, ?)",
+            ("legacy_user", "hash", "2024-01-01T00:00:00+00:00"),
+        )
+        conn.commit()
+
+        # Apply the additive migration helper.
+        ensure_tenancy_columns(conn)
+
+        # Both pre-existing rows now carry the default scope.
+        ent_ku, grp_ku = _scope(conn, "knowledge_units", "id", "legacy_ku_1")
+        assert (ent_ku, grp_ku) == (DEFAULT_ENTERPRISE_ID, DEFAULT_GROUP_ID)
+
+        ent_u, grp_u = _scope(conn, "users", "username", "legacy_user")
+        assert (ent_u, grp_u) == (DEFAULT_ENTERPRISE_ID, DEFAULT_GROUP_ID)
+
+        # And the column is now NOT NULL — explicit NULL is rejected.
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO knowledge_units (id, data, enterprise_id) "
+                "VALUES (?, ?, ?)",
+                ("ku_null", "{}", None),
+            )
+
+        conn.close()
+
+    def test_helper_is_idempotent(self, tmp_path: Path) -> None:
+        # Calling ensure_tenancy_columns twice on the same DB must not
+        # raise "duplicate column" — the runtime triggers it on every
+        # process startup.
+        db = tmp_path / "idempotent.db"
+        conn = sqlite3.connect(str(db))
+        conn.executescript(
+            """
+            CREATE TABLE knowledge_units (id TEXT PRIMARY KEY, data TEXT NOT NULL);
+            CREATE TABLE users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT NOT NULL UNIQUE,
+                password_hash TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            );
+            """
+        )
+        conn.commit()
+        ensure_tenancy_columns(conn)
+        ensure_tenancy_columns(conn)  # must not raise
+        conn.close()
+
+
+# --- alembic upgrade / downgrade ---------------------------------------
+
+
+class TestAlembicMigration:
+    """End-to-end: run the Alembic migration on an empty DB and on a
+    DB that already has rows. Both upgrade and downgrade must complete
+    cleanly. This is the migration smoke-test the PR description calls
+    for.
+    """
+
+    def _run_alembic(self, db_path: Path, command: str) -> subprocess.CompletedProcess[str]:
+        repo_root = Path(__file__).resolve().parents[1]
+        return subprocess.run(
+            ["uv", "run", "alembic", command, "head" if command == "upgrade" else "base"],
+            cwd=str(repo_root),
+            env={
+                "PATH": _path_env(),
+                "CQ_DB_PATH": str(db_path),
+                "HOME": str(Path.home()),
+            },
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_upgrade_then_downgrade_clean_on_empty_db(self, tmp_path: Path) -> None:
+        db = tmp_path / "alembic_empty.db"
+        # Touch the DB so the file exists but has no schema.
+        sqlite3.connect(str(db)).close()
+
+        up = self._run_alembic(db, "upgrade")
+        assert up.returncode == 0, f"upgrade failed: {up.stderr}\n{up.stdout}"
+
+        down = self._run_alembic(db, "downgrade")
+        assert down.returncode == 0, f"downgrade failed: {down.stderr}\n{down.stdout}"
+
+    def test_upgrade_on_legacy_db_backfills_rows(self, tmp_path: Path) -> None:
+        db = tmp_path / "alembic_legacy.db"
+        conn = sqlite3.connect(str(db))
+        conn.executescript(
+            """
+            CREATE TABLE knowledge_units (id TEXT PRIMARY KEY, data TEXT NOT NULL);
+            CREATE TABLE users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT NOT NULL UNIQUE,
+                password_hash TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            );
+            INSERT INTO knowledge_units (id, data) VALUES ('legacy_ku', '{}');
+            INSERT INTO users (username, password_hash, created_at)
+                VALUES ('legacy_user', 'hash', '2024-01-01T00:00:00+00:00');
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        up = self._run_alembic(db, "upgrade")
+        assert up.returncode == 0, f"upgrade failed: {up.stderr}\n{up.stdout}"
+
+        # Inspect the row scope post-migration.
+        check = sqlite3.connect(str(db))
+        ent_ku, grp_ku = _scope(check, "knowledge_units", "id", "legacy_ku")
+        assert (ent_ku, grp_ku) == (DEFAULT_ENTERPRISE_ID, DEFAULT_GROUP_ID)
+        ent_u, grp_u = _scope(check, "users", "username", "legacy_user")
+        assert (ent_u, grp_u) == (DEFAULT_ENTERPRISE_ID, DEFAULT_GROUP_ID)
+        check.close()
+
+
+def _path_env() -> str:
+    """Pass through the test runner's PATH so subprocess can find ``uv``."""
+    import os
+
+    return os.environ.get("PATH", "")


### PR DESCRIPTION
See branch commits for full description.

## Summary

Add enterprise_id and group_id columns to knowledge_units and users, defaulted to default-enterprise / default-group. Backfill any pre-existing rows. No read-path enforcement yet — additive only.

Reference: docs/plans/06-gap-analysis-deployed-vs-target.md (Section A + step 2 of the Recommended build order) in OneZero1ai/crosstalk-enterprise.

## What changed
- New Alembic migration (0001_phase6_step1) — first in this repo. Adds columns nullable, inline UPDATE backfill, then promotes to NOT NULL via batch_alter_table. Idempotent.
- ensure_tenancy_columns helper in tables.py mirrors the same logic for the runtime-managed schema path (RemoteStore._ensure_schema).
- Propose-time write paths (RemoteStore.insert, create_user) stamp the defaults explicitly.

## Out of scope
- Read-path filtering by enterprise_id / group_id (next PR).
- API key payload changes (later).
- Persona/User split (later).
- New tables: tenants, enterprises, groups, humans, personas, teams.

## Test plan
- pytest tests/test_tenancy_columns.py: 7 new tests pass (TestNewRowDefaults x3, TestLegacyBackfill x2, TestAlembicMigration x2)
- pytest tests/: 238 passed (231 baseline + 7 new)
- ruff check clean on changed files
- Manual end-to-end: alembic upgrade head against a legacy DB confirms backfill + NOT NULL enforcement

🤖 Generated with Claude Code