### PR TITLE
[server] Phase 6 step 2: cross-L2 forward-query endpoint + xgroup/consent schema

### DIFF
--- a/server/backend/alembic/versions/0002_phase6_step2_xgroup_consent.py
+++ b/server/backend/alembic/versions/0002_phase6_step2_xgroup_consent.py
@@ -1,0 +1,137 @@
+"""Phase 6 step 2: cross-group flag + cross-Enterprise consent + audit.
+
+Revision ID: 0002_phase6_step2
+Revises: 0001_phase6_step1
+Create Date: 2026-04-30
+
+Adds the schema delta required by /aigrp/forward-query:
+
+  - ``knowledge_units.cross_group_allowed`` — per-KU opt-in flag for
+    sharing across sibling Groups inside the same Enterprise. Defaults
+    to 0 so no existing row implicitly opens up.
+  - ``cross_enterprise_consents`` table — admin-signed records that
+    permit a foreign Enterprise's L2 to receive forward-query results
+    from this L2 under a stated policy (``summary_only`` in v1).
+  - ``cross_l2_audit`` table — append-only log of every
+    /aigrp/forward-query call, including denied probes.
+
+Mirrors the runtime ``ensure_xgroup_consent_schema`` helper so the
+Alembic-first DB and the legacy-runtime DB converge on the same shape.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0002_phase6_step2"
+down_revision: str | Sequence[str] | None = "0001_phase6_step1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _table_exists(bind: sa.engine.Connection, table_name: str) -> bool:
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def _column_names(bind: sa.engine.Connection, table_name: str) -> set[str]:
+    inspector = sa.inspect(bind)
+    if table_name not in inspector.get_table_names():
+        return set()
+    return {col["name"] for col in inspector.get_columns(table_name)}
+
+
+def upgrade() -> None:
+    """Add cross_group_allowed column + create consent and audit tables."""
+    bind = op.get_bind()
+
+    # 1. cross_group_allowed on knowledge_units (idempotent).
+    if _table_exists(bind, "knowledge_units"):
+        existing = _column_names(bind, "knowledge_units")
+        if "cross_group_allowed" not in existing:
+            op.add_column(
+                "knowledge_units",
+                sa.Column(
+                    "cross_group_allowed",
+                    sa.Integer(),
+                    nullable=True,
+                    server_default=sa.text("0"),
+                ),
+            )
+            # Backfill — same SQLite ALTER quirk as Phase 6 step 1.
+            op.execute(
+                sa.text(
+                    "UPDATE knowledge_units SET cross_group_allowed = 0 "
+                    "WHERE cross_group_allowed IS NULL"
+                )
+            )
+            with op.batch_alter_table("knowledge_units") as batch:
+                batch.alter_column(
+                    "cross_group_allowed",
+                    existing_type=sa.Integer(),
+                    nullable=False,
+                    existing_server_default=sa.text("0"),
+                )
+
+    # 2. cross_enterprise_consents — admin-signed sharing records.
+    if not _table_exists(bind, "cross_enterprise_consents"):
+        op.create_table(
+            "cross_enterprise_consents",
+            sa.Column("consent_id", sa.Text(), primary_key=True),
+            sa.Column("requester_enterprise", sa.Text(), nullable=False),
+            sa.Column("responder_enterprise", sa.Text(), nullable=False),
+            sa.Column("requester_group", sa.Text(), nullable=True),
+            sa.Column("responder_group", sa.Text(), nullable=True),
+            sa.Column("policy", sa.Text(), nullable=False),
+            sa.Column("signed_by_admin", sa.Text(), nullable=False),
+            sa.Column("signed_at", sa.Text(), nullable=False),
+            sa.Column("expires_at", sa.Text(), nullable=True),
+            sa.Column("audit_log_id", sa.Text(), nullable=False, unique=True),
+        )
+        op.create_index(
+            "idx_xent_consents_pair",
+            "cross_enterprise_consents",
+            ["requester_enterprise", "responder_enterprise"],
+        )
+
+    # 3. cross_l2_audit — append-only audit log.
+    if not _table_exists(bind, "cross_l2_audit"):
+        op.create_table(
+            "cross_l2_audit",
+            sa.Column("audit_id", sa.Text(), primary_key=True),
+            sa.Column("ts", sa.Text(), nullable=False),
+            sa.Column("requester_l2_id", sa.Text(), nullable=True),
+            sa.Column("requester_enterprise", sa.Text(), nullable=True),
+            sa.Column("requester_group", sa.Text(), nullable=True),
+            sa.Column("requester_persona", sa.Text(), nullable=True),
+            sa.Column("responder_l2_id", sa.Text(), nullable=True),
+            sa.Column("responder_enterprise", sa.Text(), nullable=True),
+            sa.Column("responder_group", sa.Text(), nullable=True),
+            sa.Column("policy_applied", sa.Text(), nullable=True),
+            sa.Column("result_count", sa.Integer(), nullable=True),
+            sa.Column("consent_id", sa.Text(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    """Drop the new tables and column.
+
+    Used by migration tests; production rollbacks should prefer leaving
+    the additive tables in place.
+    """
+    bind = op.get_bind()
+    if _table_exists(bind, "cross_l2_audit"):
+        op.drop_table("cross_l2_audit")
+    if _table_exists(bind, "cross_enterprise_consents"):
+        op.drop_index(
+            "idx_xent_consents_pair",
+            table_name="cross_enterprise_consents",
+        )
+        op.drop_table("cross_enterprise_consents")
+    if _table_exists(bind, "knowledge_units"):
+        existing = _column_names(bind, "knowledge_units")
+        if "cross_group_allowed" in existing:
+            with op.batch_alter_table("knowledge_units") as batch:
+                batch.drop_column("cross_group_allowed")

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -85,7 +85,8 @@ async def _aigrp_bootstrap_and_poll(store: RemoteStore) -> None:
 
     def _try_bootstrap() -> bool:
         """Hit the seed's /aigrp/hello and absorb its peer table.
