### PR TITLE
[server] Phase 6 step 3: presence registry + consent admin endpoints

### DIFF
--- a/server/backend/alembic/versions/0003_phase6_step3_presence.py
+++ b/server/backend/alembic/versions/0003_phase6_step3_presence.py
@@ -1,0 +1,124 @@
+"""Phase 6 step 3: presence registry + admin role column.
+
+Revision ID: 0003_phase6_step3
+Revises: 0002_phase6_step2
+Create Date: 2026-04-30
+
+Adds the schema delta required by Lanes C and D of the live-network-demo
+plan:
+
+  - ``users.role`` — TEXT NOT NULL DEFAULT 'user'. Lets admin-only routes
+    (POST /consents/sign, DELETE /consents/{id}) gate access without
+    introducing a separate roles table; v1 is global admin scope, per-
+    Enterprise admin is deferred.
+  - ``peers`` table — live presence registry keyed by ``persona``. Holds
+    the heartbeat timestamp + opt-in metadata an L2 advertises. Indexed
+    on (enterprise_id, group_id) for the active-peers listing and on
+    last_seen_at for window-bounded queries.
+
+Mirrors the runtime ``ensure_user_role_column`` and ``ensure_peers_schema``
+helpers so the Alembic-first DB and the legacy-runtime DB end up
+indistinguishable.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0003_phase6_step3"
+down_revision: str | Sequence[str] | None = "0002_phase6_step2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _table_exists(bind: sa.engine.Connection, table_name: str) -> bool:
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def _column_names(bind: sa.engine.Connection, table_name: str) -> set[str]:
+    inspector = sa.inspect(bind)
+    if table_name not in inspector.get_table_names():
+        return set()
+    return {col["name"] for col in inspector.get_columns(table_name)}
+
+
+def upgrade() -> None:
+    """Add ``users.role`` + create the ``peers`` table."""
+    bind = op.get_bind()
+
+    # 1. users.role — additive column, default 'user', NOT NULL after backfill.
+    if _table_exists(bind, "users"):
+        existing = _column_names(bind, "users")
+        if "role" not in existing:
+            op.add_column(
+                "users",
+                sa.Column(
+                    "role",
+                    sa.Text(),
+                    nullable=True,
+                    server_default=sa.text("'user'"),
+                ),
+            )
+            op.execute(
+                sa.text("UPDATE users SET role = 'user' WHERE role IS NULL")
+            )
+            with op.batch_alter_table("users") as batch:
+                batch.alter_column(
+                    "role",
+                    existing_type=sa.Text(),
+                    nullable=False,
+                    existing_server_default=sa.text("'user'"),
+                )
+
+    # 2. peers — presence registry.
+    if not _table_exists(bind, "peers"):
+        op.create_table(
+            "peers",
+            sa.Column("persona", sa.Text(), primary_key=True),
+            sa.Column("user_id", sa.Integer(), nullable=True),
+            sa.Column("enterprise_id", sa.Text(), nullable=False),
+            sa.Column("group_id", sa.Text(), nullable=False),
+            sa.Column("last_seen_at", sa.Text(), nullable=False),
+            sa.Column("expertise_vector", sa.LargeBinary(), nullable=True),
+            sa.Column("expertise_domains", sa.Text(), nullable=True),
+            sa.Column(
+                "discoverable",
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text("0"),
+            ),
+            sa.Column("working_dir_hint", sa.Text(), nullable=True),
+            sa.Column("metadata_json", sa.Text(), nullable=True),
+        )
+        op.create_index(
+            "idx_peers_enterprise_group",
+            "peers",
+            ["enterprise_id", "group_id"],
+        )
+        op.create_index(
+            "idx_peers_last_seen",
+            "peers",
+            ["last_seen_at"],
+        )
+
+
+def downgrade() -> None:
+    """Drop the ``peers`` table + remove ``users.role``.
+
+    Used by migration tests; production rollbacks should prefer leaving
+    the additive column in place since downgrading after data has been
+    written can lose role assignments.
+    """
+    bind = op.get_bind()
+    if _table_exists(bind, "peers"):
+        op.drop_index("idx_peers_last_seen", table_name="peers")
+        op.drop_index("idx_peers_enterprise_group", table_name="peers")
+        op.drop_table("peers")
+    if _table_exists(bind, "users"):
+        existing = _column_names(bind, "users")
+        if "role" in existing:
+            with op.batch_alter_table("users") as batch:
+                batch.drop_column("role")

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel, Field
 from starlette.responses import FileResponse
 
 from . import aigrp
+from .auth import require_admin
 from .auth import router as auth_router
 from .deps import API_KEY_PEPPER_ENV, require_api_key
 from .embed import compose_text, embed_text
@@ -805,6 +806,354 @@ def aigrp_forward_query(
         results=results,
         result_count=len(results),
     )
+
+
+# --- Phase 6 step 3 — Lane C: presence registry ---------------------------
+
+# Heartbeat cadence advertised back to the client. 5-min default keeps the
+# table fresh without hammering the DB; clients can over-shoot but we expect
+# the harness hook to land near this number.
+PEER_HEARTBEAT_INTERVAL_SECONDS = 300
+PEER_ACTIVE_DEFAULT_WINDOW_MIN = 15
+
+
+class PeerHeartbeatRequest(BaseModel):
+    """Request body for ``POST /peers/heartbeat``.
+
+    ``persona`` is the agent identity within the caller's tenant — e.g.
+    ``persona-cloudfront-asker``. ``discoverable=False`` keeps the
+    persona out of the active-peers listing while still recording the
+    heartbeat (so an admin dashboard can show presence even for opted-
+    out personas). ``expertise_domains`` is a free-text tag list; the
+    server stores it as JSON and returns it verbatim.
+    """
+
+    persona: str = Field(min_length=1, max_length=128)
+    discoverable: bool = False
+    working_dir_hint: str | None = Field(default=None, max_length=512)
+    expertise_domains: list[str] | None = None
+
+
+class PeerHeartbeatResponse(BaseModel):
+    """Response from a successful heartbeat — echoes the persona and tells the client when to next call back."""
+
+    persona: str
+    registered_at: str
+    next_heartbeat_in_seconds: int
+
+
+class ActivePeer(BaseModel):
+    """One row of the active-peers listing returned by GET /peers/active."""
+
+    persona: str
+    enterprise_id: str
+    group_id: str
+    last_seen_at: str
+    minutes_since_last_seen: float
+    discoverable: bool
+    working_dir_hint: str | None = None
+    expertise_domains: list[str] | None = None
+
+
+class ActivePeersResponse(BaseModel):
+    """Wire shape for GET /peers/active — list + count for client-side rendering."""
+
+    active_peers: list[ActivePeer]
+    count: int
+
+
+@api_router.post("/peers/heartbeat")
+def peers_heartbeat(
+    request: PeerHeartbeatRequest,
+    username: str = Depends(require_api_key),
+) -> PeerHeartbeatResponse:
+    """Register or refresh a persona's presence on this L2.
+
+    Auth: any valid API key. Tenancy scope (``enterprise_id`` /
+    ``group_id``) is resolved from the authenticated user's row — the
+    request body never carries scope to avoid spoofing. The row is
+    UPSERTed; ``last_seen_at`` advances to "now" on every call.
+    """
+    from datetime import UTC, datetime
+
+    store = _get_store()
+    user = store.get_user(username)
+    if user is None:
+        raise HTTPException(status_code=401, detail="User not found")
+    now = datetime.now(UTC).isoformat()
+    store.upsert_peer(
+        persona=request.persona,
+        user_id=int(user["id"]),
+        enterprise_id=user["enterprise_id"],
+        group_id=user["group_id"],
+        last_seen_at=now,
+        expertise_domains=request.expertise_domains,
+        discoverable=request.discoverable,
+        working_dir_hint=request.working_dir_hint,
+    )
+    return PeerHeartbeatResponse(
+        persona=request.persona,
+        registered_at=now,
+        next_heartbeat_in_seconds=PEER_HEARTBEAT_INTERVAL_SECONDS,
+    )
+
+
+@api_router.get("/peers/active")
+def peers_active(
+    group: Annotated[str | None, Query()] = None,
+    since_minutes: Annotated[int, Query(gt=0, le=24 * 60)] = PEER_ACTIVE_DEFAULT_WINDOW_MIN,
+    include_self: Annotated[bool, Query()] = False,
+    self_persona: Annotated[str | None, Query(alias="self_persona")] = None,
+    username: str = Depends(require_api_key),
+) -> ActivePeersResponse:
+    """Return discoverable peers in the caller's Enterprise.
+
+    Scoping rules (intentionally Enterprise-bounded):
+
+      - Cross-Enterprise visibility is NOT granted by consent; presence
+        is its own privacy plane. A consent record unlocks knowledge
+        access via /aigrp/forward-query, not who's online.
+      - ``group`` narrows further to a single Group inside the caller's
+        Enterprise.
+      - ``include_self=False`` hides ``self_persona`` from the result.
+        The requester provides ``self_persona`` because the API key
+        does not pin a single persona — one user can own many personas.
+
+    ``minutes_since_last_seen`` is computed against the row's ISO
+    timestamp at request time, so it's monotone-decreasing across calls.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    store = _get_store()
+    user = store.get_user(username)
+    if user is None:
+        raise HTTPException(status_code=401, detail="User not found")
+    now = datetime.now(UTC)
+    since_iso = (now - timedelta(minutes=since_minutes)).isoformat()
+    rows = store.list_active_peers(
+        enterprise_id=user["enterprise_id"],
+        since_iso=since_iso,
+        group_id=group,
+        exclude_persona=None if include_self else self_persona,
+    )
+    active: list[ActivePeer] = []
+    for r in rows:
+        try:
+            last_seen = datetime.fromisoformat(r["last_seen_at"])
+        except ValueError:
+            # Defensive — should never happen since we wrote ISO-8601.
+            continue
+        delta_min = max(0.0, (now - last_seen).total_seconds() / 60.0)
+        active.append(
+            ActivePeer(
+                persona=r["persona"],
+                enterprise_id=r["enterprise_id"],
+                group_id=r["group_id"],
+                last_seen_at=r["last_seen_at"],
+                minutes_since_last_seen=round(delta_min, 2),
+                discoverable=r["discoverable"],
+                working_dir_hint=r["working_dir_hint"],
+                expertise_domains=r["expertise_domains"],
+            )
+        )
+    return ActivePeersResponse(active_peers=active, count=len(active))
+
+
+# --- Phase 6 step 3 — Lane D: consent admin endpoints ---------------------
+
+
+class SignConsentRequest(BaseModel):
+    """Request body for ``POST /consents/sign``.
+
+    Group columns are optional — null means "any group on that side"
+    (wildcard). Same shape as the row schema in
+    ``cross_enterprise_consents``. Only ``summary_only`` is accepted in
+    v1; ``full_body`` cross-Enterprise sharing is intentionally deferred
+    until a higher-trust signing flow exists.
+    """
+
+    requester_enterprise: str = Field(min_length=1)
+    responder_enterprise: str = Field(min_length=1)
+    requester_group: str | None = None
+    responder_group: str | None = None
+    policy: str = Field(default="summary_only")
+    expires_at: str | None = None
+
+
+class SignConsentResponse(BaseModel):
+    """Response from POST /consents/sign — echoes the new consent_id and audit pairing."""
+
+    consent_id: str
+    signed_by_admin: str
+    signed_at: str
+    audit_log_id: str
+
+
+class ConsentRecord(BaseModel):
+    """Public view of one row from cross_enterprise_consents."""
+
+    consent_id: str
+    requester_enterprise: str
+    responder_enterprise: str
+    requester_group: str | None = None
+    responder_group: str | None = None
+    policy: str
+    signed_by_admin: str
+    signed_at: str
+    expires_at: str | None = None
+    audit_log_id: str
+
+
+class ConsentListResponse(BaseModel):
+    """Wire shape for GET /consents — listing + count."""
+
+    consents: list[ConsentRecord]
+    count: int
+
+
+@api_router.post("/consents/sign", status_code=201)
+def consents_sign(
+    request: SignConsentRequest,
+    admin_username: str = Depends(require_admin),
+) -> SignConsentResponse:
+    """Admin-only: sign a cross-Enterprise consent.
+
+    422 when the request is malformed (intra-Enterprise pair, unsupported
+    policy). 409 when an unexpired consent already exists for the same
+    ``(req_ent, resp_ent, req_grp, resp_grp)`` tuple. On success a row
+    is inserted into ``cross_enterprise_consents`` and a paired audit
+    record into ``cross_l2_audit`` with ``policy_applied='consent_signed'``.
+    """
+    import uuid
+
+    if request.requester_enterprise == request.responder_enterprise:
+        raise HTTPException(
+            status_code=422,
+            detail="cross-Enterprise consents must span two distinct Enterprises; "
+                   "use the per-KU cross_group_allowed flag for intra-Enterprise scoping",
+        )
+    if request.policy != "summary_only":
+        raise HTTPException(
+            status_code=422,
+            detail=f"unsupported policy {request.policy!r}; only 'summary_only' is allowed in v1",
+        )
+
+    store = _get_store()
+    now = aigrp.now_iso()
+    existing = store.find_active_consent_for_pair(
+        requester_enterprise=request.requester_enterprise,
+        responder_enterprise=request.responder_enterprise,
+        requester_group=request.requester_group,
+        responder_group=request.responder_group,
+        now_iso=now,
+    )
+    if existing is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=f"active consent already exists: {existing['consent_id']}",
+        )
+
+    consent_id = "consent_" + uuid.uuid4().hex[:20]
+    audit_log_id = "aud_" + uuid.uuid4().hex[:20]
+    store.insert_cross_enterprise_consent(
+        consent_id=consent_id,
+        requester_enterprise=request.requester_enterprise,
+        responder_enterprise=request.responder_enterprise,
+        requester_group=request.requester_group,
+        responder_group=request.responder_group,
+        policy=request.policy,
+        signed_by_admin=admin_username,
+        signed_at=now,
+        expires_at=request.expires_at,
+        audit_log_id=audit_log_id,
+    )
+    # Pair the sign event with a row in cross_l2_audit so the audit log
+    # tells the full story of "who signed what, when".
+    store.record_cross_l2_audit(
+        audit_id=audit_log_id,
+        ts=now,
+        requester_l2_id=None,
+        requester_enterprise=request.requester_enterprise,
+        requester_group=request.requester_group,
+        requester_persona=None,
+        responder_l2_id=None,
+        responder_enterprise=request.responder_enterprise,
+        responder_group=request.responder_group,
+        policy_applied="consent_signed",
+        result_count=0,
+        consent_id=consent_id,
+    )
+    return SignConsentResponse(
+        consent_id=consent_id,
+        signed_by_admin=admin_username,
+        signed_at=now,
+        audit_log_id=audit_log_id,
+    )
+
+
+@api_router.get("/consents")
+def consents_list(
+    include_expired: Annotated[bool, Query()] = False,
+    limit: Annotated[int, Query(gt=0, le=500)] = 50,
+    _admin: str = Depends(require_admin),
+) -> ConsentListResponse:
+    """Admin-only: list cross-Enterprise consents.
+
+    By default only active (non-expired) rows are returned; pass
+    ``include_expired=true`` to see soft-revoked / time-boxed records.
+    Records are ordered newest-first by ``signed_at``.
+    """
+    store = _get_store()
+    rows = store.list_cross_enterprise_consents(
+        include_expired=include_expired,
+        now_iso=aigrp.now_iso(),
+        limit=limit,
+    )
+    return ConsentListResponse(
+        consents=[ConsentRecord(**r) for r in rows],
+        count=len(rows),
+    )
+
+
+@api_router.delete("/consents/{consent_id}", status_code=200)
+def consents_revoke(
+    consent_id: str,
+    admin_username: str = Depends(require_admin),
+) -> dict[str, str]:
+    """Admin-only: soft-revoke a consent.
+
+    Sets ``expires_at`` to "now" rather than deleting the row, so the
+    consent's audit history (who signed it, when) survives revocation.
+    Writes a paired ``cross_l2_audit`` row with
+    ``policy_applied='consent_revoked'``. 404 when the id is unknown.
+    """
+    import uuid
+
+    store = _get_store()
+    row = store.get_cross_enterprise_consent(consent_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Consent not found")
+    now = aigrp.now_iso()
+    store.revoke_cross_enterprise_consent(consent_id=consent_id, revoked_at=now)
+    store.record_cross_l2_audit(
+        audit_id="aud_" + uuid.uuid4().hex[:20],
+        ts=now,
+        requester_l2_id=None,
+        requester_enterprise=row["requester_enterprise"],
+        requester_group=row["requester_group"],
+        requester_persona=None,
+        responder_l2_id=None,
+        responder_enterprise=row["responder_enterprise"],
+        responder_group=row["responder_group"],
+        policy_applied="consent_revoked",
+        result_count=0,
+        consent_id=consent_id,
+    )
+    return {
+        "consent_id": consent_id,
+        "revoked_at": now,
+        "revoked_by_admin": admin_username,
+    }
 
 
 @api_router.get("/query/semantic")

--- a/server/backend/src/cq_server/auth.py
+++ b/server/backend/src/cq_server/auth.py
@@ -182,6 +182,26 @@ def get_current_user(request: Request) -> str:
     return payload["sub"]
 
 
+def require_admin(
+    request: Request,
+    username: str = Depends(get_current_user),
+    store: RemoteStore = Depends(get_store),
+) -> str:
+    """FastAPI dependency: caller must be an authenticated admin user.
+
+    Returns the username on success; 401 on missing/invalid JWT (raised
+    by the chained ``get_current_user`` dep), 403 when the caller is
+    authenticated but not an admin. Admin-ness is global in v1 — there
+    is no per-Enterprise scoping yet (see plan doc, Lane D).
+    """
+    user = store.get_user(username)
+    if user is None:
+        raise HTTPException(status_code=401, detail="User not found")
+    if user.get("role") != "admin":
+        raise HTTPException(status_code=403, detail="Admin role required")
+    return username
+
+
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 

--- a/server/backend/src/cq_server/store/__init__.py
+++ b/server/backend/src/cq_server/store/__init__.py
@@ -23,8 +23,10 @@ from ..tables import (
     ensure_aigrp_peers_table,
     ensure_api_keys_table,
     ensure_embedding_columns,
+    ensure_peers_schema,
     ensure_review_columns,
     ensure_tenancy_columns,
+    ensure_user_role_column,
     ensure_users_table,
     ensure_xgroup_consent_schema,
 )
@@ -108,6 +110,11 @@ class RemoteStore:
         # registry + cross-L2 audit log. Same idempotent shape so the
         # runtime path matches the Alembic migration.
         ensure_xgroup_consent_schema(self._conn)
+        # Phase 6 step 3 — admin role column + presence registry. Both
+        # idempotent; the ``peers`` table is created lazily on every
+        # startup so a legacy DB picks it up without an explicit migration.
+        ensure_user_role_column(self._conn)
+        ensure_peers_schema(self._conn)
 
     def _check_open(self) -> None:
         """Raise if the store has been closed."""
@@ -645,18 +652,41 @@ class RemoteStore:
             username: The user's login name.
 
         Returns:
-            A dict with id, username, password_hash, and created_at keys, or
-            None if no user with that username exists.
+            A dict with id, username, password_hash, created_at, role,
+            enterprise_id, and group_id keys, or None if no user with
+            that username exists.
         """
         self._check_open()
         with self._lock:
             row = self._conn.execute(
-                "SELECT id, username, password_hash, created_at FROM users WHERE username = ?",
+                "SELECT id, username, password_hash, created_at, role, "
+                "enterprise_id, group_id FROM users WHERE username = ?",
                 (username,),
             ).fetchone()
         if row is None:
             return None
-        return {"id": row[0], "username": row[1], "password_hash": row[2], "created_at": row[3]}
+        return {
+            "id": row[0],
+            "username": row[1],
+            "password_hash": row[2],
+            "created_at": row[3],
+            "role": row[4] or "user",
+            "enterprise_id": row[5] or DEFAULT_ENTERPRISE_ID,
+            "group_id": row[6] or DEFAULT_GROUP_ID,
+        }
+
+    def set_user_role(self, username: str, role: str) -> bool:
+        """Set the role on a user. Returns True if a row was updated.
+
+        Used by tests / bootstrap scripts to promote a user to admin.
+        """
+        self._check_open()
+        with self._lock, self._conn:
+            cur = self._conn.execute(
+                "UPDATE users SET role = ? WHERE username = ?",
+                (role, username),
+            )
+        return cur.rowcount > 0
 
     def count_active_api_keys_for_user(self, user_id: int) -> int:
         """Return the number of active API keys for the given user.
@@ -1374,3 +1404,230 @@ class RemoteStore:
             )
             current += timedelta(days=1)
         return result
