### PR TITLE
[frontend] /network page — multi-Enterprise topology + AIGRP peer-mesh visualization

### DIFF
--- a/server/frontend/package.json
+++ b/server/frontend/package.json
@@ -11,6 +11,8 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "cytoscape": "^3.33.3",
+    "cytoscape-cose-bilkent": "^4.1.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router": "^7.13.1",
@@ -21,6 +23,7 @@
     "@tailwindcss/vite": "^4.2.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@types/cytoscape": "^3.31.0",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/server/frontend/pnpm-lock.yaml
+++ b/server/frontend/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      cytoscape:
+        specifier: ^3.33.3
+        version: 3.33.3
+      cytoscape-cose-bilkent:
+        specifier: ^4.1.0
+        version: 4.1.0(cytoscape@3.33.3)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -33,6 +39,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@types/cytoscape':
+        specifier: ^3.31.0
+        version: 3.31.0
       '@types/node':
         specifier: ^24.12.0
         version: 24.12.0
@@ -534,6 +543,10 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/cytoscape@3.31.0':
+    resolution: {integrity: sha512-EXHOHxqQjGxLDEh5cP4te6J0bi7LbCzmZkzsR6f703igUac8UGMdEohMyU3GHAayCTZrLQOMnaE/lqB2Ekh8Ww==}
+    deprecated: This is a stub types definition. cytoscape provides its own type definitions, so you do not need this installed.
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -793,6 +806,9 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -806,6 +822,15 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.33.3:
+    resolution: {integrity: sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==}
+    engines: {node: '>=0.10'}
 
   d3-array@3.2.4:
     resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
@@ -1143,6 +1168,9 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -2205,6 +2233,10 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/cytoscape@3.31.0':
+    dependencies:
+      cytoscape: 3.33.3
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-color@3.1.3': {}
@@ -2476,6 +2508,10 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -2491,6 +2527,13 @@ snapshots:
   css.escape@1.5.1: {}
 
   csstype@3.2.3: {}
+
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.33.3):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.33.3
+
+  cytoscape@3.33.3: {}
 
   d3-array@3.2.4:
     dependencies:
@@ -2816,6 +2859,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  layout-base@1.0.2: {}
 
   levn@0.4.1:
     dependencies:

--- a/server/frontend/src/App.tsx
+++ b/server/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { LoginPage } from "./pages/LoginPage";
 import { ReviewPage } from "./pages/ReviewPage";
 import { DashboardPage } from "./pages/DashboardPage";
 import { ApiKeysPage } from "./pages/ApiKeysPage";