-        Returns True on success. Idempotent on the seed side."""
+        Returns True on success. Idempotent on the seed side.
+        """
         try:
             hello_payload = json.dumps({
                 "l2_id": aigrp.self_l2_id(),
@@ -250,7 +251,8 @@ class AigrpLookupHit(BaseModel):
     """Lean wire shape returned by /aigrp/lookup — only the fields the
     harness needs to inject as a system-reminder. Avoids shipping the
     full KnowledgeUnit blob (with evidence, context, etc.) on every
-    prompt."""
+    prompt.
+    """
 
     ku_id: str
     summary: str
@@ -571,9 +573,238 @@ def aigrp_signature(
     _peer: None = Depends(aigrp.require_peer_key),
 ) -> AigrpSignatureResponse:
     """Return this L2's current corpus signature — centroid + Bloom filter
-    + counts. Polled by every peer on the AIGRP polling interval."""
+    + counts. Polled by every peer on the AIGRP polling interval.
+    """
     store = _get_store()
     return _build_self_signature(store)
+
+
+class AigrpForwardQueryRequest(BaseModel):
+    """Cross-L2 forward-query — one L2 asking another L2 for KUs.
+
+    Phase 6 step 2 / Lane B. The response shape mirrors /aigrp/lookup
+    where it overlaps but adds tenancy scope (so the requester can
+    correlate to its own peer table) and an explicit ``redacted_fields``
+    list for any policy-suppressed fields.
+    """
+
+    query_vec: list[float] = Field(min_length=1)
+    query_text: str = ""
+    requester_l2_id: str = Field(min_length=1)
+    requester_enterprise: str = Field(min_length=1)
+    requester_group: str = Field(min_length=1)
+    requester_persona: str = ""
+    max_results: int = Field(default=5, gt=0, le=20)
+
+
+class AigrpForwardQueryHit(BaseModel):
+    """One KU returned by /aigrp/forward-query.
+
+    ``detail`` and ``action`` are populated under ``full_body`` policy
+    and omitted (None) under ``summary_only``. ``redacted_fields`` lists
+    the field names that were withheld so the requester knows what to
+    ask for via a higher-trust channel if they need it.
+    """
+
+    ku_id: str
+    summary: str
+    detail: str | None = None
+    action: str | None = None
+    domains: list[str]
+    sim_score: float
+    redacted_fields: list[str] = Field(default_factory=list)
+
+
+class AigrpForwardQueryResponse(BaseModel):
+    """Wire shape for /aigrp/forward-query."""
+
+    responder_l2_id: str
+    responder_enterprise: str
+    responder_group: str
+    policy_applied: str  # "summary_only" | "full_body" | "denied"
+    results: list[AigrpForwardQueryHit]
+    result_count: int
+
+
+def _decide_policy_for_ku(
+    *,
+    ku_enterprise: str,
+    ku_group: str,
+    ku_cross_group_allowed: bool,
+    requester_enterprise: str,
+    requester_group: str,
+    responder_enterprise: str,
+    responder_group: str,
+    cross_enterprise_consent: dict[str, object] | None,
+) -> tuple[str, list[str]]:
+    """Return (policy, redacted_fields) for one KU.
+
+    Implements the rule set spelled out in
+    docs/plans/08-live-network-demo.md Lane B step 2:
+
+      1. Same Enterprise + same Group         -> full_body
+      2. Same Enterprise + different Group    -> full_body iff cross_group_allowed
+                                                else summary_only
+      3. Different Enterprise                 -> consent-driven; default deny
+
+    First match wins. Pure function — no DB access — so it's cheap to
+    fan over every candidate hit.
+    """
+    if requester_enterprise == ku_enterprise:
+        if requester_group == ku_group:
+            return "full_body", []
+        if ku_cross_group_allowed:
+            return "full_body", []
+        return "summary_only", ["detail", "action"]
+    # Different Enterprise.
+    if cross_enterprise_consent is None:
+        return "denied", []
+    policy = str(cross_enterprise_consent.get("policy") or "")
+    if policy == "full_body":
+        return "full_body", []
+    # v1 consent grants only summary_only sharing.
+    return "summary_only", ["detail", "action"]
+
+
+@api_router.post("/aigrp/forward-query")
+def aigrp_forward_query(
+    body: AigrpForwardQueryRequest,
+    _peer: None = Depends(aigrp.require_peer_key),
+) -> AigrpForwardQueryResponse:
+    """Cross-L2 forward-query — Phase 6 step 2.
+
+    A sibling (or, with consent, a foreign-Enterprise) L2 sends a query
+    embedding plus its identity. We run semantic search over our own
+    approved KUs, evaluate the per-KU sharing policy, and return either
+    a redacted summary list, full bodies, or zero results when policy
+    forbids. Every call is appended to the ``cross_l2_audit`` table.
+
+    Auth: shared EnterprisePeerKey (same as the rest of /aigrp/*). For
+    cross-Enterprise calls the additional gate is the
+    ``cross_enterprise_consents`` row — without that the call returns
+    zero results silently rather than 401, so probes can't fingerprint
+    consent state.
+    """
+    import uuid
+
+    store = _get_store()
+
+    responder_enterprise = aigrp.enterprise()
+    responder_group = aigrp.group()
+    responder_l2_id = aigrp.self_l2_id()
+
+    # Same-Enterprise vs cross-Enterprise gate. For cross-Enterprise the
+    # consent record drives whether we even attempt to return rows.
+    consent: dict[str, object] | None = None
+    if body.requester_enterprise != responder_enterprise:
+        consent = store.find_cross_enterprise_consent(
+            requester_enterprise=body.requester_enterprise,
+            responder_enterprise=responder_enterprise,
+            requester_group=body.requester_group,
+            responder_group=responder_group,
+            now_iso=aigrp.now_iso(),
+        )
+        if consent is None:
+            # Silent deny — log the attempt and return empty.
+            store.record_cross_l2_audit(
+                audit_id=uuid.uuid4().hex,
+                ts=aigrp.now_iso(),
+                requester_l2_id=body.requester_l2_id,
+                requester_enterprise=body.requester_enterprise,
+                requester_group=body.requester_group,
+                requester_persona=body.requester_persona or None,
+                responder_l2_id=responder_l2_id,
+                responder_enterprise=responder_enterprise,
+                responder_group=responder_group,
+                policy_applied="denied",
+                result_count=0,
+                consent_id=None,
+            )
+            return AigrpForwardQueryResponse(
+                responder_l2_id=responder_l2_id,
+                responder_enterprise=responder_enterprise,
+                responder_group=responder_group,
+                policy_applied="denied",
+                results=[],
+                result_count=0,
+            )
+
+    raw_hits = store.semantic_query_with_scope(
+        body.query_vec,
+        limit=body.max_results * 3,
+    )
+
+    results: list[AigrpForwardQueryHit] = []
+    # The response-level ``policy_applied`` is the strictest applied
+    # across the returned hits ("summary_only" wins over "full_body" if
+    # any KU was redacted).
+    response_policy = "full_body"
+    for hit in raw_hits:
+        unit: KnowledgeUnit = hit["unit"]
+        policy, redacted = _decide_policy_for_ku(
+            ku_enterprise=hit["enterprise_id"],
+            ku_group=hit["group_id"],
+            ku_cross_group_allowed=hit["cross_group_allowed"],
+            requester_enterprise=body.requester_enterprise,
+            requester_group=body.requester_group,
+            responder_enterprise=responder_enterprise,
+            responder_group=responder_group,
+            cross_enterprise_consent=consent,
+        )
+        if policy == "denied":
+            continue
+        if policy == "summary_only":
+            response_policy = "summary_only"
+            results.append(
+                AigrpForwardQueryHit(
+                    ku_id=unit.id,
+                    summary=unit.insight.summary,
+                    detail=None,
+                    action=None,
+                    domains=list(unit.domains),
+                    sim_score=hit["similarity"],
+                    redacted_fields=redacted,
+                )
+            )
+        else:
+            results.append(
+                AigrpForwardQueryHit(
+                    ku_id=unit.id,
+                    summary=unit.insight.summary,
+                    detail=unit.insight.detail,
+                    action=unit.insight.action,
+                    domains=list(unit.domains),
+                    sim_score=hit["similarity"],
+                    redacted_fields=[],
+                )
+            )
+        if len(results) >= body.max_results:
+            break
+
+    consent_id = str(consent["consent_id"]) if consent else None
+    store.record_cross_l2_audit(
+        audit_id=uuid.uuid4().hex,
+        ts=aigrp.now_iso(),
+        requester_l2_id=body.requester_l2_id,
+        requester_enterprise=body.requester_enterprise,
+        requester_group=body.requester_group,
+        requester_persona=body.requester_persona or None,
+        responder_l2_id=responder_l2_id,
+        responder_enterprise=responder_enterprise,
+        responder_group=responder_group,
+        policy_applied=response_policy,
+        result_count=len(results),
+        consent_id=consent_id,
+    )
+
+    return AigrpForwardQueryResponse(
+        responder_l2_id=responder_l2_id,
+        responder_enterprise=responder_enterprise,
+        responder_group=responder_group,
+        policy_applied=response_policy,
+        results=results,
+        result_count=len(results),
+    )
 
 
 @api_router.get("/query/semantic")

--- a/server/backend/src/cq_server/store/__init__.py
+++ b/server/backend/src/cq_server/store/__init__.py
@@ -26,6 +26,7 @@ from ..tables import (
     ensure_review_columns,
     ensure_tenancy_columns,
     ensure_users_table,
+    ensure_xgroup_consent_schema,
 )
 from ._protocol import Store
 
@@ -103,6 +104,10 @@ class RemoteStore:
         # run on every startup. Backfills legacy rows so the columns can
         # be queried without NULL handling once enforcement lands.
         ensure_tenancy_columns(self._conn)
+        # Phase 6 step 2 — cross-group flag + cross-Enterprise consent
+        # registry + cross-L2 audit log. Same idempotent shape so the
+        # runtime path matches the Alembic migration.
+        ensure_xgroup_consent_schema(self._conn)
 
     def _check_open(self) -> None:
         """Raise if the store has been closed."""
@@ -951,8 +956,10 @@ class RemoteStore:
                 )
 
     def list_aigrp_peers(self, enterprise: str) -> list[dict[str, Any]]:
-        """Return every known peer in the given Enterprise (no TTL filter —
-        peers age out via the periodic poll task overwriting last_seen).
+        """Return every known peer in the given Enterprise.
+
+        No TTL filter — peers age out via the periodic poll task
+        overwriting ``last_seen``.
         """
         self._check_open()
         with self._lock:
@@ -987,8 +994,9 @@ class RemoteStore:
         ]
 
     def approved_embeddings_iter(self) -> list[bytes]:
-        """Return all non-null approved KU embedding blobs — used to compute
-        this L2's signature centroid.
+        """Return all non-null approved KU embedding blobs.
+
+        Used to compute this L2's signature centroid.
         """
         self._check_open()
         with self._lock:
@@ -1009,6 +1017,227 @@ class RemoteStore:
                 "WHERE ku.status = 'approved'"
             ).fetchall()
         return {r[0] for r in rows if r[0]}