+
+    # -- Phase 6 step 3: presence registry ------------------------------
+
+    def upsert_peer(
+        self,
+        *,
+        persona: str,
+        user_id: int | None,
+        enterprise_id: str,
+        group_id: str,
+        last_seen_at: str,
+        expertise_domains: list[str] | None,
+        discoverable: bool,
+        working_dir_hint: str | None,
+        metadata_json: str | None = None,
+    ) -> None:
+        """UPSERT a presence row keyed by ``persona``.
+
+        Updates ``last_seen_at`` to the supplied timestamp and replaces
+        the other mutable fields on conflict; the ``expertise_vector``
+        column is left untouched here (recomputed by a future
+        embedding-cron pass — the heartbeat path stays cheap).
+        """
+        self._check_open()
+        domains_json = json.dumps(expertise_domains) if expertise_domains is not None else None
+        with self._lock, self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO peers (
+                    persona, user_id, enterprise_id, group_id, last_seen_at,
+                    expertise_domains, discoverable, working_dir_hint,
+                    metadata_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(persona) DO UPDATE SET
+                    user_id = excluded.user_id,
+                    enterprise_id = excluded.enterprise_id,
+                    group_id = excluded.group_id,
+                    last_seen_at = excluded.last_seen_at,
+                    expertise_domains = excluded.expertise_domains,
+                    discoverable = excluded.discoverable,
+                    working_dir_hint = excluded.working_dir_hint,
+                    metadata_json = excluded.metadata_json
+                """,
+                (
+                    persona, user_id, enterprise_id, group_id, last_seen_at,
+                    domains_json, 1 if discoverable else 0, working_dir_hint,
+                    metadata_json,
+                ),
+            )
+
+    def list_active_peers(
+        self,
+        *,
+        enterprise_id: str,
+        since_iso: str,
+        group_id: str | None = None,
+        exclude_persona: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return discoverable peers seen at or after ``since_iso``.
+
+        Scoped to a single Enterprise — presence is intentionally
+        Enterprise-bounded (consent unlocks knowledge access, not
+        presence visibility). ``group_id`` narrows further within the
+        Enterprise; ``exclude_persona`` filters out the caller.
+        """
+        self._check_open()
+        sql = (
+            "SELECT persona, user_id, enterprise_id, group_id, last_seen_at, "
+            "expertise_domains, discoverable, working_dir_hint, metadata_json "
+            "FROM peers "
+            "WHERE enterprise_id = ? AND last_seen_at >= ? AND discoverable = 1"
+        )
+        params: list[Any] = [enterprise_id, since_iso]
+        if group_id is not None:
+            sql += " AND group_id = ?"
+            params.append(group_id)
+        if exclude_persona is not None:
+            sql += " AND persona != ?"
+            params.append(exclude_persona)
+        sql += " ORDER BY last_seen_at DESC"
+        with self._lock:
+            rows = self._conn.execute(sql, params).fetchall()
+        return [
+            {
+                "persona": r[0],
+                "user_id": r[1],
+                "enterprise_id": r[2],
+                "group_id": r[3],
+                "last_seen_at": r[4],
+                "expertise_domains": json.loads(r[5]) if r[5] else None,
+                "discoverable": bool(r[6]),
+                "working_dir_hint": r[7],
+                "metadata_json": r[8],
+            }
+            for r in rows
+        ]
+
+    # -- Phase 6 step 3: consent admin -----------------------------------
+
+    def list_cross_enterprise_consents(
+        self,
+        *,
+        include_expired: bool = False,
+        now_iso: str,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Return cross-Enterprise consent rows, newest first.
+
+        ``include_expired=False`` filters out rows whose ``expires_at``
+        is in the past (NULL ``expires_at`` rows are kept — they never
+        expire). ``include_expired=True`` returns everything.
+        """
+        self._check_open()
+        sql = (
+            "SELECT consent_id, requester_enterprise, responder_enterprise, "
+            "requester_group, responder_group, policy, signed_by_admin, "
+            "signed_at, expires_at, audit_log_id "
+            "FROM cross_enterprise_consents"
+        )
+        params: list[Any] = []
+        if not include_expired:
+            sql += " WHERE expires_at IS NULL OR expires_at > ?"
+            params.append(now_iso)
+        sql += " ORDER BY signed_at DESC LIMIT ?"
+        params.append(limit)
+        with self._lock:
+            rows = self._conn.execute(sql, params).fetchall()
+        return [
+            {
+                "consent_id": r[0],
+                "requester_enterprise": r[1],
+                "responder_enterprise": r[2],
+                "requester_group": r[3],
+                "responder_group": r[4],
+                "policy": r[5],
+                "signed_by_admin": r[6],
+                "signed_at": r[7],
+                "expires_at": r[8],
+                "audit_log_id": r[9],
+            }
+            for r in rows
+        ]
+
+    def get_cross_enterprise_consent(self, consent_id: str) -> dict[str, Any] | None:
+        """Return a single consent record by id, or None if absent."""
+        self._check_open()
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT consent_id, requester_enterprise, responder_enterprise, "
+                "requester_group, responder_group, policy, signed_by_admin, "
+                "signed_at, expires_at, audit_log_id "
+                "FROM cross_enterprise_consents WHERE consent_id = ?",
+                (consent_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return {
+            "consent_id": row[0],
+            "requester_enterprise": row[1],
+            "responder_enterprise": row[2],
+            "requester_group": row[3],
+            "responder_group": row[4],
+            "policy": row[5],
+            "signed_by_admin": row[6],
+            "signed_at": row[7],
+            "expires_at": row[8],
+            "audit_log_id": row[9],
+        }
+
+    def find_active_consent_for_pair(
+        self,
+        *,
+        requester_enterprise: str,
+        responder_enterprise: str,
+        requester_group: str | None,
+        responder_group: str | None,
+        now_iso: str,
+    ) -> dict[str, Any] | None:
+        """Return any non-expired consent matching the exact tuple.
+
+        Distinct from ``find_cross_enterprise_consent`` which scores
+        wildcard matches. This helper is for the duplicate-detection
+        guard on the admin sign endpoint — only an *exact* match (same
+        groups, both NULL or both equal) counts as a duplicate.
+        """
+        self._check_open()
+        with self._lock:
+            row = self._conn.execute(
+                """
+                SELECT consent_id FROM cross_enterprise_consents
+                WHERE requester_enterprise = ?
+                  AND responder_enterprise = ?
+                  AND ((requester_group IS NULL AND ? IS NULL)
+                       OR requester_group = ?)
+                  AND ((responder_group IS NULL AND ? IS NULL)
+                       OR responder_group = ?)
+                  AND (expires_at IS NULL OR expires_at > ?)
+                LIMIT 1
+                """,
+                (
+                    requester_enterprise, responder_enterprise,
+                    requester_group, requester_group,
+                    responder_group, responder_group,
+                    now_iso,
+                ),
+            ).fetchone()
+        if row is None:
+            return None
+        return self.get_cross_enterprise_consent(row[0])
+
+    def revoke_cross_enterprise_consent(
+        self, *, consent_id: str, revoked_at: str
+    ) -> bool:
+        """Soft-revoke a consent by setting ``expires_at = revoked_at``.
+
+        Returns True if a row was updated. Does not hard-delete; the
+        record remains for the audit trail. Idempotent: revoking an
+        already-revoked consent updates the timestamp again (cheap and
+        consistent with the "expiry advances" semantics elsewhere).
+        """
+        self._check_open()
+        with self._lock, self._conn:
+            cur = self._conn.execute(
+                "UPDATE cross_enterprise_consents SET expires_at = ? WHERE consent_id = ?",
+                (revoked_at, consent_id),
+            )
+        return cur.rowcount > 0

--- a/server/backend/src/cq_server/tables.py
+++ b/server/backend/src/cq_server/tables.py
@@ -100,8 +100,32 @@ CREATE TABLE IF NOT EXISTS users (
     password_hash TEXT NOT NULL,
     created_at TEXT NOT NULL,
     enterprise_id TEXT NOT NULL DEFAULT '{DEFAULT_ENTERPRISE_ID}',
-    group_id TEXT NOT NULL DEFAULT '{DEFAULT_GROUP_ID}'
+    group_id TEXT NOT NULL DEFAULT '{DEFAULT_GROUP_ID}',
+    role TEXT NOT NULL DEFAULT 'user'
 );
+"""
+
+# Phase 6 step 3 — role column on users for admin-only routes.
+# Defaults to 'user'; promote with an UPDATE to grant admin (Lane D).
+_USER_ROLE_COLUMN_STATEMENTS = [
+    "ALTER TABLE users ADD COLUMN role TEXT NOT NULL DEFAULT 'user'",
+]
+
+PEERS_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS peers (
+    persona TEXT PRIMARY KEY,
+    user_id INTEGER,
+    enterprise_id TEXT NOT NULL,
+    group_id TEXT NOT NULL,
+    last_seen_at TEXT NOT NULL,
+    expertise_vector BLOB,
+    expertise_domains TEXT,
+    discoverable INTEGER NOT NULL DEFAULT 0,
+    working_dir_hint TEXT,
+    metadata_json TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_peers_enterprise_group ON peers(enterprise_id, group_id);
+CREATE INDEX IF NOT EXISTS idx_peers_last_seen ON peers(last_seen_at);
 """
 
 API_KEYS_TABLE_SQL = """
@@ -202,6 +226,40 @@ def ensure_tenancy_columns(conn: sqlite3.Connection) -> None:
     conn.execute(f"UPDATE knowledge_units SET group_id = '{DEFAULT_GROUP_ID}' WHERE group_id IS NULL")
     conn.execute(f"UPDATE users SET enterprise_id = '{DEFAULT_ENTERPRISE_ID}' WHERE enterprise_id IS NULL")
     conn.execute(f"UPDATE users SET group_id = '{DEFAULT_GROUP_ID}' WHERE group_id IS NULL")
+    conn.commit()
+
+
+def ensure_user_role_column(conn: sqlite3.Connection) -> None:
+    """Phase 6 step 3 — add ``role`` column to ``users`` if missing.
+
+    Idempotent: checks the existing schema and only ALTERs when the
+    column doesn't already exist. Pre-existing rows backfill to ``'user'``
+    so the admin gate stays closed by default.
+    """
+    cursor = conn.execute("PRAGMA table_info(users)")
+    existing = {row[1] for row in cursor.fetchall()}
+    for statement in _USER_ROLE_COLUMN_STATEMENTS:
+        col = statement.split("COLUMN ")[1].split()[0]
+        if col not in existing:
+            conn.execute(statement)
+    # Same SQLite quirk as the tenancy backfill — explicit UPDATE so any
+    # legacy row that pre-dates the column add picks up the default.
+    conn.execute("UPDATE users SET role = 'user' WHERE role IS NULL")
+    conn.commit()
+
+
+def ensure_peers_schema(conn: sqlite3.Connection) -> None:
+    """Phase 6 step 3 — create the presence registry table + indexes.
+
+    Idempotent on every startup, mirroring ``ensure_xgroup_consent_schema``.
+    The ``peers`` table is the live registry of which personas are heart-
+    beating against this L2; surfaces "active agents per L2" to the demo
+    frontend. Schema is wholly additive — no relationship to existing
+    tables beyond an optional FK-shaped ``user_id`` column (kept as a
+    plain integer to avoid retro-fitting FK constraints across legacy
+    DBs).
+    """
+    conn.executescript(PEERS_TABLE_SQL)
     conn.commit()
 
 

--- a/server/backend/tests/test_consents_revoke.py
+++ b/server/backend/tests/test_consents_revoke.py
@@ -1,0 +1,150 @@
+"""Phase 6 step 3 / Lane D: DELETE /consents/{consent_id} tests.
+
+Pins:
+  - Soft-delete sets expires_at to now (does not drop the row).
+  - Audit row written with policy_applied='consent_revoked'.
+  - 404 on unknown id.
+  - 403 for non-admin callers.
+  - Once revoked, the consent is no longer "active" — /consents lists
+    excludes it by default but include_expired=true still returns it.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import bcrypt
+import pytest
+from fastapi.testclient import TestClient
+
+from cq_server.app import _get_store, app
+
+ADMIN = "admin@acme"
+USER = "regular-user"
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "consents_revoke.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    with TestClient(app) as c:
+        store = _get_store()
+        pw = bcrypt.hashpw(b"pw", bcrypt.gensalt()).decode()
+        store.create_user(ADMIN, pw)
+        store.create_user(USER, pw)
+        store.set_user_role(ADMIN, "admin")
+        yield c
+
+
+def _login(client: TestClient, username: str) -> str:
+    resp = client.post(
+        "/api/v1/auth/login",
+        json={"username": username, "password": "pw"},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _sign(client: TestClient, jwt: str) -> str:
+    resp = client.post(
+        "/api/v1/consents/sign",
+        headers={"Authorization": f"Bearer {jwt}"},
+        json={
+            "requester_enterprise": "initech",
+            "responder_enterprise": "acme",
+            "policy": "summary_only",
+        },
+    )
+    assert resp.status_code == 201
+    return resp.json()["consent_id"]
+
+
+class TestRevokeHappyPath:
+    def test_revoke_returns_200_and_soft_deletes(self, client: TestClient) -> None:
+        jwt = _login(client, ADMIN)
+        cid = _sign(client, jwt)
+        resp = client.delete(
+            f"/api/v1/consents/{cid}",
+            headers={"Authorization": f"Bearer {jwt}"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["consent_id"] == cid
+        assert body["revoked_at"]
+        assert body["revoked_by_admin"] == ADMIN
+        # Row still exists; expires_at advanced.
+        store = _get_store()
+        row = store.get_cross_enterprise_consent(cid)
+        assert row is not None
+        assert row["expires_at"] == body["revoked_at"]
+
+    def test_revoke_writes_audit_row(self, client: TestClient) -> None:
+        jwt = _login(client, ADMIN)
+        cid = _sign(client, jwt)
+        client.delete(
+            f"/api/v1/consents/{cid}",
+            headers={"Authorization": f"Bearer {jwt}"},
+        )
+        store = _get_store()
+        with store._lock:
+            rows = store._conn.execute(
+                "SELECT policy_applied FROM cross_l2_audit "
+                "WHERE consent_id = ? ORDER BY ts ASC",
+                (cid,),
+            ).fetchall()
+        # One row from sign, one from revoke.
+        kinds = [r[0] for r in rows]
+        assert kinds == ["consent_signed", "consent_revoked"]
+
+
+class TestRevokeNotFound:
+    def test_unknown_id_returns_404(self, client: TestClient) -> None:
+        jwt = _login(client, ADMIN)
+        resp = client.delete(
+            "/api/v1/consents/consent_does_not_exist",
+            headers={"Authorization": f"Bearer {jwt}"},
+        )
+        assert resp.status_code == 404
+
+
+class TestRevokeAuth:
+    def test_non_admin_returns_403(self, client: TestClient) -> None:
+        admin_jwt = _login(client, ADMIN)
+        cid = _sign(client, admin_jwt)
+        user_jwt = _login(client, USER)
+        resp = client.delete(
+            f"/api/v1/consents/{cid}",
+            headers={"Authorization": f"Bearer {user_jwt}"},
+        )
+        assert resp.status_code == 403
+
+    def test_no_auth_returns_401(self, client: TestClient) -> None:
+        resp = client.delete("/api/v1/consents/anything")
+        assert resp.status_code == 401
+
+
+class TestRevokedDropsFromActiveList:
+    def test_revoked_consent_hidden_unless_include_expired(self, client: TestClient) -> None:
+        jwt = _login(client, ADMIN)
+        cid = _sign(client, jwt)
+        client.delete(
+            f"/api/v1/consents/{cid}",
+            headers={"Authorization": f"Bearer {jwt}"},
+        )
+        active = client.get(
+            "/api/v1/consents",
+            headers={"Authorization": f"Bearer {jwt}"},
+        ).json()
+        # The "expires_at = now" row still appears as active because
+        # the SQL filter is "expires_at > now"; but on any later request
+        # it'll have aged out. Allow either count here, but with
+        # include_expired=true it must show.
+        assert active["count"] in (0, 1)
+        all_ = client.get(
+            "/api/v1/consents",
+            headers={"Authorization": f"Bearer {jwt}"},
+            params={"include_expired": True},
+        ).json()
+        cids = {c["consent_id"] for c in all_["consents"]}
+        assert cid in cids

--- a/server/backend/tests/test_consents_sign.py
+++ b/server/backend/tests/test_consents_sign.py
@@ -1,0 +1,298 @@
+"""Phase 6 step 3 / Lane D: POST /consents/sign tests.
+
+Pins:
+  - Happy path inserts a consent + paired audit row.
+  - Intra-Enterprise (req_ent == resp_ent) returns 422.
+  - Unsupported policies return 422.
+  - Duplicate active consent for same tuple returns 409.
+  - Admin-only — non-admin users get 403.
+  - expires_at is honored (not echoed as the row's signed_at).
+"""
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import bcrypt
+import pytest
+from fastapi.testclient import TestClient
+
+from cq_server.app import _get_store, app
+
+ADMIN = "admin@acme"
+USER = "regular-user"
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "consents.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    with TestClient(app) as c:
+        store = _get_store()
+        pw = bcrypt.hashpw(b"pw", bcrypt.gensalt()).decode()
+        store.create_user(ADMIN, pw)
+        store.create_user(USER, pw)
+        store.set_user_role(ADMIN, "admin")
+        yield c
+
+
+def _login(client: TestClient, username: str) -> str:
+    resp = client.post(
+        "/api/v1/auth/login",
+        json={"username": username, "password": "pw"},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+class TestSignHappyPath:
+    def test_sign_returns_201_and_inserts_row(self, client: TestClient) -> None:
+        jwt = _login(client, ADMIN)
+        resp = client.post(
+            "/api/v1/consents/sign",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={
+                "requester_enterprise": "initech",
+                "responder_enterprise": "acme",
+                "requester_group": "engineering",
+                "responder_group": "engineering",
+                "policy": "summary_only",
+                "expires_at": "2027-04-30T00:00:00+00:00",
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["consent_id"].startswith("consent_")
+        assert body["signed_by_admin"] == ADMIN
+        assert body["audit_log_id"].startswith("aud_")
+        # Row landed.
+        store = _get_store()
+        row = store.get_cross_enterprise_consent(body["consent_id"])
+        assert row is not None
+        assert row["requester_enterprise"] == "initech"
+        assert row["responder_enterprise"] == "acme"
+        assert row["policy"] == "summary_only"
+        assert row["expires_at"] == "2027-04-30T00:00:00+00:00"
+
+    def test_sign_writes_paired_audit_row(self, client: TestClient) -> None:
+        jwt = _login(client, ADMIN)
+        resp = client.post(
+            "/api/v1/consents/sign",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={
+                "requester_enterprise": "initech",
+                "responder_enterprise": "acme",
+                "policy": "summary_only",
+            },
+        )
+        assert resp.status_code == 201
+        consent_id = resp.json()["consent_id"]
+        store = _get_store()
+        with store._lock:
+            rows = store._conn.execute(
+                "SELECT policy_applied, consent_id FROM cross_l2_audit "
+                "WHERE consent_id = ?",
+                (consent_id,),
+            ).fetchall()
+        assert len(rows) == 1
+        assert rows[0][0] == "consent_signed"
+
+
+class TestSignValidation:
+    def test_intra_enterprise_returns_422(self, client: TestClient) -> None:
+        jwt = _login(client, ADMIN)
+        resp = client.post(
+            "/api/v1/consents/sign",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={
+                "requester_enterprise": "acme",
+                "responder_enterprise": "acme",
+                "policy": "summary_only",
+            },
+        )
+        assert resp.status_code == 422
+        assert "two distinct" in resp.json()["detail"]
+
+    def test_unsupported_policy_returns_422(self, client: TestClient) -> None:
+        jwt = _login(client, ADMIN)
+        resp = client.post(
+            "/api/v1/consents/sign",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={
+                "requester_enterprise": "initech",
+                "responder_enterprise": "acme",
+                "policy": "full_body",
+            },
+        )
+        assert resp.status_code == 422
+        assert "summary_only" in resp.json()["detail"]
+
+
+class TestSignDuplicate:
+    def test_duplicate_active_tuple_returns_409(self, client: TestClient) -> None:
+        jwt = _login(client, ADMIN)
+        first = client.post(
+            "/api/v1/consents/sign",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={
+                "requester_enterprise": "initech",
+                "responder_enterprise": "acme",
+                "requester_group": "rd",
+                "responder_group": "engineering",
+                "policy": "summary_only",
+            },
+        )
+        assert first.status_code == 201
+        second = client.post(
+            "/api/v1/consents/sign",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={
+                "requester_enterprise": "initech",
+                "responder_enterprise": "acme",
+                "requester_group": "rd",
+                "responder_group": "engineering",
+                "policy": "summary_only",
+            },
+        )
+        assert second.status_code == 409
+        assert first.json()["consent_id"] in second.json()["detail"]
+
+    def test_different_group_pair_is_not_duplicate(self, client: TestClient) -> None:
+        jwt = _login(client, ADMIN)
+        a = client.post(
+            "/api/v1/consents/sign",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={
+                "requester_enterprise": "initech",
+                "responder_enterprise": "acme",
+                "requester_group": "rd",
+                "responder_group": "engineering",
+                "policy": "summary_only",
+            },
+        )
+        b = client.post(
+            "/api/v1/consents/sign",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={
+                "requester_enterprise": "initech",
+                "responder_enterprise": "acme",
+                "requester_group": "rd",
+                "responder_group": "solutions",  # different
+                "policy": "summary_only",
+            },
+        )
+        assert a.status_code == 201
+        assert b.status_code == 201
+
+    def test_wildcard_and_specific_can_coexist(self, client: TestClient) -> None:
+        jwt = _login(client, ADMIN)
+        wild = client.post(
+            "/api/v1/consents/sign",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={
+                "requester_enterprise": "initech",
+                "responder_enterprise": "acme",
+                "policy": "summary_only",  # null wildcards
+            },
+        )
+        specific = client.post(
+            "/api/v1/consents/sign",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={
+                "requester_enterprise": "initech",
+                "responder_enterprise": "acme",
+                "requester_group": "rd",
+                "responder_group": "engineering",
+                "policy": "summary_only",
+            },
+        )
+        assert wild.status_code == 201
+        assert specific.status_code == 201
+
+
+class TestSignAuth:
+    def test_non_admin_returns_403(self, client: TestClient) -> None:
+        jwt = _login(client, USER)
+        resp = client.post(
+            "/api/v1/consents/sign",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={
+                "requester_enterprise": "initech",
+                "responder_enterprise": "acme",
+                "policy": "summary_only",
+            },
+        )
+        assert resp.status_code == 403
+
+    def test_no_auth_returns_401(self, client: TestClient) -> None:
+        resp = client.post(
+            "/api/v1/consents/sign",
+            json={
+                "requester_enterprise": "initech",
+                "responder_enterprise": "acme",
+                "policy": "summary_only",
+            },
+        )
+        assert resp.status_code == 401
+
+
+class TestList:
+    def test_list_returns_signed_consents(self, client: TestClient) -> None:
+        jwt = _login(client, ADMIN)
+        client.post(
+            "/api/v1/consents/sign",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={
+                "requester_enterprise": "initech",
+                "responder_enterprise": "acme",
+                "policy": "summary_only",
+            },
+        )
+        resp = client.get(
+            "/api/v1/consents",
+            headers={"Authorization": f"Bearer {jwt}"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["count"] == 1
+        assert body["consents"][0]["responder_enterprise"] == "acme"
+
+    def test_list_excludes_expired_by_default(self, client: TestClient) -> None:
+        jwt = _login(client, ADMIN)
+        # Sign + then manually backdate expires_at into the past.
+        signed = client.post(
+            "/api/v1/consents/sign",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={
+                "requester_enterprise": "initech",
+                "responder_enterprise": "acme",
+                "policy": "summary_only",
+            },
+        )
+        cid = signed.json()["consent_id"]
+        store = _get_store()
+        with store._lock, store._conn:
+            store._conn.execute(
+                "UPDATE cross_enterprise_consents SET expires_at = ? WHERE consent_id = ?",
+                ("2020-01-01T00:00:00+00:00", cid),
+            )
+        active = client.get(
+            "/api/v1/consents",
+            headers={"Authorization": f"Bearer {jwt}"},
+        ).json()
+        assert active["count"] == 0
+        all_ = client.get(
+            "/api/v1/consents",
+            headers={"Authorization": f"Bearer {jwt}"},
+            params={"include_expired": True},
+        ).json()
+        assert all_["count"] == 1
+
+    def test_list_requires_admin(self, client: TestClient) -> None:
+        jwt = _login(client, USER)
+        resp = client.get(
+            "/api/v1/consents",
+            headers={"Authorization": f"Bearer {jwt}"},
+        )
+        assert resp.status_code == 403

--- a/server/backend/tests/test_migration_0003_presence.py
+++ b/server/backend/tests/test_migration_0003_presence.py
@@ -1,0 +1,171 @@
+"""Phase 6 step 3: Alembic migration smoke-test.
+
+Mirrors the pattern in ``test_migration_0002_xgroup_consent.py``. Runs
+``alembic upgrade head`` and ``alembic downgrade base`` against both an
+empty DB and a populated legacy DB; both cycles must complete without
+raising and end with the expected schema.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _run_alembic(db_path: Path, command: str, target: str) -> subprocess.CompletedProcess[str]:
+    repo_root = Path(__file__).resolve().parents[1]
+    return subprocess.run(
+        ["uv", "run", "alembic", command, target],
+        cwd=str(repo_root),
+        env={
+            "PATH": os.environ.get("PATH", ""),
+            "CQ_DB_PATH": str(db_path),
+            "HOME": str(Path.home()),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?", (name,)
+    ).fetchone()
+    return row is not None
+
+
+def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return any(r[1] == column for r in rows)
+
+
+class TestUpgradeDowngradeEmpty:
+    def test_upgrade_then_downgrade_clean_on_empty_db(self, tmp_path: Path) -> None:
+        db = tmp_path / "alembic_empty.db"
+        sqlite3.connect(str(db)).close()  # touch
+
+        up = _run_alembic(db, "upgrade", "head")
+        assert up.returncode == 0, f"upgrade failed:\n{up.stderr}\n{up.stdout}"
+
+        check = sqlite3.connect(str(db))
+        try:
+            assert _table_exists(check, "peers")
+            # peers indexes exist.
+            idx_rows = check.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='peers'"
+            ).fetchall()
+            idx_names = {r[0] for r in idx_rows}
+            assert "idx_peers_enterprise_group" in idx_names
+            assert "idx_peers_last_seen" in idx_names
+            # If users exists (it doesn't on a truly-empty DB — runtime
+            # creates it lazily), then role exists too.
+            if _table_exists(check, "users"):
+                assert _column_exists(check, "users", "role")
+        finally:
+            check.close()
+
+        down = _run_alembic(db, "downgrade", "base")
+        assert down.returncode == 0, f"downgrade failed:\n{down.stderr}\n{down.stdout}"
+
+        check = sqlite3.connect(str(db))
+        try:
+            assert not _table_exists(check, "peers")
+        finally:
+            check.close()
+
+
+class TestUpgradeOnLegacyDb:
+    def test_upgrade_on_populated_legacy_db_adds_role_and_peers(
+        self, tmp_path: Path
+    ) -> None:
+        db = tmp_path / "alembic_legacy.db"
+        # Pre-step-1 shape: minimal users/knowledge_units, no tenancy /
+        # xgroup / role columns. Seed one user so the role-backfill is
+        # exercised.
+        conn = sqlite3.connect(str(db))
+        conn.executescript(
+            """
+            CREATE TABLE knowledge_units (id TEXT PRIMARY KEY, data TEXT NOT NULL);
+            CREATE TABLE users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT NOT NULL UNIQUE,
+                password_hash TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            );
+            INSERT INTO users (username, password_hash, created_at)
+                VALUES ('legacy-user', 'hash', '2024-01-01T00:00:00+00:00');
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        up = _run_alembic(db, "upgrade", "head")
+        assert up.returncode == 0, f"upgrade failed:\n{up.stderr}\n{up.stdout}"
+
+        check = sqlite3.connect(str(db))
+        try:
+            # All three migration steps applied.
+            assert _column_exists(check, "knowledge_units", "enterprise_id")
+            assert _column_exists(check, "knowledge_units", "cross_group_allowed")
+            assert _column_exists(check, "users", "role")
+            assert _table_exists(check, "peers")
+            # Backfill: legacy user gets role='user'.
+            row = check.execute(
+                "SELECT role FROM users WHERE username = 'legacy-user'"
+            ).fetchone()
+            assert row is not None
+            assert row[0] == "user"
+        finally:
+            check.close()
+
+
+class TestStepwiseUpgrade:
+    """0001 -> 0002 -> 0003 must apply in order."""
+
+    def test_upgrade_to_0002_then_head(self, tmp_path: Path) -> None:
+        db = tmp_path / "alembic_stepwise.db"
+        sqlite3.connect(str(db)).close()
+
+        first = _run_alembic(db, "upgrade", "0002_phase6_step2")
+        assert first.returncode == 0, f"step 2 upgrade failed:\n{first.stderr}\n{first.stdout}"
+
+        # peers must NOT exist yet.
+        check = sqlite3.connect(str(db))
+        try:
+            assert not _table_exists(check, "peers")
+        finally:
+            check.close()
+
+        second = _run_alembic(db, "upgrade", "head")
+        assert second.returncode == 0, f"step 3 upgrade failed:\n{second.stderr}\n{second.stdout}"
+
+        check = sqlite3.connect(str(db))
+        try:
+            assert _table_exists(check, "peers")
+        finally:
+            check.close()
+
+
+@pytest.mark.parametrize("invalid_dir", [None])
+def test_alembic_history_includes_0003(invalid_dir: object) -> None:
+    """Sanity: alembic history shows 0003 chained off 0002."""
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        ["uv", "run", "alembic", "history"],
+        cwd=str(repo_root),
+        env={
+            "PATH": os.environ.get("PATH", ""),
+            "HOME": str(Path.home()),
+            "CQ_DB_PATH": "/tmp/cq-alembic-history-check-0003.db",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "0002_phase6_step2" in result.stdout
+    assert "0003_phase6_step3" in result.stdout

--- a/server/backend/tests/test_peers_active.py
+++ b/server/backend/tests/test_peers_active.py
@@ -1,0 +1,174 @@
+"""Phase 6 step 3 / Lane C: GET /peers/active scoping + filter tests.
+
+Pins:
+  - Cross-Enterprise visibility is silently dropped (presence is
+    Enterprise-bounded, even if a consent record is in place).
+  - since_minutes filters out stale rows.
+  - discoverable=False rows are hidden regardless of last_seen_at.
+  - group filter narrows within the same Enterprise.
+  - include_self=False + self_persona excludes the caller's own row.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import bcrypt
+import pytest
+from fastapi.testclient import TestClient
+
+from cq_server.app import _get_store, app
+from cq_server.deps import require_api_key
+
+ALICE = "alice"  # acme/engineering
+BOB = "bob"      # acme/solutions
+CARLA = "carla"  # initech/r-and-d (cross-Enterprise)
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "peers_active.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    with TestClient(app) as c:
+        store = _get_store()
+        pw = bcrypt.hashpw(b"pw", bcrypt.gensalt()).decode()
+        store.create_user(ALICE, pw)
+        store.create_user(BOB, pw)
+        store.create_user(CARLA, pw)
+        with store._lock, store._conn:
+            store._conn.execute(
+                "UPDATE users SET enterprise_id = 'acme', group_id = 'engineering' WHERE username = ?",
+                (ALICE,),
+            )
+            store._conn.execute(
+                "UPDATE users SET enterprise_id = 'acme', group_id = 'solutions' WHERE username = ?",
+                (BOB,),
+            )
+            store._conn.execute(
+                "UPDATE users SET enterprise_id = 'initech', group_id = 'r-and-d' WHERE username = ?",
+                (CARLA,),
+            )
+        yield c
+
+
+def _heartbeat(client: TestClient, *, as_user: str, persona: str, discoverable: bool = True) -> None:
+    app.dependency_overrides[require_api_key] = lambda: as_user
+    try:
+        client.post(
+            "/api/v1/peers/heartbeat",
+            json={"persona": persona, "discoverable": discoverable},
+        )
+    finally:
+        app.dependency_overrides.pop(require_api_key, None)
+
+
+def _set_last_seen(persona: str, when: datetime) -> None:
+    """Manually rewind a row's ``last_seen_at`` to test the since filter."""
+    store = _get_store()
+    with store._lock, store._conn:
+        store._conn.execute(
+            "UPDATE peers SET last_seen_at = ? WHERE persona = ?",
+            (when.isoformat(), persona),
+        )
+
+
+def _list_active(client: TestClient, *, as_user: str, **params: object) -> dict:
+    app.dependency_overrides[require_api_key] = lambda: as_user
+    try:
+        resp = client.get("/api/v1/peers/active", params=params)
+    finally:
+        app.dependency_overrides.pop(require_api_key, None)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+class TestEnterpriseScoping:
+    def test_cross_enterprise_returns_nothing(self, client: TestClient) -> None:
+        # Alice (acme) registers; Carla (initech) lists. She must not see
+        # Alice — even though they're both alive, presence is bounded.
+        _heartbeat(client, as_user=ALICE, persona="persona-alice")
+        body = _list_active(client, as_user=CARLA)
+        assert body["count"] == 0
+        assert body["active_peers"] == []
+
+    def test_same_enterprise_different_group_visible(self, client: TestClient) -> None:
+        # Alice in acme/engineering; Bob in acme/solutions. Both see each other.
+        _heartbeat(client, as_user=ALICE, persona="persona-alice")
+        _heartbeat(client, as_user=BOB, persona="persona-bob")
+        body = _list_active(client, as_user=ALICE, include_self=True)
+        personas = {p["persona"] for p in body["active_peers"]}
+        assert {"persona-alice", "persona-bob"} == personas
+
+
+class TestSinceMinutesFilter:
+    def test_stale_rows_dropped(self, client: TestClient) -> None:
+        _heartbeat(client, as_user=ALICE, persona="persona-fresh")
+        _heartbeat(client, as_user=ALICE, persona="persona-stale")
+        # Rewind persona-stale 30 min into the past.
+        _set_last_seen("persona-stale", datetime.now(UTC) - timedelta(minutes=30))
+        # Default since_minutes = 15; persona-stale should drop out.
+        body = _list_active(client, as_user=ALICE, include_self=True)
+        personas = {p["persona"] for p in body["active_peers"]}
+        assert "persona-fresh" in personas
+        assert "persona-stale" not in personas
+
+    def test_widened_window_includes_stale(self, client: TestClient) -> None:
+        _heartbeat(client, as_user=ALICE, persona="persona-stale")
+        _set_last_seen("persona-stale", datetime.now(UTC) - timedelta(minutes=30))
+        body = _list_active(client, as_user=ALICE, include_self=True, since_minutes=60)
+        personas = {p["persona"] for p in body["active_peers"]}
+        assert "persona-stale" in personas
+
+
+class TestDiscoverableFilter:
+    def test_undiscoverable_rows_hidden(self, client: TestClient) -> None:
+        _heartbeat(client, as_user=ALICE, persona="persona-public", discoverable=True)
+        _heartbeat(client, as_user=ALICE, persona="persona-private", discoverable=False)
+        body = _list_active(client, as_user=ALICE, include_self=True)
+        personas = {p["persona"] for p in body["active_peers"]}
+        assert "persona-public" in personas
+        assert "persona-private" not in personas
+
+
+class TestGroupFilter:
+    def test_group_param_narrows_to_one_group(self, client: TestClient) -> None:
+        _heartbeat(client, as_user=ALICE, persona="persona-alice")  # acme/engineering
+        _heartbeat(client, as_user=BOB, persona="persona-bob")      # acme/solutions
+        body = _list_active(client, as_user=ALICE, include_self=True, group="solutions")
+        personas = {p["persona"] for p in body["active_peers"]}
+        assert personas == {"persona-bob"}
+
+
+class TestIncludeSelf:
+    def test_self_excluded_by_default_when_persona_passed(self, client: TestClient) -> None:
+        _heartbeat(client, as_user=ALICE, persona="persona-me")
+        _heartbeat(client, as_user=ALICE, persona="persona-other")
+        body = _list_active(
+            client, as_user=ALICE, include_self=False, self_persona="persona-me"
+        )
+        personas = {p["persona"] for p in body["active_peers"]}
+        assert "persona-me" not in personas
+        assert "persona-other" in personas
+
+    def test_include_self_true_returns_self(self, client: TestClient) -> None:
+        _heartbeat(client, as_user=ALICE, persona="persona-me")
+        body = _list_active(
+            client, as_user=ALICE, include_self=True, self_persona="persona-me"
+        )
+        personas = {p["persona"] for p in body["active_peers"]}
+        assert "persona-me" in personas
+
+
+class TestResponseShape:
+    def test_minutes_since_last_seen_is_non_negative_float(self, client: TestClient) -> None:
+        _heartbeat(client, as_user=ALICE, persona="persona-shape")
+        body = _list_active(client, as_user=ALICE, include_self=True)
+        assert body["count"] == 1
+        peer = body["active_peers"][0]
+        assert peer["enterprise_id"] == "acme"
+        assert peer["group_id"] == "engineering"
+        assert peer["discoverable"] is True
+        assert isinstance(peer["minutes_since_last_seen"], float)
+        assert peer["minutes_since_last_seen"] >= 0.0

--- a/server/backend/tests/test_peers_heartbeat.py
+++ b/server/backend/tests/test_peers_heartbeat.py
@@ -1,0 +1,201 @@
+"""Phase 6 step 3 / Lane C: presence heartbeat upsert tests.
+
+Pins:
+  - First heartbeat inserts; subsequent heartbeats update last_seen_at.
+  - expertise_domains JSON-roundtrips (list in -> list out, null stays null).
+  - tenancy scope is resolved from the API key's owning user, never trusted
+    from the request body.
+  - persona is the primary key — two heartbeats with the same persona
+    end up as one row.
+"""
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import bcrypt
+import pytest
+from fastapi.testclient import TestClient
+
+from cq_server.app import _get_store, app
+from cq_server.deps import require_api_key
+
+ALICE = "alice"
+BOB = "bob"
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "peers_heartbeat.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    with TestClient(app) as c:
+        # Bootstrap two users in distinct enterprise/group pairs so the
+        # tenancy-scope test can confirm the resolved scope follows the
+        # auth user, not the request body.
+        store = _get_store()
+        pw = bcrypt.hashpw(b"pw", bcrypt.gensalt()).decode()
+        store.create_user(ALICE, pw)
+        store.create_user(BOB, pw)
+        # Promote Alice to a foreign tenancy scope. Bob stays default.
+        with store._lock, store._conn:
+            store._conn.execute(
+                "UPDATE users SET enterprise_id = 'acme', group_id = 'engineering' "
+                "WHERE username = ?",
+                (ALICE,),
+            )
+        yield c
+
+
+def _override_api_key(username: str) -> None:
+    app.dependency_overrides[require_api_key] = lambda: username
+
+
+def _clear_override() -> None:
+    app.dependency_overrides.pop(require_api_key, None)
+
+
+class TestHeartbeatUpsert:
+    def test_first_heartbeat_inserts_row(self, client: TestClient) -> None:
+        _override_api_key(ALICE)
+        try:
+            resp = client.post(
+                "/api/v1/peers/heartbeat",
+                json={
+                    "persona": "persona-cloudfront-asker",
+                    "discoverable": True,
+                    "working_dir_hint": "investigating CloudFront 403s",
+                    "expertise_domains": ["aws", "cloudfront", "security"],
+                },
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["persona"] == "persona-cloudfront-asker"
+            assert body["next_heartbeat_in_seconds"] == 300
+            assert body["registered_at"]  # non-empty ISO timestamp
+        finally:
+            _clear_override()
+
+    def test_second_heartbeat_advances_last_seen_at(self, client: TestClient) -> None:
+        _override_api_key(ALICE)
+        try:
+            r1 = client.post(
+                "/api/v1/peers/heartbeat",
+                json={"persona": "persona-x", "discoverable": True},
+            )
+            r2 = client.post(
+                "/api/v1/peers/heartbeat",
+                json={"persona": "persona-x", "discoverable": True},
+            )
+            assert r1.status_code == r2.status_code == 200
+            # The second registered_at should be >= the first; ISO-8601
+            # comparison is lexicographic for fixed-width UTC strings.
+            assert r2.json()["registered_at"] >= r1.json()["registered_at"]
+            # And there should be exactly one row in the DB.
+            store = _get_store()
+            with store._lock:
+                count = store._conn.execute(
+                    "SELECT COUNT(*) FROM peers WHERE persona = 'persona-x'"
+                ).fetchone()[0]
+            assert count == 1
+        finally:
+            _clear_override()
+
+
+class TestTenancyResolvedFromAuth:
+    def test_scope_follows_auth_user_not_body(self, client: TestClient) -> None:
+        _override_api_key(ALICE)
+        try:
+            client.post(
+                "/api/v1/peers/heartbeat",
+                json={"persona": "persona-alice", "discoverable": True},
+            )
+        finally:
+            _clear_override()
+        store = _get_store()
+        with store._lock:
+            row = store._conn.execute(
+                "SELECT enterprise_id, group_id FROM peers WHERE persona = ?",
+                ("persona-alice",),
+            ).fetchone()
+        assert row == ("acme", "engineering")
+
+    def test_two_users_same_persona_overwrites_scope(self, client: TestClient) -> None:
+        # Alice (acme/engineering) registers persona-shared; then Bob
+        # (default-enterprise/default-group) registers the same persona
+        # name. Persona is the PK, so the row reflects the latest writer.
+        _override_api_key(ALICE)
+        try:
+            client.post(
+                "/api/v1/peers/heartbeat",
+                json={"persona": "persona-shared", "discoverable": True},
+            )
+        finally:
+            _clear_override()
+        _override_api_key(BOB)
+        try:
+            client.post(
+                "/api/v1/peers/heartbeat",
+                json={"persona": "persona-shared", "discoverable": True},
+            )
+        finally:
+            _clear_override()
+        store = _get_store()
+        with store._lock:
+            row = store._conn.execute(
+                "SELECT enterprise_id, group_id FROM peers WHERE persona = ?",
+                ("persona-shared",),
+            ).fetchone()
+        # Bob's scope wins as the latest writer.
+        assert row == ("default-enterprise", "default-group")
+
+
+class TestExpertiseDomainsRoundtrip:
+    def test_list_roundtrips_through_json(self, client: TestClient) -> None:
+        _override_api_key(ALICE)
+        try:
+            client.post(
+                "/api/v1/peers/heartbeat",
+                json={
+                    "persona": "persona-domains",
+                    "discoverable": True,
+                    "expertise_domains": ["aws", "lambda", "cold-start"],
+                },
+            )
+        finally:
+            _clear_override()
+        store = _get_store()
+        with store._lock:
+            row = store._conn.execute(
+                "SELECT expertise_domains FROM peers WHERE persona = ?",
+                ("persona-domains",),
+            ).fetchone()
+        assert json.loads(row[0]) == ["aws", "lambda", "cold-start"]
+
+    def test_null_expertise_domains_stays_null(self, client: TestClient) -> None:
+        _override_api_key(ALICE)
+        try:
+            client.post(
+                "/api/v1/peers/heartbeat",
+                json={"persona": "persona-no-domains", "discoverable": True},
+            )
+        finally:
+            _clear_override()
+        store = _get_store()
+        with store._lock:
+            row = store._conn.execute(
+                "SELECT expertise_domains FROM peers WHERE persona = ?",
+                ("persona-no-domains",),
+            ).fetchone()
+        assert row[0] is None
+
+
+class TestAuthRequired:
+    def test_no_api_key_returns_401(self, client: TestClient) -> None:
+        # No override; the require_api_key dep should reject.
+        resp = client.post(
+            "/api/v1/peers/heartbeat",
+            json={"persona": "persona-naked", "discoverable": True},
+        )
+        assert resp.status_code == 401


### PR DESCRIPTION
## Summary

Lanes C and D of the live-network-demo plan, shipped together because both touch `app.py`, `tables.py`, and `store/`. Refs `docs/plans/08-live-network-demo.md` (Lanes C+D) on `OneZero1ai/crosstalk-enterprise`.

### Lane C — presence registry

A 5-min heartbeat surface that keeps a `peers` table fresh per L2; the demo frontend reads `/peers/active` to show "live agents per L2."

- New `peers` table keyed by `persona` (PK), with `enterprise_id` / `group_id` resolved from the auth user — never trusted from the request body.
- `POST /api/v1/peers/heartbeat` — API-key auth; UPSERTs `last_seen_at` + opt-in metadata (`discoverable`, `working_dir_hint`, `expertise_domains`); returns `next_heartbeat_in_seconds: 300`.
- `GET /api/v1/peers/active` — API-key auth; Enterprise-scoped listing with `?group`, `?since_minutes`, `?include_self`, `?self_persona`. Cross-Enterprise visibility is silently dropped even when a consent record is in place — presence is its own privacy plane (consent unlocks knowledge access, not who's online).

### Lane D — consent admin endpoints

The DB layer was already shipped in PR #11 (`insert_cross_enterprise_consent`); this is the HTTP wrapper an admin uses to sign/list/revoke.

- New `users.role` column (default `'user'`) + `require_admin` dep in `auth.py`. Admin scope is global in v1 — per-Enterprise admin is deferred.
- `POST /api/v1/consents/sign` — admin-only; 422 on intra-Enterprise pair or unsupported policy; 409 on duplicate active tuple; writes a paired `cross_l2_audit` row with `policy_applied='consent_signed'`.
- `GET /api/v1/consents` — admin-only; `?include_expired`, `?limit`; newest-first.
- `DELETE /api/v1/consents/{id}` — admin-only; soft-revoke (advances `expires_at` to now); paired audit row with `policy_applied='consent_revoked'`; 404 on unknown id.

### Schema

Additive only. Migration `0003_phase6_step3_presence.py` adds `users.role` + `peers` table + indexes (`idx_peers_enterprise_group`, `idx_peers_last_seen`). Runtime `ensure_user_role_column` + `ensure_peers_schema` helpers run on every startup so legacy DBs converge with the Alembic-first DB.

### Tests

- `test_peers_heartbeat.py` (8 tests) — UPSERT, last_seen advances, JSON roundtrip, tenancy resolved from auth, auth required.
- `test_peers_active.py` (8 tests) — Enterprise scoping (cross-Enterprise empty), since_minutes filter, discoverable filter, group filter, include_self / self_persona.
- `test_consents_sign.py` (12 tests) — happy path + audit pairing, 422 intra-Enterprise / bad policy, 409 duplicate, wildcard + specific coexist, admin-only auth, list filters expired.
- `test_consents_revoke.py` (6 tests) — soft-delete, audit row written, 404 unknown, 403 non-admin, drop from active list.
- `test_migration_0003_presence.py` (4 tests) — empty + legacy DB upgrade/downgrade, stepwise 0002 -> 0003, history check.

255 baseline tests still pass; total: **293 passed**.

## Test plan

- [x] `pytest tests/` — 293 passed (255 baseline + 38 new)
- [x] `alembic upgrade head` works on empty DB and on legacy pre-step-1 DB
- [x] `alembic downgrade base` cleans up
- [x] `ruff check` — no new errors introduced (8 pre-existing in app.py from PR #11)
- [ ] Wire frontend to `/peers/active` in Lane E (follow-up PR)
- [ ] Add heartbeat hook to `8l-cq` fragment / claude-mux side (follow-up; out of scope per plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)