+import { NetworkPage } from "./pages/NetworkPage";
 
 function AppRoutes() {
   const { isAuthenticated } = useAuth();
@@ -24,6 +25,7 @@ function AppRoutes() {
       >
         <Route path="/review" element={<ReviewPage />} />
         <Route path="/dashboard" element={<DashboardPage />} />
+        <Route path="/network" element={<NetworkPage />} />
         <Route path="/settings/api-keys" element={<ApiKeysPage />} />
       </Route>
       <Route path="*" element={<Navigate to="/review" replace />} />

--- a/server/frontend/src/components/Layout.tsx
+++ b/server/frontend/src/components/Layout.tsx
@@ -8,6 +8,8 @@ export function Layout() {
   const location = useLocation();
   const [pendingCount, setPendingCount] = useState(0);
   const onDashboard = location.pathname === "/dashboard";
+  // Network page needs a full-width main; everything else stays narrow.
+  const wide = location.pathname === "/network";
 
   useEffect(() => {
     if (onDashboard) return;
@@ -48,6 +50,7 @@ export function Layout() {
             <span className="text-lg font-bold text-indigo-600">cq</span>
             {navLink("/review", "Review")}
             {navLink("/dashboard", "Dashboard")}
+            {navLink("/network", "Network")}
             {navLink("/settings/api-keys", "API Keys")}
           </div>
           <div className="flex items-center gap-3">
@@ -61,7 +64,11 @@ export function Layout() {
           </div>
         </div>
       </nav>
-      <main className="max-w-2xl mx-auto py-8 px-4">
+      <main
+        className={
+          wide ? "w-full px-0 py-0" : "max-w-2xl mx-auto py-8 px-4"
+        }
+      >
         <Outlet context={{ setPendingCount }} />
       </main>
     </div>

--- a/server/frontend/src/network/components/DemoControls.tsx
+++ b/server/frontend/src/network/components/DemoControls.tsx
@@ -1,0 +1,29 @@
+// Lane F wires up the actual orchestration. For Lane E we render the buttons
+// disabled with an explanatory tooltip so the layout/affordance lands first.
+
+const BUTTONS = [
+  { label: "Run cross-Group query", id: "run-cross-group" },
+  { label: "Try cross-Enterprise (no consent)", id: "try-cross-enterprise" },
+  { label: "Sign cross-Enterprise consent", id: "sign-consent" },
+];
+
+export function DemoControls() {
+  return (
+    <div
+      data-testid="demo-controls"
+      className="flex h-10 items-center justify-center gap-2 border-t border-gray-200 bg-white px-4"
+    >
+      {BUTTONS.map((b) => (
+        <button
+          key={b.id}
+          type="button"
+          disabled
+          title="Wired in Lane F"
+          className="cursor-not-allowed rounded-md border border-gray-200 bg-gray-50 px-3 py-1 text-xs font-medium text-gray-400"
+        >
+          {b.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/server/frontend/src/network/components/L2DetailPanel.tsx
+++ b/server/frontend/src/network/components/L2DetailPanel.tsx
@@ -1,0 +1,133 @@
+import type { TopologyL2 } from "../types";
+import { timeAgo } from "../../utils";
+
+interface Props {
+  l2: TopologyL2 | null;
+  onClose: () => void;
+}
+
+export function L2DetailPanel({ l2, onClose }: Props) {
+  if (!l2) return null;
+  return (
+    <aside
+      data-testid="l2-detail-panel"
+      className="absolute right-0 top-0 h-full w-80 overflow-y-auto border-l border-gray-200 bg-white p-5 shadow-lg"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <h3 className="truncate text-base font-semibold text-gray-900">
+            {l2.l2_id}
+          </h3>
+          <p className="text-xs uppercase tracking-wide text-gray-500">
+            {l2.group}
+          </p>
+        </div>
+        <button
+          onClick={onClose}
+          aria-label="Close detail panel"
+          className="rounded text-gray-400 hover:text-gray-700"
+        >
+          <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+            <path
+              fillRule="evenodd"
+              d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </button>
+      </div>
+
+      <div className="mt-4 space-y-1 text-xs">
+        <div className="text-gray-500">Endpoint</div>
+        <code className="block truncate rounded bg-gray-100 px-2 py-1 font-mono text-[11px] text-gray-700">
+          {l2.endpoint_url}
+        </code>
+      </div>
+
+      <dl className="mt-4 grid grid-cols-3 gap-2 text-center">
+        <div className="rounded border border-gray-200 p-2">
+          <dt className="text-[10px] uppercase text-gray-400">KUs</dt>
+          <dd className="text-lg font-semibold text-gray-900">{l2.ku_count}</dd>
+        </div>
+        <div className="rounded border border-gray-200 p-2">
+          <dt className="text-[10px] uppercase text-gray-400">Domains</dt>
+          <dd className="text-lg font-semibold text-gray-900">
+            {l2.domain_count}
+          </dd>
+        </div>
+        <div className="rounded border border-gray-200 p-2">
+          <dt className="text-[10px] uppercase text-gray-400">Peers</dt>
+          <dd className="text-lg font-semibold text-gray-900">
+            {l2.peer_count}
+          </dd>
+        </div>
+      </dl>
+
+      <section className="mt-5">
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+          Peers
+        </h4>
+        {l2.peers.length === 0 ? (
+          <p className="mt-1 text-sm text-gray-400">No peers</p>
+        ) : (
+          <ul className="mt-2 space-y-1">
+            {l2.peers.map((p) => (
+              <li
+                key={p.l2_id}
+                className="flex items-center justify-between rounded px-2 py-1 text-sm hover:bg-gray-50"
+              >
+                <span className="truncate font-mono text-xs text-gray-700">
+                  {p.l2_id}
+                </span>
+                <span className="text-[11px] text-gray-400">
+                  {p.last_signature_at ? timeAgo(p.last_signature_at) : "—"}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="mt-5">
+        <h4 className="text-xs font-semibold uppercase tracking-wide text-gray-500">
+          Active personas
+        </h4>
+        {l2.active_personas.length === 0 ? (
+          <p className="mt-1 text-sm text-gray-400">None active</p>
+        ) : (
+          <ul className="mt-2 space-y-2">
+            {l2.active_personas.map((p) => (
+              <li key={p.persona} className="rounded border border-gray-100 p-2">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="truncate font-mono text-xs text-gray-800">
+                    {p.persona}
+                  </span>
+                  <span className="text-[10px] text-gray-400">
+                    {timeAgo(p.last_seen_at)}
+                  </span>
+                </div>
+                {p.working_dir_hint && (
+                  <code className="mt-1 block truncate text-[11px] text-gray-500">
+                    {p.working_dir_hint}
+                  </code>
+                )}
+                {p.expertise_domains.length > 0 && (
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {p.expertise_domains.map((d) => (
+                      <span
+                        key={d}
+                        className="rounded-full bg-indigo-50 px-1.5 py-0.5 text-[10px] text-indigo-700"
+                      >
+                        {d}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </aside>
+  );
+}

--- a/server/frontend/src/network/components/TopologyCanvas.tsx
+++ b/server/frontend/src/network/components/TopologyCanvas.tsx
@@ -1,0 +1,234 @@
+import { useEffect, useRef } from "react";
+import cytoscape from "cytoscape";
+import type { Core, ElementDefinition } from "cytoscape";
+import coseBilkent from "cytoscape-cose-bilkent";
+import type { CytoElement, CytoNodeData } from "../graph";
+
+let extensionRegistered = false;
+function ensureExtension() {
+  if (extensionRegistered) return;
+  // cytoscape extension registration mutates global cytoscape state — do once.
+  cytoscape.use(coseBilkent);
+  extensionRegistered = true;
+}
+
+interface Props {
+  elements: CytoElement[];
+  selectedL2Id: string | null;
+  onSelectL2: (id: string | null) => void;
+}
+
+export function TopologyCanvas({ elements, selectedL2Id, onSelectL2 }: Props) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const cyRef = useRef<Core | null>(null);
+
+  // Mount: build cy instance once.
+  useEffect(() => {
+    if (!containerRef.current) return;
+    ensureExtension();
+
+    const cy = cytoscape({
+      container: containerRef.current,
+      elements: elements as ElementDefinition[],
+      // cose-bilkent handles compound + force layout cleanly.
+      // Type isn't in cytoscape's built-in LayoutOptions union; cast.
+      layout: {
+        name: "cose-bilkent",
+        animate: false,
+        randomize: true,
+        nodeRepulsion: 8000,
+        idealEdgeLength: 100,
+        edgeElasticity: 0.45,
+        gravity: 0.4,
+      } as cytoscape.LayoutOptions,
+      style: [
+        {
+          selector: "node.l2",
+          style: {
+            label: "data(label)",
+            "text-valign": "center",
+            "text-halign": "center",
+            "font-size": 11,
+            "font-weight": 600,
+            color: "#1f2937",
+            "text-outline-color": "#fff",
+            "text-outline-width": 2,
+            // Size proportional to ku_count, clamped.
+            width: "mapData(ku_count, 0, 300, 30, 90)",
+            height: "mapData(ku_count, 0, 300, 30, 90)",
+            "border-width": 2,
+          },
+        },
+        {
+          selector: "node.enterprise-orion",
+          style: {
+            "background-color": "#6366f1", // indigo-500
+            "border-color": "#4338ca", // indigo-700
+          },
+        },
+        {
+          selector: "node.enterprise-acme",
+          style: {
+            "background-color": "#14b8a6", // teal-500
+            "border-color": "#0f766e", // teal-700
+          },
+        },
+        {
+          selector: "node.cluster",
+          style: {
+            label: "data(label)",
+            "text-valign": "top",
+            "text-halign": "center",
+            "font-size": 14,
+            "font-weight": 700,
+            color: "#374151",
+            "background-opacity": 0.05,
+            "border-width": 1,
+            "border-style": "dashed",
+            "border-color": "#9ca3af",
+            padding: "24px",
+            "background-color": "#f3f4f6",
+          },
+        },
+        {
+          selector: "node.cluster.cluster-orion",
+          style: {
+            "background-color": "#eef2ff", // indigo-50
+            "border-color": "#a5b4fc", // indigo-300
+          },
+        },
+        {
+          selector: "node.cluster.cluster-acme",
+          style: {
+            "background-color": "#f0fdfa", // teal-50
+            "border-color": "#5eead4", // teal-300
+          },
+        },
+        {
+          selector: "node.l2:selected",
+          style: {
+            "border-color": "#f59e0b", // amber-500
+            "border-width": 4,
+          },
+        },
+        {
+          selector: "edge.peer-edge",
+          style: {
+            width: 2,
+            "line-color": "#6b7280",
+            "curve-style": "bezier",
+            opacity: 0.7,
+          },
+        },
+        {
+          selector: "edge.cross-edge.unconsented",
+          style: {
+            width: 1.5,
+            "line-color": "#9ca3af",
+            "line-style": "dashed",
+            "curve-style": "bezier",
+            opacity: 0.5,
+          },
+        },
+        {
+          selector: "edge.cross-edge.consented",
+          style: {
+            width: 2.5,
+            "line-color": "#10b981", // emerald-500
+            "curve-style": "bezier",
+            opacity: 0.85,
+          },
+        },
+      ],
+      wheelSensitivity: 0.2,
+    });
+
+    cy.on("tap", "node.l2", (evt) => {
+      const id = evt.target.id();
+      onSelectL2(id);
+    });
+    cy.on("tap", (evt) => {
+      // Click on background clears selection.
+      if (evt.target === cy) onSelectL2(null);
+    });
+
+    cyRef.current = cy;
+    return () => {
+      cy.destroy();
+      cyRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Sync elements when topology changes.
+  useEffect(() => {
+    const cy = cyRef.current;
+    if (!cy) return;
+    cy.batch(() => {
+      cy.elements().remove();
+      cy.add(elements as ElementDefinition[]);
+    });
+    cy.layout({
+      name: "cose-bilkent",
+      animate: false,
+      randomize: false,
+      fit: true,
+    } as cytoscape.LayoutOptions).run();
+  }, [elements]);
+
+  // Sync external selection -> cy.
+  useEffect(() => {
+    const cy = cyRef.current;
+    if (!cy) return;
+    cy.nodes().unselect();
+    if (selectedL2Id) {
+      const node = cy.getElementById(selectedL2Id);
+      if (node && node.length > 0) node.select();
+    }
+  }, [selectedL2Id]);
+
+  // Hidden test-only DOM mirror — Cytoscape draws to <canvas>, which is
+  // opaque to Testing Library. Mirror the data we feed it for assertions.
+  const nodeData = elements
+    .map((e) => e.data)
+    .filter((d): d is CytoNodeData => "kind" in d);
+  const edgeData = elements.filter(
+    (e) => "kind" in e.data && (e.data.kind === "peer" || e.data.kind === "cross"),
+  );
+
+  return (
+    <div className="relative h-full w-full">
+      <div
+        ref={containerRef}
+        data-testid="topology-canvas"
+        className="h-full w-full bg-gray-50"
+      />
+      {/* Test mirror — invisible but queryable. */}
+      <div data-testid="topology-mirror" className="sr-only" aria-hidden="true">
+        {nodeData.map((n) => (
+          <span
+            key={n.id}
+            data-testid={`mirror-node-${n.kind}`}
+            data-node-id={n.id}
+            data-enterprise={n.enterprise}
+            data-group={n.group}
+          >
+            {n.label}
+          </span>
+        ))}
+        {edgeData.map((e) => {
+          const d = e.data as { id: string; kind: string; consented?: boolean };
+          return (
+            <span
+              key={d.id}
+              data-testid={`mirror-edge-${d.kind}`}
+              data-edge-id={d.id}
+              data-consented={String(!!d.consented)}
+              data-classes={e.classes ?? ""}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/server/frontend/src/network/cytoscape-shims.d.ts
+++ b/server/frontend/src/network/cytoscape-shims.d.ts
@@ -1,0 +1,5 @@
+declare module "cytoscape-cose-bilkent" {
+  import type { Ext } from "cytoscape";
+  const ext: Ext;
+  export default ext;
+}

--- a/server/frontend/src/network/fixtures/topology.fixture.ts
+++ b/server/frontend/src/network/fixtures/topology.fixture.ts
@@ -1,0 +1,149 @@
+import type { TopologyResponse } from "../types";
+
+// Static fixture mirroring the live test-fleet shape (6 L2s across 2 Enterprises).
+// Used in dev/tests until Lane F's server-side proxy ships at /api/v1/network/topology.
+
+const NOW = "2026-04-30T12:00:00Z";
+const RECENT = "2026-04-30T11:59:30Z";
+
+const ORION_L2_IDS = ["orion/engineering", "orion/solutions", "orion/gtm"];
+const ACME_L2_IDS = ["acme/engineering", "acme/solutions", "acme/finance"];
+
+function peersExcluding(allIds: string[], selfId: string) {
+  return allIds
+    .filter((id) => id !== selfId)
+    .map((id) => ({ l2_id: id, last_signature_at: RECENT }));
+}
+
+export const topologyFixture: TopologyResponse = {
+  generated_at: NOW,
+  enterprises: [
+    {
+      enterprise: "orion",
+      l2s: [
+        {
+          l2_id: "orion/engineering",
+          group: "engineering",
+          endpoint_url:
+            "http://test-ori-Alb-uYtCiM8iwUDE-1537178551.us-east-1.elb.amazonaws.com",
+          ku_count: 287,
+          domain_count: 42,
+          peer_count: 2,
+          generated_at: NOW,
+          peers: peersExcluding(ORION_L2_IDS, "orion/engineering"),
+          active_personas: [
+            {
+              persona: "claude-mux-dev",
+              last_seen_at: RECENT,
+              working_dir_hint: "~/projects/clawrig",
+              expertise_domains: ["aws", "terraform", "ecs"],
+            },
+          ],
+        },
+        {
+          l2_id: "orion/solutions",
+          group: "solutions",
+          endpoint_url:
+            "http://test-ori-Alb-iWhYcfoCeuHA-164324034.us-east-1.elb.amazonaws.com",
+          ku_count: 154,
+          domain_count: 28,
+          peer_count: 2,
+          generated_at: NOW,
+          peers: peersExcluding(ORION_L2_IDS, "orion/solutions"),
+          active_personas: [
+            {
+              persona: "solutions-architect",
+              last_seen_at: RECENT,
+              working_dir_hint: "~/projects/case-study",
+              expertise_domains: ["customer-success", "demo"],
+            },
+          ],
+        },
+        {
+          l2_id: "orion/gtm",
+          group: "gtm",
+          endpoint_url:
+            "http://test-ori-Alb-D7CVfG04aGRc-778844735.us-east-1.elb.amazonaws.com",
+          ku_count: 96,
+          domain_count: 19,
+          peer_count: 2,
+          generated_at: NOW,
+          peers: peersExcluding(ORION_L2_IDS, "orion/gtm"),
+          active_personas: [
+            {
+              persona: "gtm-pitch-builder",
+              last_seen_at: RECENT,
+              working_dir_hint: "~/projects/nebula-gtm-pitch",
+              expertise_domains: ["pitch-deck", "narrative"],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      enterprise: "acme",
+      l2s: [
+        {
+          l2_id: "acme/engineering",
+          group: "engineering",
+          endpoint_url:
+            "http://test-acm-Alb-w0Eq2rO5MeVM-1954810296.us-east-1.elb.amazonaws.com",
+          ku_count: 211,
+          domain_count: 35,
+          peer_count: 2,
+          generated_at: NOW,
+          peers: peersExcluding(ACME_L2_IDS, "acme/engineering"),
+          active_personas: [
+            {
+              persona: "acme-platform-eng",
+              last_seen_at: RECENT,
+              working_dir_hint: "~/work/acme-infra",
+              expertise_domains: ["kubernetes", "go"],
+            },
+          ],
+        },
+        {
+          l2_id: "acme/solutions",
+          group: "solutions",
+          endpoint_url:
+            "http://test-acm-Alb-jIOoMinF94dR-73889023.us-east-1.elb.amazonaws.com",
+          ku_count: 132,
+          domain_count: 24,
+          peer_count: 2,
+          generated_at: NOW,
+          peers: peersExcluding(ACME_L2_IDS, "acme/solutions"),
+          active_personas: [
+            {
+              persona: "acme-se-east",
+              last_seen_at: RECENT,
+              working_dir_hint: "~/work/customer-X-poc",
+              expertise_domains: ["integration", "salesforce"],
+            },
+          ],
+        },
+        {
+          l2_id: "acme/finance",
+          group: "finance",
+          endpoint_url:
+            "http://test-acm-Alb-3z1VuBmK1VDX-1994393375.us-east-1.elb.amazonaws.com",
+          ku_count: 64,
+          domain_count: 12,
+          peer_count: 2,
+          generated_at: NOW,
+          peers: peersExcluding(ACME_L2_IDS, "acme/finance"),
+          active_personas: [
+            {
+              persona: "acme-fpa",
+              last_seen_at: RECENT,
+              working_dir_hint: "~/work/quarterly-close",
+              expertise_domains: ["quickbooks", "reporting"],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  // No active cross-Enterprise consents in the default fixture — Lane F demo
+  // toggles "Sign cross-Enterprise consent" to populate this list at runtime.
+  cross_enterprise_consents: [],
+};

--- a/server/frontend/src/network/graph.ts
+++ b/server/frontend/src/network/graph.ts
@@ -1,0 +1,162 @@
+import type {
+  CrossEnterpriseConsent,
+  TopologyResponse,
+} from "./types";
+
+export interface CytoNodeData {
+  id: string;
+  label: string;
+  enterprise: string;
+  group: string;
+  ku_count: number;
+  parent?: string;
+  // 'enterprise-cluster' nodes are compound parents; 'l2' nodes are L2 endpoints.
+  kind: "enterprise-cluster" | "l2";
+}
+
+export interface CytoEdgeData {
+  id: string;
+  source: string;
+  target: string;
+  // 'peer' = same-Enterprise AIGRP mesh edge.
+  // 'cross' = cross-Enterprise edge (consented or unconsented).
+  kind: "peer" | "cross";
+  consented: boolean;
+}
+
+export interface CytoElement {
+  data: CytoNodeData | CytoEdgeData;
+  classes?: string;
+}
+
+function consentMatches(
+  consent: CrossEnterpriseConsent,
+  reqEnt: string,
+  reqGroup: string,
+  resEnt: string,
+  resGroup: string,
+): boolean {
+  if (consent.requester_enterprise !== reqEnt) return false;
+  if (consent.responder_enterprise !== resEnt) return false;
+  if (consent.requester_group !== null && consent.requester_group !== reqGroup)
+    return false;
+  if (consent.responder_group !== null && consent.responder_group !== resGroup)
+    return false;
+  return true;
+}
+
+function isConsented(
+  consents: CrossEnterpriseConsent[],
+  fromEnt: string,
+  fromGroup: string,
+  toEnt: string,
+  toGroup: string,
+): boolean {
+  // Either direction (requester->responder or responder->requester) counts.
+  return consents.some(
+    (c) =>
+      consentMatches(c, fromEnt, fromGroup, toEnt, toGroup) ||
+      consentMatches(c, toEnt, toGroup, fromEnt, fromGroup),
+  );
+}
+
+/**
+ * Build Cytoscape elements from a TopologyResponse.
+ *
+ * - Each Enterprise becomes a compound parent node (cluster).
+ * - Each L2 becomes a child node.
+ * - Same-Enterprise peer edges drawn as solid 'peer' edges (deduped).
+ * - Cross-Enterprise edges drawn between every L2 pair across enterprises;
+ *   `consented` flag controls styling. Deduped so each pair appears once.
+ */
+export function buildElements(topology: TopologyResponse): CytoElement[] {
+  const elements: CytoElement[] = [];
+
+  for (const ent of topology.enterprises) {
+    const parentId = `cluster:${ent.enterprise}`;
+    elements.push({
+      data: {
+        id: parentId,
+        label: ent.enterprise.toUpperCase(),
+        enterprise: ent.enterprise,
+        group: "",
+        ku_count: 0,
+        kind: "enterprise-cluster",
+      },
+      classes: `cluster cluster-${ent.enterprise}`,
+    });
+
+    for (const l2 of ent.l2s) {
+      elements.push({
+        data: {
+          id: l2.l2_id,
+          label: l2.group,
+          enterprise: ent.enterprise,
+          group: l2.group,
+          ku_count: l2.ku_count,
+          parent: parentId,
+          kind: "l2",
+        },
+        classes: `l2 enterprise-${ent.enterprise}`,
+      });
+    }
+  }
+
+  // Same-Enterprise peer edges (dedupe via canonical sort).
+  const seenPeerEdges = new Set<string>();
+  for (const ent of topology.enterprises) {
+    for (const l2 of ent.l2s) {
+      for (const peer of l2.peers) {
+        const [a, b] = [l2.l2_id, peer.l2_id].sort();
+        const edgeId = `peer:${a}--${b}`;
+        if (seenPeerEdges.has(edgeId)) continue;
+        seenPeerEdges.add(edgeId);
+        elements.push({
+          data: {
+            id: edgeId,
+            source: a,
+            target: b,
+            kind: "peer",
+            consented: true,
+          },
+          classes: "peer-edge",
+        });
+      }
+    }
+  }
+
+  // Cross-Enterprise edges — every pair of L2s across distinct enterprises.
+  if (topology.enterprises.length >= 2) {
+    const ents = topology.enterprises;
+    for (let i = 0; i < ents.length; i++) {
+      for (let j = i + 1; j < ents.length; j++) {
+        const a = ents[i];
+        const b = ents[j];
+        for (const aL2 of a.l2s) {
+          for (const bL2 of b.l2s) {
+            const consented = isConsented(
+              topology.cross_enterprise_consents,
+              a.enterprise,
+              aL2.group,
+              b.enterprise,
+              bL2.group,
+            );
+            const [src, tgt] = [aL2.l2_id, bL2.l2_id].sort();
+            elements.push({
+              data: {
+                id: `cross:${src}--${tgt}`,
+                source: src,
+                target: tgt,
+                kind: "cross",
+                consented,
+              },
+              classes: consented ? "cross-edge consented" : "cross-edge unconsented",
+            });
+          }
+        }
+      }
+    }
+  }
+
+  return elements;
+}

--- a/server/frontend/src/network/types.ts
+++ b/server/frontend/src/network/types.ts
@@ -1,0 +1,46 @@
+// Topology API contract — server-side proxy at /api/v1/network/topology
+// (proxy itself is Lane F; this page consumes the contract)
+
+export interface TopologyPeerEdge {
+  l2_id: string;
+  last_signature_at: string | null;
+}
+
+export interface TopologyActivePersona {
+  persona: string;
+  last_seen_at: string;
+  working_dir_hint: string | null;
+  expertise_domains: string[];
+}
+
+export interface TopologyL2 {
+  l2_id: string;
+  group: string;
+  endpoint_url: string;
+  ku_count: number;
+  domain_count: number;
+  peer_count: number;
+  generated_at: string | null;
+  peers: TopologyPeerEdge[];
+  active_personas: TopologyActivePersona[];
+}
+
+export interface TopologyEnterprise {
+  enterprise: string;
+  l2s: TopologyL2[];
+}
+
+export interface CrossEnterpriseConsent {
+  requester_enterprise: string;
+  responder_enterprise: string;
+  requester_group: string | null;
+  responder_group: string | null;
+  policy: "summary_only" | "full_body";
+  expires_at: string | null;
+}
+
+export interface TopologyResponse {
+  generated_at: string;
+  enterprises: TopologyEnterprise[];
+  cross_enterprise_consents: CrossEnterpriseConsent[];
+}

--- a/server/frontend/src/network/useTopologyPoll.test.ts
+++ b/server/frontend/src/network/useTopologyPoll.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useTopologyPoll } from "./useTopologyPoll";
+import { topologyFixture } from "./fixtures/topology.fixture";
+import type { TopologyResponse } from "./types";
+
+describe("useTopologyPoll", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("loads from fixture immediately when useFixture=true", () => {
+    const { result } = renderHook(() => useTopologyPoll({ useFixture: true }));
+    expect(result.current.data).toEqual(topologyFixture);
+    expect(result.current.error).toBeNull();
+    expect(result.current.lastUpdated).not.toBeNull();
+  });
+
+  it("calls the fetcher on mount and re-polls on the interval", async () => {
+    const fetcher = vi.fn<() => Promise<TopologyResponse>>().mockResolvedValue(
+      topologyFixture,
+    );
+    // Use a short real interval so the test stays fast.
+    renderHook(() => useTopologyPoll({ fetcher, intervalMs: 30 }));
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(fetcher.mock.calls.length).toBeGreaterThanOrEqual(2), {
+      timeout: 500,
+    });
+    await waitFor(() => expect(fetcher.mock.calls.length).toBeGreaterThanOrEqual(3), {
+      timeout: 500,
+    });
+  });
+
+  it("records error and preserves last-good data on fetch failure", async () => {
+    const fetcher = vi
+      .fn<() => Promise<TopologyResponse>>()
+      .mockResolvedValueOnce(topologyFixture)
+      .mockRejectedValue(new Error("HTTP 503"));
+    const { result } = renderHook(() =>
+      useTopologyPoll({ fetcher, intervalMs: 30 }),
+    );
+    await waitFor(() => expect(result.current.data).toEqual(topologyFixture));
+    const firstUpdate = result.current.lastUpdated;
+    expect(firstUpdate).not.toBeNull();
+
+    await waitFor(() => expect(result.current.error).toBe("HTTP 503"), {
+      timeout: 500,
+    });
+    // Last-good data is preserved through the error.
+    expect(result.current.data).toEqual(topologyFixture);
+    expect(result.current.lastUpdated).toBe(firstUpdate);
+  });
+
+  it("recovers and clears error on subsequent successful fetch", async () => {
+    const fetcher = vi
+      .fn<() => Promise<TopologyResponse>>()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValue(topologyFixture);
+    // Longer interval ensures we observe the error state before recovery.
+    const { result } = renderHook(() =>
+      useTopologyPoll({ fetcher, intervalMs: 200 }),
+    );
+    await waitFor(() => expect(result.current.error).toBe("boom"));
+    await waitFor(() => expect(result.current.data).toEqual(topologyFixture), {
+      timeout: 1000,
+    });
+    expect(result.current.error).toBeNull();
+  });
+
+  it("stops polling after unmount", async () => {
+    const fetcher = vi.fn<() => Promise<TopologyResponse>>().mockResolvedValue(
+      topologyFixture,
+    );
+    const { unmount } = renderHook(() =>
+      useTopologyPoll({ fetcher, intervalMs: 30 }),
+    );
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(1));
+    unmount();
+    const callsAtUnmount = fetcher.mock.calls.length;
+    await new Promise((r) => setTimeout(r, 150));
+    expect(fetcher.mock.calls.length).toBe(callsAtUnmount);
+  });
+});

--- a/server/frontend/src/network/useTopologyPoll.ts
+++ b/server/frontend/src/network/useTopologyPoll.ts
@@ -1,0 +1,90 @@
+import { useEffect, useRef, useState } from "react";
+import { getToken } from "../api";
+import type { TopologyResponse } from "./types";
+import { topologyFixture } from "./fixtures/topology.fixture";
+
+export interface TopologyPollState {
+  data: TopologyResponse | null;
+  error: string | null;
+  lastUpdated: number | null; // epoch ms of last successful response
+}
+
+export interface UseTopologyPollOptions {
+  intervalMs?: number;
+  // Test seam — supplies an alternate fetcher (default: real fetch with auth).
+  fetcher?: () => Promise<TopologyResponse>;
+  // When true, skip network and use the bundled fixture. Useful for storybook/
+  // demo environments where the proxy isn't reachable. Off by default.
+  useFixture?: boolean;
+}
+
+const DEFAULT_INTERVAL_MS = 5000;
+
+async function defaultFetcher(): Promise<TopologyResponse> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  const token = getToken();
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+  const resp = await fetch("/api/v1/network/topology", { headers });
+  if (!resp.ok) {
+    throw new Error(`HTTP ${resp.status}`);
+  }
+  return resp.json();
+}
+
+export function useTopologyPoll(
+  options: UseTopologyPollOptions = {},
+): TopologyPollState {
+  const {
+    intervalMs = DEFAULT_INTERVAL_MS,
+    fetcher,
+    useFixture = false,
+  } = options;
+  const [state, setState] = useState<TopologyPollState>(() =>
+    useFixture
+      ? {
+          data: topologyFixture,
+          error: null,
+          lastUpdated: Date.now(),
+        }
+      : { data: null, error: null, lastUpdated: null },
+  );
+  // Keep latest fetcher in a ref so changing it doesn't restart the timer.
+  const fetcherRef = useRef<() => Promise<TopologyResponse>>(
+    fetcher ?? defaultFetcher,
+  );
+  useEffect(() => {
+    fetcherRef.current = fetcher ?? defaultFetcher;
+  }, [fetcher]);
+
+  useEffect(() => {
+    if (useFixture) return;
+
+    let cancelled = false;
+
+    async function tick() {
+      try {
+        const data = await fetcherRef.current();
+        if (cancelled) return;
+        setState({ data, error: null, lastUpdated: Date.now() });
+      } catch (err) {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : "fetch failed";
+        // Preserve last-good data + lastUpdated so the canvas doesn't blank.
+        setState((prev) => ({ ...prev, error: message }));
+      }
+    }
+
+    tick();
+    const id = setInterval(tick, intervalMs);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [intervalMs, useFixture]);
+
+  return state;
+}

--- a/server/frontend/src/pages/NetworkPage.test.tsx
+++ b/server/frontend/src/pages/NetworkPage.test.tsx
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { NetworkPage } from "./NetworkPage";
+import { topologyFixture } from "../network/fixtures/topology.fixture";
+
+// Cytoscape touches canvas APIs that happy-dom doesn't fully implement,
+// so we mock the canvas component and rely on the props it receives.
+vi.mock("../network/components/TopologyCanvas", () => ({
+  TopologyCanvas: ({
+    elements,
+  }: {
+    elements: Array<{
+      data: Record<string, unknown>;
+      classes?: string;
+    }>;
+  }) => (
+    <div data-testid="topology-canvas">
+      {elements.map((e) => {
+        const data = e.data as {
+          id: string;
+          kind?: string;
+          enterprise?: string;
+          source?: string;
+          target?: string;
+          consented?: boolean;
+        };
+        if (data.kind === "l2" || data.kind === "enterprise-cluster") {
+          return (
+            <span
+              key={data.id}
+              data-testid={`mirror-node-${data.kind}`}
+              data-node-id={data.id}
+              data-enterprise={data.enterprise}
+            />
+          );
+        }
+        if (data.kind === "peer" || data.kind === "cross") {
+          return (
+            <span
+              key={data.id}
+              data-testid={`mirror-edge-${data.kind}`}
+              data-edge-id={data.id}
+              data-consented={String(!!data.consented)}
+              data-classes={e.classes ?? ""}
+            />
+          );
+        }
+        return null;
+      })}
+    </div>
+  ),
+}));
+
+describe("NetworkPage", () => {
+  beforeEach(() => {
+    // Stub fetch so the polling hook never makes real requests if
+    // initialData isn't supplied for some reason.
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(topologyFixture),
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders 2 Enterprise clusters and 6 L2 nodes from the fixture", () => {
+    render(<NetworkPage initialData={topologyFixture} />);
+    const clusterNodes = screen.getAllByTestId("mirror-node-enterprise-cluster");
+    expect(clusterNodes).toHaveLength(2);
+    const enterprises = clusterNodes.map((n) => n.dataset.enterprise);
+    expect(enterprises).toEqual(expect.arrayContaining(["orion", "acme"]));
+
+    const l2Nodes = screen.getAllByTestId("mirror-node-l2");
+    expect(l2Nodes).toHaveLength(6);
+  });
+
+  it("renders cross-Enterprise edges as unconsented dashed lines (no consents in fixture)", () => {
+    render(<NetworkPage initialData={topologyFixture} />);
+    const crossEdges = screen.getAllByTestId("mirror-edge-cross");
+    // 3 orion L2s × 3 acme L2s = 9 cross edges
+    expect(crossEdges).toHaveLength(9);
+    for (const e of crossEdges) {
+      expect(e.dataset.consented).toBe("false");
+      expect(e.dataset.classes).toMatch(/unconsented/);
+    }
+  });
+
+  it("renders same-Enterprise peer-mesh edges (3 per enterprise = 6 total)", () => {
+    render(<NetworkPage initialData={topologyFixture} />);
+    const peerEdges = screen.getAllByTestId("mirror-edge-peer");
+    // each Enterprise: 3 nodes -> 3 unique pairs -> 3 edges; 2 enterprises = 6
+    expect(peerEdges).toHaveLength(6);
+  });
+
+  it("renders the demo controls strip with 3 disabled buttons", () => {
+    render(<NetworkPage initialData={topologyFixture} />);
+    const controls = screen.getByTestId("demo-controls");
+    const buttons = controls.querySelectorAll("button");
+    expect(buttons).toHaveLength(3);
+    for (const b of buttons) {
+      expect(b).toBeDisabled();
+      expect(b.title).toBe("Wired in Lane F");
+    }
+  });
+
+  it("shows the page header and last-updated indicator", () => {
+    render(<NetworkPage initialData={topologyFixture} />);
+    expect(screen.getByText(/live network topology/i)).toBeInTheDocument();
+    expect(screen.getByTestId("last-updated")).toBeInTheDocument();
+  });
+});

--- a/server/frontend/src/pages/NetworkPage.tsx
+++ b/server/frontend/src/pages/NetworkPage.tsx
@@ -1,0 +1,105 @@
+import { useMemo, useState } from "react";
+import { useTopologyPoll } from "../network/useTopologyPoll";
+import { buildElements } from "../network/graph";
+import { TopologyCanvas } from "../network/components/TopologyCanvas";
+import { L2DetailPanel } from "../network/components/L2DetailPanel";
+import { DemoControls } from "../network/components/DemoControls";
+import type { TopologyL2, TopologyResponse } from "../network/types";
+
+interface NetworkPageProps {
+  // Test seam — production code never passes this.
+  initialData?: TopologyResponse;
+}
+
+function findL2(
+  topology: TopologyResponse | null,
+  l2_id: string | null,
+): TopologyL2 | null {
+  if (!topology || !l2_id) return null;
+  for (const ent of topology.enterprises) {
+    for (const l2 of ent.l2s) {
+      if (l2.l2_id === l2_id) return l2;
+    }
+  }
+  return null;
+}
+
+function lastUpdatedLabel(lastUpdated: number | null): string {
+  if (!lastUpdated) return "never";
+  const seconds = Math.max(0, Math.floor((Date.now() - lastUpdated) / 1000));
+  if (seconds < 5) return "just now";
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}m ago`;
+}
+
+export function NetworkPage({ initialData }: NetworkPageProps = {}) {
+  const poll = useTopologyPoll({ useFixture: !!initialData });
+  // Tests can preempt the polling result so they don't have to mock fetch.
+  const data = initialData ?? poll.data;
+  const [selectedL2Id, setSelectedL2Id] = useState<string | null>(null);
+
+  const elements = useMemo(
+    () => (data ? buildElements(data) : []),
+    [data],
+  );
+  const selectedL2 = findL2(data, selectedL2Id);
+
+  return (
+    // 100vh minus the 49px nav bar (py-3 + line height ~25px).
+    <div
+      className="relative flex flex-col"
+      style={{ height: "calc(100vh - 49px)" }}
+    >
+      {/* Top bar with title + last-updated */}
+      <div className="flex items-center justify-between border-b border-gray-200 bg-white px-5 py-2">
+        <div>
+          <h1 className="text-base font-semibold text-gray-900">
+            Live network topology
+          </h1>
+          <p className="text-xs text-gray-500">
+            Multi-Enterprise AIGRP peer-mesh — polled every 5s
+          </p>
+        </div>
+        <div
+          data-testid="last-updated"
+          className="flex items-center gap-2 text-xs text-gray-500"
+        >
+          {poll.error && (
+            <span
+              className="rounded-full bg-amber-100 px-2 py-0.5 font-medium text-amber-700"
+              title={poll.error}
+            >
+              fetch error
+            </span>
+          )}
+          <span>updated {lastUpdatedLabel(poll.lastUpdated)}</span>
+        </div>
+      </div>
+
+      {/* Canvas + slide-out detail */}
+      <div className="relative flex-1 overflow-hidden">
+        {!data ? (
+          <div
+            data-testid="topology-empty"
+            className="flex h-full items-center justify-center text-sm text-gray-400"
+          >
+            {poll.error ? "topology unavailable" : "loading topology…"}
+          </div>
+        ) : (
+          <TopologyCanvas
+            elements={elements}
+            selectedL2Id={selectedL2Id}
+            onSelectL2={setSelectedL2Id}
+          />
+        )}
+        <L2DetailPanel
+          l2={selectedL2}
+          onClose={() => setSelectedL2Id(null)}
+        />
+      </div>
+
+      <DemoControls />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Lane E of `docs/plans/08-live-network-demo.md` (in `OneZero1ai/crosstalk-enterprise`).

Adds an authenticated `/network` page that visualises the live multi-Enterprise AIGRP peer-mesh in real time.

### Layout (top to bottom)

- **Top bar** — title + "updated Xs ago" indicator with an inline "fetch error" pill if polling falters.
- **Topology canvas (~60% of viewport)** — Cytoscape force-directed graph (cose-bilkent layout). Two compound parents (`orion` indigo, `acme` teal) wrap their L2 children; node size is proportional to `ku_count`. Intra-Enterprise AIGRP peer edges are drawn solid; cross-Enterprise edges are dashed-grey when no consent is in `cross_enterprise_consents`, and solid emerald when a consent matches.
- **Slide-out L2 detail panel** — clicking an L2 node reveals `l2_id`, `group`, `endpoint_url`, KU/domain/peer counts, peer list with `last_signature_at` ages, and active personas with their `working_dir_hint` + expertise tags.
- **Demo controls strip (~40px)** — three placeholder buttons ("Run cross-Group query", "Try cross-Enterprise (no consent)", "Sign cross-Enterprise consent") rendered disabled with a `Wired in Lane F` tooltip so the affordance lands first.

### Data source

Currently fixture-backed via `src/network/fixtures/topology.fixture.ts` (mirrors the 6 live test-fleet L2s with realistic KU counts and one mock active persona per L2). The page polls `/api/v1/network/topology` every 5 seconds via `useTopologyPoll()`; the server-side proxy at that path is Lane F's job. The hook accepts a `fetcher` seam for tests and a `useFixture` flag for offline demos.

The browser cannot hit the test-fleet ALBs directly (HTTP from an HTTPS frontend = mixed-content), so the proxy is the only viable shape.

### Wiring

- `Layout.tsx` gets a "Network" nav item alongside Dashboard/Review/API Keys, and a wide-mode `<main>` that the `/network` route opts into so the canvas can use the full viewport without breaking the narrow layout used elsewhere.
- New deps: `cytoscape` + `cytoscape-cose-bilkent` (plus `@types/cytoscape`). No React-Cytoscape wrapper — vanilla `cytoscape()` inside a ref is enough and avoids needing custom `.d.ts` for the wrapper.

## Out of scope (Lane F)

- Server-side `/api/v1/network/topology` proxy aggregating the 6 L2s.
- Live presence registry call (Lane C ships `/peers/active`; consumed when both lanes land).
- Demo button orchestration + animated packet trace.

## Test plan

- [x] `pnpm test` clean — 21 tests pass (5 new for NetworkPage + 5 new for useTopologyPoll).
- [x] `pnpm lint` clean.
- [x] `pnpm build` succeeds.
- [ ] Manual smoke once Lane F's proxy lands — toggle a consent in the response and confirm cross-Enterprise edges flip from dashed-grey to emerald-solid in real time.
- [ ] Verify nav item lands correctly between Dashboard and API Keys on a logged-in session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)