+
+    # -- Phase 6 step 2: cross-L2 forward-query support ------------------
+
+    def semantic_query_with_scope(
+        self,
+        query_vec: list[float],
+        *,
+        limit: int = 10,
+        status: str = "approved",
+    ) -> list[dict[str, Any]]:
+        """Cosine-rank approved KUs, returning scope + xgroup flag per row.
+
+        Used by /aigrp/forward-query — the policy-evaluation step needs
+        ``enterprise_id`` / ``group_id`` / ``cross_group_allowed`` per
+        candidate KU, which the plain ``semantic_query`` path doesn't
+        return. Kept separate to avoid widening the returned tuple shape
+        of the existing call sites.
+
+        Returns one dict per hit, sorted by similarity desc, limited.
+        """
+        import numpy as np
+
+        self._check_open()
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT data, embedding, enterprise_id, group_id, "
+                "cross_group_allowed FROM knowledge_units "
+                "WHERE status = ? AND embedding IS NOT NULL",
+                (status,),
+            ).fetchall()
+        if not rows:
+            return []
+
+        query = np.array(query_vec, dtype=np.float32)
+        q_norm = np.linalg.norm(query)
+        if q_norm == 0:
+            return []
+        query = query / q_norm
+
+        scored: list[tuple[float, KnowledgeUnit, str, str, int]] = []
+        for data_str, blob, ent, grp, xgroup in rows:
+            vec = np.frombuffer(blob, dtype=np.float32)
+            if vec.size == 0:
+                continue
+            v_norm = np.linalg.norm(vec)
+            if v_norm == 0:
+                continue
+            sim = float(np.dot(query, vec / v_norm))
+            unit = KnowledgeUnit.model_validate_json(data_str)
+            scored.append((sim, unit, ent or DEFAULT_ENTERPRISE_ID, grp or DEFAULT_GROUP_ID, int(xgroup or 0)))
+        scored.sort(key=lambda t: t[0], reverse=True)
+        return [
+            {
+                "unit": unit,
+                "similarity": sim,
+                "enterprise_id": ent,
+                "group_id": grp,
+                "cross_group_allowed": bool(xgroup),
+            }
+            for sim, unit, ent, grp, xgroup in scored[:limit]
+        ]
+
+    def find_cross_enterprise_consent(
+        self,
+        *,
+        requester_enterprise: str,
+        responder_enterprise: str,
+        requester_group: str | None,
+        responder_group: str | None,
+        now_iso: str,
+    ) -> dict[str, Any] | None:
+        """Look up an active consent record for a (req-ent, resp-ent) pair.
+
+        Group-level columns are nullable in the schema — null means "any
+        group on that side". The lookup picks the most-specific match
+        first (both groups specified) and falls back through the wildcard
+        rows. ``now_iso`` lets the caller pin "active" to a specific
+        clock; expired rows are skipped.
+        """
+        self._check_open()
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT consent_id, requester_group, responder_group,
+                       policy, signed_by_admin, signed_at, expires_at,
+                       audit_log_id
+                FROM cross_enterprise_consents
+                WHERE requester_enterprise = ?
+                  AND responder_enterprise = ?
+                  AND (expires_at IS NULL OR expires_at > ?)
+                """,
+                (requester_enterprise, responder_enterprise, now_iso),
+            ).fetchall()
+        if not rows:
+            return None
+
+        # Score: exact group match worth more than null wildcard.
+        def _score(req_g: str | None, resp_g: str | None) -> int:
+            return (
+                (2 if req_g == requester_group and req_g is not None else 0)
+                + (2 if resp_g == responder_group and resp_g is not None else 0)
+                + (1 if req_g is None else 0)
+                + (1 if resp_g is None else 0)
+            )
+
+        best = None
+        best_score = -1
+        for r in rows:
+            req_g, resp_g = r[1], r[2]
+            # Only accept rows where the group constraints are satisfied
+            # — exact match OR null (wildcard).
+            if req_g is not None and req_g != requester_group:
+                continue
+            if resp_g is not None and resp_g != responder_group:
+                continue
+            score = _score(req_g, resp_g)
+            if score > best_score:
+                best_score = score
+                best = r
+        if best is None:
+            return None
+        return {
+            "consent_id": best[0],
+            "requester_group": best[1],
+            "responder_group": best[2],
+            "policy": best[3],
+            "signed_by_admin": best[4],
+            "signed_at": best[5],
+            "expires_at": best[6],
+            "audit_log_id": best[7],
+        }
+
+    def insert_cross_enterprise_consent(
+        self,
+        *,
+        consent_id: str,
+        requester_enterprise: str,
+        responder_enterprise: str,
+        requester_group: str | None,
+        responder_group: str | None,
+        policy: str,
+        signed_by_admin: str,
+        signed_at: str,
+        expires_at: str | None,
+        audit_log_id: str,
+    ) -> None:
+        """Insert a consent record.
+
+        Used by tests today; the admin sign-consent endpoint (Lane D)
+        will call this in a follow-up PR.
+        """
+        self._check_open()
+        with self._lock, self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO cross_enterprise_consents (
+                    consent_id, requester_enterprise, responder_enterprise,
+                    requester_group, responder_group, policy,
+                    signed_by_admin, signed_at, expires_at, audit_log_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    consent_id, requester_enterprise, responder_enterprise,
+                    requester_group, responder_group, policy,
+                    signed_by_admin, signed_at, expires_at, audit_log_id,
+                ),
+            )
+
+    def record_cross_l2_audit(
+        self,
+        *,
+        audit_id: str,
+        ts: str,
+        requester_l2_id: str | None,
+        requester_enterprise: str | None,
+        requester_group: str | None,
+        requester_persona: str | None,
+        responder_l2_id: str | None,
+        responder_enterprise: str | None,
+        responder_group: str | None,
+        policy_applied: str,
+        result_count: int,
+        consent_id: str | None,
+    ) -> None:
+        """Append a row to ``cross_l2_audit``.
+
+        Every /aigrp/forward-query call writes one row regardless of
+        outcome — even denied requests are logged so an Enterprise admin
+        can see who tried to ask what.
+        """
+        self._check_open()
+        with self._lock, self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO cross_l2_audit (
+                    audit_id, ts, requester_l2_id, requester_enterprise,
+                    requester_group, requester_persona,
+                    responder_l2_id, responder_enterprise, responder_group,
+                    policy_applied, result_count, consent_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    audit_id, ts, requester_l2_id, requester_enterprise,
+                    requester_group, requester_persona,
+                    responder_l2_id, responder_enterprise, responder_group,
+                    policy_applied, result_count, consent_id,
+                ),
+            )
+
+    def set_ku_cross_group_allowed(self, unit_id: str, allowed: bool) -> bool:
+        """Flip the per-KU cross-group sharing flag.
+
+        Returns True if a row was updated.
+        """
+        self._check_open()
+        with self._lock, self._conn:
+            cur = self._conn.execute(
+                "UPDATE knowledge_units SET cross_group_allowed = ? WHERE id = ?",
+                (1 if allowed else 0, unit_id),
+            )
+        return cur.rowcount > 0
 
     def confidence_distribution(self) -> dict[str, int]:
         """Return confidence distribution buckets for approved KUs."""

--- a/server/backend/src/cq_server/tables.py
+++ b/server/backend/src/cq_server/tables.py
@@ -32,6 +32,49 @@ _TENANCY_COLUMN_STATEMENTS_USERS = [
     f"ALTER TABLE users ADD COLUMN group_id TEXT NOT NULL DEFAULT '{DEFAULT_GROUP_ID}'",
 ]
 
+# Phase 6 step 2 — cross-group / cross-enterprise sharing controls.
+# `cross_group_allowed` is the per-KU opt-in flag the forward-query
+# endpoint consults when an in-Enterprise sibling Group asks. Default 0
+# preserves the prior behavior (no implicit cross-Group sharing) for
+# every existing row.
+_XGROUP_COLUMN_STATEMENTS = [
+    "ALTER TABLE knowledge_units ADD COLUMN cross_group_allowed INTEGER NOT NULL DEFAULT 0",
+]
+
+CROSS_ENTERPRISE_CONSENTS_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS cross_enterprise_consents (
+    consent_id TEXT PRIMARY KEY,
+    requester_enterprise TEXT NOT NULL,
+    responder_enterprise TEXT NOT NULL,
+    requester_group TEXT,
+    responder_group TEXT,
+    policy TEXT NOT NULL,
+    signed_by_admin TEXT NOT NULL,
+    signed_at TEXT NOT NULL,
+    expires_at TEXT,
+    audit_log_id TEXT NOT NULL UNIQUE
+);
+CREATE INDEX IF NOT EXISTS idx_xent_consents_pair
+    ON cross_enterprise_consents(requester_enterprise, responder_enterprise);
+"""
+
+CROSS_L2_AUDIT_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS cross_l2_audit (
+    audit_id TEXT PRIMARY KEY,
+    ts TEXT NOT NULL,
+    requester_l2_id TEXT,
+    requester_enterprise TEXT,
+    requester_group TEXT,
+    requester_persona TEXT,
+    responder_l2_id TEXT,
+    responder_enterprise TEXT,
+    responder_group TEXT,
+    policy_applied TEXT,
+    result_count INTEGER,
+    consent_id TEXT
+);
+"""
+
 AIGRP_PEERS_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS aigrp_peers (
     l2_id TEXT PRIMARY KEY,
@@ -159,4 +202,28 @@ def ensure_tenancy_columns(conn: sqlite3.Connection) -> None:
     conn.execute(f"UPDATE knowledge_units SET group_id = '{DEFAULT_GROUP_ID}' WHERE group_id IS NULL")
     conn.execute(f"UPDATE users SET enterprise_id = '{DEFAULT_ENTERPRISE_ID}' WHERE enterprise_id IS NULL")
     conn.execute(f"UPDATE users SET group_id = '{DEFAULT_GROUP_ID}' WHERE group_id IS NULL")
+    conn.commit()
+
+
+def ensure_xgroup_consent_schema(conn: sqlite3.Connection) -> None:
+    """Phase 6 step 2 — additive schema for cross-L2 forward-query.
+
+    Idempotent on every startup, mirroring ``ensure_tenancy_columns``.
+    Adds ``cross_group_allowed`` to ``knowledge_units`` (default 0 — no
+    implicit sharing) and creates the ``cross_enterprise_consents`` and
+    ``cross_l2_audit`` tables. Both tables are write-once-from-server's
+    perspective (admin signs consents in Lane D; audits are append-only)
+    so no schema migration besides the initial CREATE.
+    """
+    cursor = conn.execute("PRAGMA table_info(knowledge_units)")
+    existing_ku = {row[1] for row in cursor.fetchall()}
+    for statement in _XGROUP_COLUMN_STATEMENTS:
+        col = statement.split("COLUMN ")[1].split()[0]
+        if col not in existing_ku:
+            conn.execute(statement)
+    # Backfill: SQLite's ADD COLUMN ... DEFAULT 0 leaves pre-existing
+    # rows NULL on some older builds; force every row to 0 for safety.
+    conn.execute("UPDATE knowledge_units SET cross_group_allowed = 0 WHERE cross_group_allowed IS NULL")
+    conn.executescript(CROSS_ENTERPRISE_CONSENTS_TABLE_SQL)
+    conn.executescript(CROSS_L2_AUDIT_TABLE_SQL)
     conn.commit()

--- a/server/backend/tests/test_forward_query.py
+++ b/server/backend/tests/test_forward_query.py
@@ -1,0 +1,456 @@
+"""Phase 6 step 2: cross-L2 /aigrp/forward-query endpoint tests.
+
+Covers the policy-evaluation matrix:
+
+  - same-Enterprise + same-Group               -> full_body
+  - same-Enterprise + different-Group, no flag -> summary_only
+  - same-Enterprise + different-Group, flag    -> full_body
+  - different-Enterprise, no consent           -> empty (silent deny)
+  - different-Enterprise, with consent         -> summary_only
+
+Plus the audit-log invariant (every call writes one row).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import struct
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from cq.models import Insight, create_knowledge_unit
+from fastapi.testclient import TestClient
+
+from cq_server.app import _get_store, app
+from cq_server.tables import DEFAULT_ENTERPRISE_ID, DEFAULT_GROUP_ID
+
+PEER_KEY = "test-peer-key-forward-query"
+
+
+def _pack_vec(vec: list[float]) -> bytes:
+    """Pack a float list into the same little-endian float32 bytes the
+    Bedrock embedder writes — keeps the test fixture independent of
+    Bedrock connectivity."""
+    return struct.pack(f"<{len(vec)}f", *vec)
+
+
+def _unit_vec(dim: int = 8, axis: int = 0) -> list[float]:
+    """Unit vector with all weight on one axis. Two such vectors with the
+    same axis cosine-similar to ~1.0; different axes give ~0.0. Easier
+    to reason about than random vectors."""
+    v = [0.0] * dim
+    v[axis] = 1.0
+    return v
+
+
+@pytest.fixture()
+def aigrp_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    """TestClient configured with the AIGRP peer key + a clean DB.
+
+    The responder L2's identity is set via env: enterprise=acme,
+    group=solutions. Tests exercise requester_enterprise/group via the
+    request body to drive the policy matrix.
+    """
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "fwdq.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    monkeypatch.setenv("CQ_AIGRP_PEER_KEY", PEER_KEY)
+    monkeypatch.setenv("CQ_ENTERPRISE", "acme")
+    monkeypatch.setenv("CQ_GROUP", "solutions")
+    # Disable Bedrock — tests inject pre-packed embeddings directly.
+    monkeypatch.setenv("CQ_EMBED_ENABLED", "false")
+    with TestClient(app) as c:
+        yield c
+
+
+def _seed_ku(
+    *,
+    summary: str = "AWS CloudFront cache key gotcha",
+    detail: str = "Cache key omits query strings by default.",
+    action: str = "Add forwarded query strings to the cache policy.",
+    domains: list[str] | None = None,
+    embedding_axis: int = 0,
+    enterprise_id: str = "acme",
+    group_id: str = "solutions",
+    cross_group_allowed: bool = False,
+) -> str:
+    """Insert an approved KU with an explicit embedding and tenancy scope.
+
+    Returns the new KU id. The runtime ``insert`` path always stamps
+    default-enterprise/default-group, so tests then UPDATE the row to
+    apply the desired tenancy / xgroup flag — keeps the production code
+    path clean.
+    """
+    store = _get_store()
+    domains = domains or ["test-fleet", "aws", "cloudfront"]
+    unit = create_knowledge_unit(
+        domains=domains,
+        insight=Insight(summary=summary, detail=detail, action=action),
+    )
+    embedding = _pack_vec(_unit_vec(axis=embedding_axis))
+    store.insert(unit, embedding=embedding, embedding_model="amazon.titan-embed-text-v2:0")
+    # Approve so semantic_query picks it up.
+    store.set_review_status(unit.id, "approved", "test-reviewer")
+    # Set tenancy scope + xgroup flag explicitly.
+    with store._lock, store._conn:
+        store._conn.execute(
+            "UPDATE knowledge_units SET enterprise_id = ?, group_id = ?, "
+            "cross_group_allowed = ? WHERE id = ?",
+            (enterprise_id, group_id, 1 if cross_group_allowed else 0, unit.id),
+        )
+    return unit.id
+
+
+def _post_forward_query(
+    client: TestClient,
+    *,
+    requester_enterprise: str,
+    requester_group: str,
+    requester_l2_id: str = "acme-engineering-l2",
+    requester_persona: str = "persona-cloudfront-asker",
+    query_axis: int = 0,
+    max_results: int = 5,
+    peer_key: str = PEER_KEY,
+) -> Any:
+    """Issue a forward-query call with a unit-vector embedding."""
+    return client.post(
+        "/api/v1/aigrp/forward-query",
+        headers={"authorization": f"Bearer {peer_key}"},
+        json={
+            "query_vec": _unit_vec(axis=query_axis),
+            "query_text": "cloudfront cache",
+            "requester_l2_id": requester_l2_id,
+            "requester_enterprise": requester_enterprise,
+            "requester_group": requester_group,
+            "requester_persona": requester_persona,
+            "max_results": max_results,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. same-Enterprise, different-Group, cross_group_allowed = false
+# ---------------------------------------------------------------------------
+
+
+class TestSameEnterpriseDiffGroupSummaryOnly:
+    def test_returns_summary_only_when_flag_off(self, aigrp_client: TestClient) -> None:
+        ku_id = _seed_ku(
+            enterprise_id="acme",
+            group_id="solutions",  # responder is acme/solutions
+            cross_group_allowed=False,
+        )
+        resp = _post_forward_query(
+            aigrp_client,
+            requester_enterprise="acme",
+            requester_group="engineering",  # different group
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["responder_enterprise"] == "acme"
+        assert body["responder_group"] == "solutions"
+        assert body["policy_applied"] == "summary_only"
+        assert body["result_count"] == 1
+        hit = body["results"][0]
+        assert hit["ku_id"] == ku_id
+        assert hit["summary"] == "AWS CloudFront cache key gotcha"
+        # Detail/action redacted.
+        assert hit["detail"] is None
+        assert hit["action"] is None
+        assert set(hit["redacted_fields"]) == {"detail", "action"}
+
+
+# ---------------------------------------------------------------------------
+# 2. same-Enterprise, different-Group, cross_group_allowed = true
+# ---------------------------------------------------------------------------
+
+
+class TestSameEnterpriseDiffGroupWithFlag:
+    def test_returns_full_body_when_flag_on(self, aigrp_client: TestClient) -> None:
+        ku_id = _seed_ku(
+            enterprise_id="acme",
+            group_id="solutions",
+            cross_group_allowed=True,
+        )
+        resp = _post_forward_query(
+            aigrp_client,
+            requester_enterprise="acme",
+            requester_group="engineering",
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["policy_applied"] == "full_body"
+        assert body["result_count"] == 1
+        hit = body["results"][0]
+        assert hit["ku_id"] == ku_id
+        assert hit["detail"] == "Cache key omits query strings by default."
+        assert hit["action"] == "Add forwarded query strings to the cache policy."
+        assert hit["redacted_fields"] == []
+
+
+# ---------------------------------------------------------------------------
+# 3. cross-Enterprise, no consent -> silent zero results
+# ---------------------------------------------------------------------------
+
+
+class TestCrossEnterpriseNoConsent:
+    def test_returns_empty_not_401(self, aigrp_client: TestClient) -> None:
+        # Seed something findable on the responder side.
+        _seed_ku(enterprise_id="acme", group_id="solutions")
+        resp = _post_forward_query(
+            aigrp_client,
+            requester_enterprise="initech",  # foreign Enterprise
+            requester_group="r-and-d",
+        )
+        # Critically: NOT 401 — consent state must not be probeable.
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["policy_applied"] == "denied"
+        assert body["result_count"] == 0
+        assert body["results"] == []
+
+
+# ---------------------------------------------------------------------------
+# 4. cross-Enterprise, with consent -> summary_only
+# ---------------------------------------------------------------------------
+
+
+class TestCrossEnterpriseWithConsent:
+    def test_returns_summary_only_when_consent_signed(self, aigrp_client: TestClient) -> None:
+        ku_id = _seed_ku(
+            enterprise_id="acme",
+            group_id="solutions",
+            cross_group_allowed=False,  # ignored on cross-Enterprise path
+        )
+        # Sign a consent: initech -> acme, summary_only.
+        store = _get_store()
+        store.insert_cross_enterprise_consent(
+            consent_id="cons_" + uuid.uuid4().hex[:12],
+            requester_enterprise="initech",
+            responder_enterprise="acme",
+            requester_group=None,  # any group on the requester side
+            responder_group=None,
+            policy="summary_only",
+            signed_by_admin="admin@acme.example",
+            signed_at="2026-04-30T00:00:00+00:00",
+            expires_at=None,
+            audit_log_id="aud_" + uuid.uuid4().hex[:12],
+        )
+        resp = _post_forward_query(
+            aigrp_client,
+            requester_enterprise="initech",
+            requester_group="r-and-d",
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["policy_applied"] == "summary_only"
+        assert body["result_count"] == 1
+        hit = body["results"][0]
+        assert hit["ku_id"] == ku_id
+        assert hit["detail"] is None
+        assert hit["action"] is None
+        assert set(hit["redacted_fields"]) == {"detail", "action"}
+
+
+# ---------------------------------------------------------------------------
+# 5. audit log written on every call
+# ---------------------------------------------------------------------------
+
+
+class TestAuditLog:
+    def _audit_rows(self) -> list[tuple[Any, ...]]:
+        store = _get_store()
+        with store._lock:
+            return store._conn.execute(
+                "SELECT requester_enterprise, requester_group, "
+                "responder_enterprise, responder_group, policy_applied, "
+                "result_count, consent_id "
+                "FROM cross_l2_audit ORDER BY ts ASC"
+            ).fetchall()
+
+    def test_audit_row_written_on_every_call(self, aigrp_client: TestClient) -> None:
+        _seed_ku(enterprise_id="acme", group_id="solutions")
+        resp = _post_forward_query(
+            aigrp_client,
+            requester_enterprise="acme",
+            requester_group="engineering",
+        )
+        assert resp.status_code == 200
+        rows = self._audit_rows()
+        assert len(rows) == 1
+        (req_ent, req_grp, resp_ent, resp_grp, policy, count, consent_id) = rows[0]
+        assert req_ent == "acme"
+        assert req_grp == "engineering"
+        assert resp_ent == "acme"
+        assert resp_grp == "solutions"
+        assert policy == "summary_only"
+        assert count == 1
+        assert consent_id is None  # same-Enterprise → no consent record involved
+
+    def test_denied_call_also_logs_audit_row(self, aigrp_client: TestClient) -> None:
+        _seed_ku(enterprise_id="acme", group_id="solutions")
+        resp = _post_forward_query(
+            aigrp_client,
+            requester_enterprise="initech",
+            requester_group="r-and-d",
+        )
+        assert resp.status_code == 200
+        rows = self._audit_rows()
+        assert len(rows) == 1
+        assert rows[0][4] == "denied"
+        assert rows[0][5] == 0
+
+    def test_consent_id_recorded_on_cross_enterprise_hit(self, aigrp_client: TestClient) -> None:
+        _seed_ku(enterprise_id="acme", group_id="solutions")
+        store = _get_store()
+        consent_id = "cons_" + uuid.uuid4().hex[:12]
+        store.insert_cross_enterprise_consent(
+            consent_id=consent_id,
+            requester_enterprise="initech",
+            responder_enterprise="acme",
+            requester_group=None,
+            responder_group=None,
+            policy="summary_only",
+            signed_by_admin="admin@acme.example",
+            signed_at="2026-04-30T00:00:00+00:00",
+            expires_at=None,
+            audit_log_id="aud_" + uuid.uuid4().hex[:12],
+        )
+        resp = _post_forward_query(
+            aigrp_client,
+            requester_enterprise="initech",
+            requester_group="r-and-d",
+        )
+        assert resp.status_code == 200
+        rows = self._audit_rows()
+        assert len(rows) == 1
+        assert rows[0][6] == consent_id
+
+
+# ---------------------------------------------------------------------------
+# 6. auth — wrong peer key still rejected
+# ---------------------------------------------------------------------------
+
+
+class TestAuth:
+    def test_wrong_peer_key_returns_401(self, aigrp_client: TestClient) -> None:
+        resp = _post_forward_query(
+            aigrp_client,
+            requester_enterprise="acme",
+            requester_group="engineering",
+            peer_key="wrong-key-of-same-length-as-real",
+        )
+        assert resp.status_code == 401
+
+    def test_missing_peer_key_returns_401(self, aigrp_client: TestClient) -> None:
+        resp = aigrp_client.post(
+            "/api/v1/aigrp/forward-query",
+            json={
+                "query_vec": _unit_vec(),
+                "requester_l2_id": "acme-engineering-l2",
+                "requester_enterprise": "acme",
+                "requester_group": "engineering",
+            },
+        )
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# 7. defaults — legacy KUs (no explicit scope) still match same-Enterprise
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultsSafety:
+    def test_legacy_default_scope_does_not_leak_to_strangers(
+        self, aigrp_client: TestClient
+    ) -> None:
+        # A KU with default-enterprise / default-group is in a different
+        # Enterprise from the responder (acme). Must not leak.
+        _seed_ku(
+            enterprise_id=DEFAULT_ENTERPRISE_ID,
+            group_id=DEFAULT_GROUP_ID,
+        )
+        resp = _post_forward_query(
+            aigrp_client,
+            requester_enterprise=DEFAULT_ENTERPRISE_ID,
+            requester_group=DEFAULT_GROUP_ID,
+        )
+        # Requester claims default-enterprise but responder is "acme" —
+        # cross-Enterprise path with no consent → empty.
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["policy_applied"] == "denied"
+        assert body["result_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 8. consent — cross_enterprise_consents schema constraints
+# ---------------------------------------------------------------------------
+
+
+class TestConsentLookup:
+    def test_expired_consent_is_ignored(self, aigrp_client: TestClient) -> None:
+        _seed_ku(enterprise_id="acme", group_id="solutions")
+        store = _get_store()
+        store.insert_cross_enterprise_consent(
+            consent_id="cons_expired",
+            requester_enterprise="initech",
+            responder_enterprise="acme",
+            requester_group=None,
+            responder_group=None,
+            policy="summary_only",
+            signed_by_admin="admin@acme.example",
+            signed_at="2024-01-01T00:00:00+00:00",
+            expires_at="2024-12-31T23:59:59+00:00",  # in the past
+            audit_log_id="aud_expired",
+        )
+        resp = _post_forward_query(
+            aigrp_client,
+            requester_enterprise="initech",
+            requester_group="r-and-d",
+        )
+        body = resp.json()
+        assert body["policy_applied"] == "denied"
+        assert body["result_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 9. /aigrp/* prefix mount — endpoint is reachable on both / and /api/v1
+# ---------------------------------------------------------------------------
+
+
+class TestRouteMounts:
+    def test_endpoint_reachable_on_root_path(self, aigrp_client: TestClient) -> None:
+        # SDK callers hit / directly (legacy compat); frontend hits /api/v1.
+        _seed_ku(enterprise_id="acme", group_id="solutions")
+        resp = aigrp_client.post(
+            "/aigrp/forward-query",
+            headers={"authorization": f"Bearer {PEER_KEY}"},
+            json={
+                "query_vec": _unit_vec(),
+                "requester_l2_id": "acme-engineering-l2",
+                "requester_enterprise": "acme",
+                "requester_group": "engineering",
+                "max_results": 5,
+            },
+        )
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# 10. SQLite NOT NULL on cross_group_allowed
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaConstraints:
+    def test_cross_group_allowed_column_is_not_null(self, aigrp_client: TestClient) -> None:
+        store = _get_store()
+        with pytest.raises(sqlite3.IntegrityError), store._lock, store._conn:
+            store._conn.execute(
+                "INSERT INTO knowledge_units (id, data, cross_group_allowed) "
+                "VALUES (?, ?, ?)",
+                ("ku_null_xgroup", "{}", None),
+            )

--- a/server/backend/tests/test_migration_0002_xgroup_consent.py
+++ b/server/backend/tests/test_migration_0002_xgroup_consent.py
@@ -1,0 +1,179 @@
+"""Phase 6 step 2: Alembic migration smoke-test.
+
+Mirrors the pattern in ``test_tenancy_columns.py::TestAlembicMigration``.
+Runs ``alembic upgrade head`` and ``alembic downgrade base`` against
+both an empty DB and a populated legacy DB; both cycles must complete
+without raising and must end with the expected schema in place.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _run_alembic(db_path: Path, command: str, target: str) -> subprocess.CompletedProcess[str]:
+    repo_root = Path(__file__).resolve().parents[1]
+    return subprocess.run(
+        ["uv", "run", "alembic", command, target],
+        cwd=str(repo_root),
+        env={
+            "PATH": os.environ.get("PATH", ""),
+            "CQ_DB_PATH": str(db_path),
+            "HOME": str(Path.home()),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?", (name,)
+    ).fetchone()
+    return row is not None
+
+
+def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return any(r[1] == column for r in rows)
+
+
+class TestUpgradeDowngradeEmpty:
+    def test_upgrade_then_downgrade_clean_on_empty_db(self, tmp_path: Path) -> None:
+        db = tmp_path / "alembic_empty.db"
+        sqlite3.connect(str(db)).close()  # touch
+
+        up = _run_alembic(db, "upgrade", "head")
+        assert up.returncode == 0, f"upgrade failed:\n{up.stderr}\n{up.stdout}"
+
+        # After upgrade head: cross_l2_audit + cross_enterprise_consents
+        # exist; if knowledge_units has been created (it hasn't on a
+        # truly-empty DB, since the runtime store creates it lazily),
+        # then cross_group_allowed exists too.
+        check = sqlite3.connect(str(db))
+        try:
+            assert _table_exists(check, "cross_l2_audit")
+            assert _table_exists(check, "cross_enterprise_consents")
+            if _table_exists(check, "knowledge_units"):
+                assert _column_exists(check, "knowledge_units", "cross_group_allowed")
+        finally:
+            check.close()
+
+        down = _run_alembic(db, "downgrade", "base")
+        assert down.returncode == 0, f"downgrade failed:\n{down.stderr}\n{down.stdout}"
+
+        # After full downgrade the new tables are gone.
+        check = sqlite3.connect(str(db))
+        try:
+            assert not _table_exists(check, "cross_l2_audit")
+            assert not _table_exists(check, "cross_enterprise_consents")
+        finally:
+            check.close()
+
+
+class TestUpgradeOnLegacyDb:
+    def test_upgrade_on_populated_legacy_db_adds_column_and_tables(
+        self, tmp_path: Path
+    ) -> None:
+        db = tmp_path / "alembic_legacy.db"
+
+        # Pre-step-1 shape: knowledge_units / users without tenancy
+        # columns. This is what production looks like before any
+        # Phase 6 migration runs.
+        conn = sqlite3.connect(str(db))
+        conn.executescript(
+            """
+            CREATE TABLE knowledge_units (id TEXT PRIMARY KEY, data TEXT NOT NULL);
+            CREATE TABLE users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT NOT NULL UNIQUE,
+                password_hash TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            );
+            INSERT INTO knowledge_units (id, data) VALUES ('legacy_ku', '{}');
+            INSERT INTO users (username, password_hash, created_at)
+                VALUES ('legacy_user', 'hash', '2024-01-01T00:00:00+00:00');
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        up = _run_alembic(db, "upgrade", "head")
+        assert up.returncode == 0, f"upgrade failed:\n{up.stderr}\n{up.stdout}"
+
+        check = sqlite3.connect(str(db))
+        try:
+            # Step 1 columns landed.
+            assert _column_exists(check, "knowledge_units", "enterprise_id")
+            assert _column_exists(check, "knowledge_units", "group_id")
+            # Step 2 column landed.
+            assert _column_exists(check, "knowledge_units", "cross_group_allowed")
+            # New tables exist.
+            assert _table_exists(check, "cross_enterprise_consents")
+            assert _table_exists(check, "cross_l2_audit")
+            # Pre-existing row picks up cross_group_allowed = 0.
+            row = check.execute(
+                "SELECT cross_group_allowed FROM knowledge_units WHERE id = ?",
+                ("legacy_ku",),
+            ).fetchone()
+            assert row is not None
+            assert row[0] == 0
+        finally:
+            check.close()
+
+
+class TestStepwiseUpgrade:
+    """Confirm 0001 -> 0002 is applied in the right order — going to
+    the 0001 head first, then to head, must work without error."""
+
+    def test_upgrade_to_0001_then_head(self, tmp_path: Path) -> None:
+        db = tmp_path / "alembic_stepwise.db"
+        sqlite3.connect(str(db)).close()
+
+        first = _run_alembic(db, "upgrade", "0001_phase6_step1")
+        assert first.returncode == 0, f"step 1 upgrade failed:\n{first.stderr}\n{first.stdout}"
+
+        # cross_l2_audit must NOT exist yet — that's a step-2 table.
+        check = sqlite3.connect(str(db))
+        try:
+            assert not _table_exists(check, "cross_l2_audit")
+        finally:
+            check.close()
+
+        second = _run_alembic(db, "upgrade", "head")
+        assert second.returncode == 0, f"step 2 upgrade failed:\n{second.stderr}\n{second.stdout}"
+
+        check = sqlite3.connect(str(db))
+        try:
+            assert _table_exists(check, "cross_l2_audit")
+            assert _table_exists(check, "cross_enterprise_consents")
+        finally:
+            check.close()
+
+
+@pytest.mark.parametrize("invalid_dir", [None])
+def test_alembic_history_is_linear(invalid_dir: object) -> None:
+    """Sanity: alembic history should show 0002 chained off 0001."""
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        ["uv", "run", "alembic", "history"],
+        cwd=str(repo_root),
+        env={
+            "PATH": os.environ.get("PATH", ""),
+            "HOME": str(Path.home()),
+            "CQ_DB_PATH": "/tmp/cq-alembic-history-check.db",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    # Both revs appear; 0002 lists 0001 as its predecessor.
+    assert "0001_phase6_step1" in result.stdout
+    assert "0002_phase6_step2" in result.stdout


### PR DESCRIPTION
## Summary

Adds `POST /api/v1/aigrp/forward-query` — the endpoint that lets one L2 ask another L2 "do you have knowledge on this query, and can you share it under what policy?" Same `EnterprisePeerKey` Bearer auth as the rest of `/aigrp/*`.

## Policy evaluation (first match wins)

Per-KU evaluation lives in pure function `_decide_policy_for_ku` in `app.py`:

1. **Same Enterprise + same Group** -> `full_body`
2. **Same Enterprise + different Group** -> `full_body` iff the KU's `cross_group_allowed` flag is `true`; otherwise `summary_only` (detail + action redacted, listed in `redacted_fields`)
3. **Different Enterprise** -> consent-driven. Looks up `cross_enterprise_consents` for the `(requester_enterprise, responder_enterprise)` pair. No active consent -> **silent** zero results (NOT 401 — probes must not be able to fingerprint consent state). Active consent with `policy=summary_only` -> redacted hits. `full_body` policy supported in the schema for v2; v1 admin sign-flow grants `summary_only` only.

The response-level `policy_applied` is the strictest applied across the returned hits — `summary_only` wins over `full_body` if any KU was redacted.

## Migration delta — `0002_phase6_step2_xgroup_consent.py`

All additive, idempotent on both empty and populated DBs:

- `knowledge_units.cross_group_allowed` (BOOLEAN/INTEGER, default 0). Backfilled to 0 for legacy rows; promoted to NOT NULL after backfill (SQLite batch path; Postgres handles it natively).
- `cross_enterprise_consents` — admin-signed records. Nullable `requester_group` / `responder_group` columns mean "any group on that side" (wildcard match). Includes `signed_by_admin`, `signed_at`, optional `expires_at`, and `audit_log_id UNIQUE`. Indexed on `(requester_enterprise, responder_enterprise)` for the lookup hot path.
- `cross_l2_audit` — append-only log of every `/forward-query` call (including denied probes), with `consent_id` stamped when applicable.

Mirrors `ensure_tenancy_columns`'s pattern: a runtime helper `ensure_xgroup_consent_schema` runs on every server startup so legacy DBs converge on the same shape as Alembic-first DBs.

## Out of scope (per the task spec)

- Frontend wiring (Lane E will consume this)
- Real cross-Enterprise consent admin UI / sign endpoint (Lane D — `insert_cross_enterprise_consent` is exposed on the store today and used by tests; admin endpoint follows)
- Multi-region forward-query routing
- Streaming responses

Reference: `OneZero1ai/crosstalk-enterprise` `docs/plans/08-live-network-demo.md` (Lane B, step 2).

## Test plan

- [x] `tests/test_forward_query.py` — 13 tests covering the policy matrix, audit log invariant, auth, route mounts (root + `/api/v1`), and schema NOT-NULL constraints.
- [x] `tests/test_migration_0002_xgroup_consent.py` — 4 tests: upgrade+downgrade clean on empty DB; upgrade on populated legacy DB backfills `cross_group_allowed=0`; stepwise upgrade (`0001` then head); `alembic history` shows linear chain.
- [x] Full suite: 255 pass (was 238 + 17 new).
- [x] `ruff check --no-fix` clean on the four new/touched files (`tables.py`, `store/__init__.py`, `0002_*.py`, both new test files). `app.py` carries 8 pre-existing D205 violations in unrelated code; my new endpoint code is clean.
- [ ] Manual: deploy to a two-L2 dev mesh and exercise `/forward-query` between them — Lane B step 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)