### PR TITLE
[server] /api/v1/network/* — topology aggregation, DSN resolve, demo orchestration

### DIFF
--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -27,6 +27,7 @@ from .auth import router as auth_router
 from .deps import API_KEY_PEPPER_ENV, require_api_key
 from .embed import compose_text, embed_text
 from .embed import model_id as embed_model_id
+from .network import router as network_router
 from .quality import check_propose_quality
 from .review import router as review_router
 from .scoring import apply_confirmation, apply_flag
@@ -214,6 +215,7 @@ async def lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
 api_router = APIRouter()
 api_router.include_router(auth_router)
 api_router.include_router(review_router)
+api_router.include_router(network_router)
 
 
 @api_router.get("/health")

--- a/server/backend/src/cq_server/network.py
+++ b/server/backend/src/cq_server/network.py
@@ -1,0 +1,1020 @@
+"""Network-demo proxy endpoints — Lane H/I/J support.
+
+This module aggregates calls across the live 6-L2 fleet for the
+``/network`` page in the frontend. It owns three POST endpoints:
+
+* ``/api/v1/network/topology`` — fan-out aggregator that calls each L2's
+  ``/aigrp/peers``, ``/aigrp/signature``, and ``/peers/active`` and folds
+  the result into the ``TopologyResponse`` shape the frontend types
+  declare. Cached in-process for 3 seconds to damp the 5s poll cadence.
+* ``/api/v1/network/dsn/resolve`` — DSN-style intent resolver. Embeds the
+  free-text intent via Bedrock Titan, fans out to every L2's
+  ``/aigrp/signature`` to recover its centroid, ranks by cosine
+  similarity, returns top-N candidates with the policy that *would* be
+  applied if the caller forwarded a query.
+* ``/api/v1/network/demo/{scenario}`` — three deterministic packet-trace
+  scenarios that exercise the live fleet end-to-end (cross-Group,
+  cross-Enterprise blocked, cross-Enterprise consented). Returns a list
+  of trace events the frontend animates as a packet flow over the
+  topology graph.
+
+The module is the only place the FLEET_L2S table lives today; a future
+PR can move it into env-var or DB config.
+
+Auth is the standard JWT dep (``get_current_user``) — these endpoints
+expose network-operations metadata, not raw KU bodies, so any logged-in
+user can see them. The fan-out itself authenticates to each L2 with the
+per-Enterprise peer key (read from SSM Parameter Store at startup) for
+``/aigrp/*`` and an admin-issued JWT for ``/peers/active``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+import os
+import struct
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from .auth import create_token, get_current_user
+from .deps import get_store
+from .embed import embed_text, unpack
+from .store import RemoteStore
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Fleet roster — the 6 L2s the demo aggregates over.
+#
+# Hardcoded in-module for now. Each row carries the slug used in API
+# requests, the Enterprise/Group it belongs to, and the ALB endpoint the
+# proxy will fan out to. Future PR can move this to env vars.
+# ---------------------------------------------------------------------------
+
+FLEET_L2S: list[dict[str, str]] = [
+    {
+        "slug": "orion-eng",
+        "enterprise": "orion",
+        "group": "engineering",
+        "endpoint": "http://test-ori-Alb-uYtCiM8iwUDE-1537178551.us-east-1.elb.amazonaws.com",
+    },
+    {
+        "slug": "orion-sol",
+        "enterprise": "orion",
+        "group": "solutions",
+        "endpoint": "http://test-ori-Alb-iWhYcfoCeuHA-164324034.us-east-1.elb.amazonaws.com",
+    },
+    {
+        "slug": "orion-gtm",
+        "enterprise": "orion",
+        "group": "gtm",
+        "endpoint": "http://test-ori-Alb-D7CVfG04aGRc-778844735.us-east-1.elb.amazonaws.com",
+    },
+    {
+        "slug": "acme-eng",
+        "enterprise": "acme",
+        "group": "engineering",
+        "endpoint": "http://test-acm-Alb-w0Eq2rO5MeVM-1954810296.us-east-1.elb.amazonaws.com",
+    },
+    {
+        "slug": "acme-sol",
+        "enterprise": "acme",
+        "group": "solutions",
+        "endpoint": "http://test-acm-Alb-jIOoMinF94dR-73889023.us-east-1.elb.amazonaws.com",
+    },
+    {
+        "slug": "acme-fin",
+        "enterprise": "acme",
+        "group": "finance",
+        "endpoint": "http://test-acm-Alb-3z1VuBmK1VDX-1994393375.us-east-1.elb.amazonaws.com",
+    },
+]
+
+
+L2_FANOUT_TIMEOUT_SECONDS = 10.0
+TOPOLOGY_CACHE_TTL_SECONDS = 3.0
+
+
+# ---------------------------------------------------------------------------
+# SSM peer-key resolution.
+#
+# Per-Enterprise shared secrets live at /8l-aigrp/<enterprise>/peer-key as
+# SecureStrings. We pull them once at first call and cache; tests bypass
+# via _PEER_KEY_OVERRIDES (monkeypatchable).
+# ---------------------------------------------------------------------------
+
+_PEER_KEY_CACHE: dict[str, str] = {}
+_PEER_KEY_OVERRIDES: dict[str, str] = {}
+
+
+def _peer_key_for(enterprise: str) -> str:
+    """Resolve the AIGRP peer key for ``enterprise`` from cache or SSM.
+
+    Returns an empty string when the key cannot be resolved — callers
+    treat that as "skip this L2" rather than failing the whole fan-out
+    so a one-Enterprise SSM outage doesn't dark-out the demo for the
+    other Enterprise.
+    """
+    if enterprise in _PEER_KEY_OVERRIDES:
+        return _PEER_KEY_OVERRIDES[enterprise]
+    if enterprise in _PEER_KEY_CACHE:
+        return _PEER_KEY_CACHE[enterprise]
+    # Local override via env (for one-shot dev, e.g. running both L2 keys
+    # under the same value during smoke tests).
+    env_key = os.environ.get(f"CQ_AIGRP_PEER_KEY_{enterprise.upper()}", "")
+    if env_key:
+        _PEER_KEY_CACHE[enterprise] = env_key
+        return env_key
+    try:
+        import boto3
+
+        ssm = boto3.client(
+            "ssm", region_name=os.environ.get("AWS_REGION", "us-east-1")
+        )
+        resp = ssm.get_parameter(
+            Name=f"/8l-aigrp/{enterprise}/peer-key",
+            WithDecryption=True,
+        )
+        value = resp["Parameter"]["Value"]
+        _PEER_KEY_CACHE[enterprise] = value
+        return value
+    except Exception:
+        logger.warning("failed to resolve peer key for enterprise=%s", enterprise)
+        _PEER_KEY_CACHE[enterprise] = ""
+        return ""
+
+
+def _admin_service_jwt() -> str:
+    """Mint a short-lived admin JWT to authenticate /peers/active calls.
+
+    Each L2 in the fleet validates this with its own ``CQ_JWT_SECRET``;
+    in dev that secret is shared, in prod each L2 gets its own and we'd
+    move to per-L2 service tokens — out of scope for this PR. Returns
+    empty string when no secret is configured.
+    """
+    secret = os.environ.get("CQ_JWT_SECRET", "")
+    if not secret:
+        return ""
+    # Username here is informational; the receiving L2 only checks
+    # signature + expiry. We send "service-network-proxy" so audit logs
+    # can identify the caller.
+    return create_token("service-network-proxy", secret=secret, ttl_hours=1)
+
+
+# ---------------------------------------------------------------------------
+# Pydantic response models.
+# ---------------------------------------------------------------------------
+
+
+class TopologyPeerEdge(BaseModel):
+    """One edge in the peer mesh — pairs a peer's L2 id with the time we last got a signature from it."""
+
+    l2_id: str
+    last_signature_at: str | None = None
+
+
+class TopologyActivePersona(BaseModel):
+    """An active persona on an L2 — wire shape for the frontend's topology view."""
+
+    persona: str
+    last_seen_at: str
+    working_dir_hint: str | None = None
+    expertise_domains: list[str] = Field(default_factory=list)
+
+
+class TopologyL2(BaseModel):
+    """One L2 row inside the topology aggregate.
+
+    ``peer_count`` is null when the L2 was unreachable during the
+    fan-out — the frontend renders such rows greyed-out rather than
+    failing the whole topology call.
+    """
+
+    l2_id: str
+    group: str
+    endpoint_url: str
+    ku_count: int = 0
+    domain_count: int = 0
+    peer_count: int | None = None
+    generated_at: str | None = None
+    peers: list[TopologyPeerEdge] = Field(default_factory=list)
+    active_personas: list[TopologyActivePersona] = Field(default_factory=list)
+
+
+class TopologyEnterprise(BaseModel):
+    """Enterprise grouping — bundles the L2s that share an Enterprise."""
+
+    enterprise: str
+    l2s: list[TopologyL2]
+
+
+class TopologyConsent(BaseModel):
+    """Cross-Enterprise consent edge for the topology view."""
+
+    requester_enterprise: str
+    responder_enterprise: str
+    requester_group: str | None = None
+    responder_group: str | None = None
+    policy: str
+    expires_at: str | None = None
+
+
+class TopologyResponse(BaseModel):
+    """Aggregated network view returned by ``POST /network/topology``."""
+
+    generated_at: str
+    enterprises: list[TopologyEnterprise]
+    cross_enterprise_consents: list[TopologyConsent] = Field(default_factory=list)
+
+
+class DsnResolveRequest(BaseModel):
+    """Request body for ``POST /network/dsn/resolve`` — the DSN search bar."""
+
+    intent: str = Field(min_length=1)
+    max_candidates: int = Field(default=5, gt=0, le=20)
+    include_consented_cross_enterprise: bool = True
+
+
+class DsnCandidate(BaseModel):
+    """One ranked L2 candidate returned by the DSN resolver."""
+
+    l2_id: str
+    enterprise: str
+    group: str
+    sim_score: float
+    ku_count_in_topic: int = 0
+    top_domains: list[str] = Field(default_factory=list)
+    expert_personas: list[str] = Field(default_factory=list)
+    policy_if_queried: str
+    policy_reason: str
+
+
+class DsnPathStep(BaseModel):
+    """One step in the DSN resolution timing breakdown."""
+
+    step: str
+    latency_ms: int
+    l2_count: int | None = None
+
+
+class DsnResolveResponse(BaseModel):
+    """Wire shape for ``POST /network/dsn/resolve``."""
+
+    intent: str
+    embedding_dims: int
+    candidates: list[DsnCandidate]
+    resolution_path: list[DsnPathStep]
+
+
+class DemoScenarioRequest(BaseModel):
+    """Body for ``POST /network/demo/{scenario}`` — caller identifies their own L2."""
+
+    requester_persona: str = Field(min_length=1)
+    requester_l2_slug: str = Field(min_length=1)
+
+
+class TraceEvent(BaseModel):
+    """One event in a demo packet trace."""
+
+    step: int
+    ts: str
+    l2_id: str
+    action: str
+    payload_preview: str = ""
+    result_summary: str = ""
+    latency_ms: int = 0
+
+
+class TraceFinalResult(BaseModel):
+    """One row of the final knowledge result returned by a demo run."""
+
+    summary: str
+    redacted_fields: list[str] = Field(default_factory=list)
+    sim_score: float = 0.0
+
+
+class TraceResponse(BaseModel):
+    """Wire shape for any of the three demo scenarios."""
+
+    scenario: str
+    started_at: str
+    completed_at: str
+    total_latency_ms: int
+    trace: list[TraceEvent]
+    final_results: list[TraceFinalResult] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Fan-out helpers.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _L2Snapshot:
+    """In-memory result of one L2's fan-out (peers + signature + active)."""
+
+    slug: str
+    enterprise: str
+    group: str
+    endpoint: str
+    peers: list[dict[str, Any]] | None = None
+    signature: dict[str, Any] | None = None
+    active_personas: list[dict[str, Any]] | None = None
+    reachable: bool = False
+
+
+async def _fetch_one_l2(client: httpx.AsyncClient, l2: dict[str, str]) -> _L2Snapshot:
+    """Fan out three calls to one L2 in parallel; return a snapshot.
+
+    Errors are swallowed individually — a partial response (e.g. peers
+    OK but /peers/active 401) still yields a valid snapshot with the
+    rest populated. Used by the topology aggregator.
+    """
+    snap = _L2Snapshot(
+        slug=l2["slug"],
+        enterprise=l2["enterprise"],
+        group=l2["group"],
+        endpoint=l2["endpoint"],
+    )
+    peer_key = _peer_key_for(l2["enterprise"])
+    admin_jwt = _admin_service_jwt()
+    base = l2["endpoint"].rstrip("/")
+    aigrp_headers = (
+        {"authorization": f"Bearer {peer_key}"} if peer_key else {}
+    )
+    admin_headers = (
+        {"authorization": f"Bearer {admin_jwt}"} if admin_jwt else {}
+    )
+
+    async def _peers() -> dict[str, Any] | None:
+        try:
+            r = await client.get(f"{base}/api/v1/aigrp/peers", headers=aigrp_headers)
+            if r.status_code == 200:
+                return r.json()
+        except Exception:
+            logger.warning("aigrp/peers fetch failed slug=%s", l2["slug"])
+        return None
+
+    async def _sig() -> dict[str, Any] | None:
+        try:
+            r = await client.get(
+                f"{base}/api/v1/aigrp/signature", headers=aigrp_headers
+            )
+            if r.status_code == 200:
+                return r.json()
+        except Exception:
+            logger.warning("aigrp/signature fetch failed slug=%s", l2["slug"])
+        return None
+
+    async def _active() -> list[dict[str, Any]] | None:
+        try:
+            r = await client.get(
+                f"{base}/api/v1/peers/active",
+                headers=admin_headers,
+                params={"include_self": "true", "since_minutes": 60},
+            )
+            if r.status_code == 200:
+                body = r.json()
+                return list(body.get("active_peers", []))
+        except Exception:
+            logger.warning("peers/active fetch failed slug=%s", l2["slug"])
+        return None
+
+    peers_res, sig_res, active_res = await asyncio.gather(
+        _peers(), _sig(), _active(), return_exceptions=False
+    )
+    if peers_res is not None:
+        snap.peers = peers_res.get("peers", [])
+        snap.reachable = True
+    if sig_res is not None:
+        snap.signature = sig_res
+        snap.reachable = True
+    if active_res is not None:
+        snap.active_personas = active_res
+    return snap
+
+
+async def _fan_out_all(fleet: list[dict[str, str]]) -> list[_L2Snapshot]:
+    """Issue parallel fan-out to every L2 in the fleet, return snapshots."""
+    timeout = httpx.Timeout(L2_FANOUT_TIMEOUT_SECONDS)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        return await asyncio.gather(*[_fetch_one_l2(client, l2) for l2 in fleet])
+
+
+# ---------------------------------------------------------------------------
+# Topology aggregator + cache.
+# ---------------------------------------------------------------------------
+
+
+_TOPOLOGY_CACHE: dict[str, Any] = {"value": None, "expires_at": 0.0}
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _build_topology(snapshots: list[_L2Snapshot], consents: list[dict[str, Any]]) -> TopologyResponse:
+    """Fold L2 snapshots + consent rows into the wire shape."""
+    by_enterprise: dict[str, list[TopologyL2]] = {}
+    for snap in snapshots:
+        sig = snap.signature or {}
+        peers = snap.peers
+        active = snap.active_personas or []
+        l2_id = sig.get("l2_id") or f"{snap.enterprise}/{snap.group}"
+        peer_edges: list[TopologyPeerEdge] = []
+        if peers is not None:
+            for p in peers:
+                if p.get("l2_id") == l2_id:
+                    continue  # skip self-row
+                peer_edges.append(
+                    TopologyPeerEdge(
+                        l2_id=p.get("l2_id", ""),
+                        last_signature_at=p.get("last_signature_at"),
+                    )
+                )
+        active_personas = [
+            TopologyActivePersona(
+                persona=row.get("persona", ""),
+                last_seen_at=row.get("last_seen_at", ""),
+                working_dir_hint=row.get("working_dir_hint"),
+                expertise_domains=list(row.get("expertise_domains") or []),
+            )
+            for row in active
+        ]
+        l2_row = TopologyL2(
+            l2_id=l2_id,
+            group=snap.group,
+            endpoint_url=snap.endpoint,
+            ku_count=int(sig.get("ku_count", 0)),
+            domain_count=int(sig.get("domain_count", 0)),
+            peer_count=(len(peers) if peers is not None else None),
+            generated_at=sig.get("computed_at"),
+            peers=peer_edges,
+            active_personas=active_personas,
+        )
+        by_enterprise.setdefault(snap.enterprise, []).append(l2_row)
+
+    enterprises = [
+        TopologyEnterprise(enterprise=name, l2s=l2s)
+        for name, l2s in sorted(by_enterprise.items())
+    ]
+    consent_rows = [
+        TopologyConsent(
+            requester_enterprise=c["requester_enterprise"],
+            responder_enterprise=c["responder_enterprise"],
+            requester_group=c.get("requester_group"),
+            responder_group=c.get("responder_group"),
+            policy=c["policy"],
+            expires_at=c.get("expires_at"),
+        )
+        for c in consents
+    ]
+    return TopologyResponse(
+        generated_at=_now_iso(),
+        enterprises=enterprises,
+        cross_enterprise_consents=consent_rows,
+    )
+
+
+# ---------------------------------------------------------------------------
+# DSN policy decisioning.
+# ---------------------------------------------------------------------------
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    """Cosine similarity between two equal-length vectors. Defensive on length mismatch."""
+    import math
+
+    n = min(len(a), len(b))
+    if n == 0:
+        return 0.0
+    dot = sum(a[i] * b[i] for i in range(n))
+    na = math.sqrt(sum(a[i] * a[i] for i in range(n)))
+    nb = math.sqrt(sum(b[i] * b[i] for i in range(n)))
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def _decode_centroid(b64_str: str | None) -> list[float] | None:
+    """Decode a base64-encoded packed-float32 centroid back into a Python list."""
+    if not b64_str:
+        return None
+    try:
+        blob = base64.b64decode(b64_str)
+        n = len(blob) // 4
+        return list(struct.unpack(f"<{n}f", blob))
+    except Exception:
+        logger.warning("failed to decode centroid")
+        return None
+
+
+def _decide_dsn_policy(
+    *,
+    caller_enterprise: str,
+    caller_group: str,
+    cand_enterprise: str,
+    cand_group: str,
+    consents: list[dict[str, Any]],
+    include_consented_cross_enterprise: bool,
+) -> tuple[str, str]:
+    """Return (policy, reason) for a candidate L2 from the caller's POV.
+
+    Mirrors the per-KU policy ladder in ``_decide_policy_for_ku`` but
+    works at the L2-level (since DSN doesn't have per-KU
+    cross_group_allowed flags to consult). The returned policy is the
+    *upper bound* — actual forward-query may downgrade if the KUs are
+    not cross-group-shareable.
+    """
+    if caller_enterprise == cand_enterprise:
+        if caller_group == cand_group:
+            return "full_body", "same_enterprise_same_group"
+        return "summary_only", "same_enterprise_xgroup_summary"
+    # Cross-Enterprise — search for a matching consent.
+    for c in consents:
+        if (
+            c.get("requester_enterprise") == caller_enterprise
+            and c.get("responder_enterprise") == cand_enterprise
+        ):
+            req_g = c.get("requester_group")
+            resp_g = c.get("responder_group")
+            if (req_g is None or req_g == caller_group) and (
+                resp_g is None or resp_g == cand_group
+            ):
+                return c.get("policy", "summary_only"), "cross_enterprise_consent"
+    if include_consented_cross_enterprise:
+        return "denied", "cross_enterprise_no_consent"
+    return "denied", "boundary"
+
+
+# ---------------------------------------------------------------------------
+# Router.
+# ---------------------------------------------------------------------------
+
+
+router = APIRouter(prefix="/network", tags=["network"])
+
+
+@router.post("/topology", response_model=TopologyResponse)
+async def network_topology(
+    _username: str = Depends(get_current_user),
+    store: RemoteStore = Depends(get_store),
+) -> TopologyResponse:
+    """Aggregate per-L2 metadata + consent edges into the topology view.
+
+    Cached in-process for ``TOPOLOGY_CACHE_TTL_SECONDS`` to damp the
+    frontend's 5s poll loop. Per-L2 failures are tolerated (rendered
+    as ``peer_count=null`` rows).
+    """
+    now = time.monotonic()
+    cached = _TOPOLOGY_CACHE.get("value")
+    if cached is not None and _TOPOLOGY_CACHE.get("expires_at", 0.0) > now:
+        return cached  # type: ignore[no-any-return]
+
+    snapshots = await _fan_out_all(FLEET_L2S)
+    consents = store.list_cross_enterprise_consents(
+        include_expired=False, now_iso=_now_iso(), limit=200
+    )
+    response = _build_topology(snapshots, consents)
+    _TOPOLOGY_CACHE["value"] = response
+    _TOPOLOGY_CACHE["expires_at"] = now + TOPOLOGY_CACHE_TTL_SECONDS
+    return response
+
+
+def _resolve_caller_scope(store: RemoteStore, username: str) -> tuple[str, str]:
+    """Pull the caller's (enterprise_id, group_id) from their user row."""
+    user = store.get_user(username)
+    if user is None:
+        raise HTTPException(status_code=401, detail="User not found")
+    return str(user.get("enterprise_id") or ""), str(user.get("group_id") or "")
+
+
+@router.post("/dsn/resolve", response_model=DsnResolveResponse)
+async def network_dsn_resolve(
+    request: DsnResolveRequest,
+    username: str = Depends(get_current_user),
+    store: RemoteStore = Depends(get_store),
+) -> DsnResolveResponse:
+    """Embed the caller's intent and rank fleet L2s by topical similarity.
+
+    The ranking is purely centroid-based — no KU bodies leave the
+    queried L2s. Each candidate carries the policy that *would* be
+    applied if the caller called ``/aigrp/forward-query`` against it,
+    so the frontend can pre-render boundary edges.
+    """
+    caller_ent, caller_grp = _resolve_caller_scope(store, username)
+
+    path: list[DsnPathStep] = []
+
+    t0 = time.monotonic()
+    payload = embed_text(request.intent)
+    embed_ms = int((time.monotonic() - t0) * 1000)
+    if payload is None:
+        raise HTTPException(status_code=503, detail="embedding unavailable")
+    intent_vec = unpack(payload[0])
+    path.append(DsnPathStep(step="embed", latency_ms=embed_ms))
+
+    t1 = time.monotonic()
+    snapshots = await _fan_out_all(FLEET_L2S)
+    fan_ms = int((time.monotonic() - t1) * 1000)
+    path.append(
+        DsnPathStep(step="fan_out_signatures", latency_ms=fan_ms, l2_count=len(FLEET_L2S))
+    )
+
+    t2 = time.monotonic()
+    consents = store.list_cross_enterprise_consents(
+        include_expired=False, now_iso=_now_iso(), limit=200
+    )
+
+    candidates: list[DsnCandidate] = []
+    for snap in snapshots:
+        sig = snap.signature or {}
+        centroid = _decode_centroid(sig.get("embedding_centroid_b64"))
+        sim = _cosine(intent_vec, centroid) if centroid else 0.0
+        policy, reason = _decide_dsn_policy(
+            caller_enterprise=caller_ent,
+            caller_group=caller_grp,
+            cand_enterprise=snap.enterprise,
+            cand_group=snap.group,
+            consents=consents,
+            include_consented_cross_enterprise=request.include_consented_cross_enterprise,
+        )
+        if policy == "denied" and not request.include_consented_cross_enterprise and reason == "boundary":
+            continue
+        l2_id = sig.get("l2_id") or f"{snap.enterprise}/{snap.group}"
+        active = snap.active_personas or []
+        expert_personas = [
+            p.get("persona", "") for p in active if p.get("discoverable") is not False
+        ][:5]
+        candidates.append(
+            DsnCandidate(
+                l2_id=l2_id,
+                enterprise=snap.enterprise,
+                group=snap.group,
+                sim_score=round(sim, 4),
+                ku_count_in_topic=int(sig.get("ku_count", 0)),
+                top_domains=[],
+                expert_personas=expert_personas,
+                policy_if_queried=policy,
+                policy_reason=reason,
+            )
+        )
+
+    candidates.sort(key=lambda c: c.sim_score, reverse=True)
+    candidates = candidates[: request.max_candidates]
+    rank_ms = int((time.monotonic() - t2) * 1000)
+    path.append(DsnPathStep(step="rank", latency_ms=rank_ms))
+
+    return DsnResolveResponse(
+        intent=request.intent,
+        embedding_dims=len(intent_vec),
+        candidates=candidates,
+        resolution_path=path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Demo orchestration.
+# ---------------------------------------------------------------------------
+
+
+_DEMO_INTENTS: dict[str, str] = {
+    "cross-group-query": "CloudFront cache invalidation gotchas",
+    "cross-enterprise-blocked": "Bedrock Titan embedding throughput tuning",
+    "cross-enterprise-consented": "Bedrock Titan embedding throughput tuning",
+}
+
+
+def _l2_by_slug(slug: str) -> dict[str, str] | None:
+    """Resolve a fleet slug to the FLEET_L2S row, or None."""
+    for row in FLEET_L2S:
+        if row["slug"] == slug:
+            return row
+    return None
+
+
+def _trace_event(
+    step: int,
+    *,
+    l2_id: str,
+    action: str,
+    payload_preview: str = "",
+    result_summary: str = "",
+    latency_ms: int = 0,
+) -> TraceEvent:
+    """Build one trace event with a stamped timestamp."""
+    return TraceEvent(
+        step=step,
+        ts=_now_iso(),
+        l2_id=l2_id,
+        action=action,
+        payload_preview=payload_preview,
+        result_summary=result_summary,
+        latency_ms=latency_ms,
+    )
+
+
+async def _call_aigrp_lookup(
+    client: httpx.AsyncClient,
+    l2: dict[str, str],
+    *,
+    intent: str,
+    persona: str,
+) -> tuple[dict[str, Any] | None, int]:
+    """Helper: call /aigrp/lookup on an L2; return (body, latency_ms)."""
+    base = l2["endpoint"].rstrip("/")
+    peer_key = _peer_key_for(l2["enterprise"])
+    headers = {"authorization": f"Bearer {peer_key}"} if peer_key else {}
+    t0 = time.monotonic()
+    try:
+        r = await client.post(
+            f"{base}/api/v1/aigrp/lookup",
+            headers=headers,
+            json={
+                "context": intent,
+                "trigger": "demo",
+                "persona": persona,
+                "max_results": 5,
+            },
+        )
+        latency = int((time.monotonic() - t0) * 1000)
+        if r.status_code == 200:
+            return r.json(), latency
+    except Exception:
+        logger.warning("aigrp/lookup failed slug=%s", l2["slug"])
+    return None, int((time.monotonic() - t0) * 1000)
+
+
+async def _call_forward_query(
+    client: httpx.AsyncClient,
+    target: dict[str, str],
+    *,
+    requester: dict[str, str],
+    requester_persona: str,
+    query_vec: list[float],
+    query_text: str,
+) -> tuple[dict[str, Any] | None, int]:
+    """Helper: call /aigrp/forward-query on the target L2 with the requester's scope."""
+    base = target["endpoint"].rstrip("/")
+    # forward-query uses the *target*'s peer key (caller signs with the
+    # responder's key in this internal-fleet topology). For cross-Enterprise
+    # the responder has its own key, which is why we resolve by target.
+    peer_key = _peer_key_for(target["enterprise"])
+    headers = {"authorization": f"Bearer {peer_key}"} if peer_key else {}
+    t0 = time.monotonic()
+    try:
+        r = await client.post(
+            f"{base}/api/v1/aigrp/forward-query",
+            headers=headers,
+            json={
+                "query_vec": query_vec,
+                "query_text": query_text,
+                "requester_l2_id": f"{requester['enterprise']}/{requester['group']}",
+                "requester_enterprise": requester["enterprise"],
+                "requester_group": requester["group"],
+                "requester_persona": requester_persona,
+                "max_results": 5,
+            },
+        )
+        latency = int((time.monotonic() - t0) * 1000)
+        if r.status_code == 200:
+            return r.json(), latency
+    except Exception:
+        logger.warning("forward-query failed slug=%s", target["slug"])
+    return None, int((time.monotonic() - t0) * 1000)
+
+
+async def _resolve_dsn_internal(
+    intent: str, caller_enterprise: str, caller_group: str, store: RemoteStore
+) -> tuple[DsnResolveResponse | None, list[float], int]:
+    """Inline DSN resolve used by demo scenarios. Returns (response, intent_vec, dsn_ms)."""
+    t0 = time.monotonic()
+    payload = embed_text(intent)
+    if payload is None:
+        return None, [], int((time.monotonic() - t0) * 1000)
+    intent_vec = unpack(payload[0])
+    snapshots = await _fan_out_all(FLEET_L2S)
+    consents = store.list_cross_enterprise_consents(
+        include_expired=False, now_iso=_now_iso(), limit=200
+    )
+    candidates: list[DsnCandidate] = []
+    for snap in snapshots:
+        sig = snap.signature or {}
+        centroid = _decode_centroid(sig.get("embedding_centroid_b64"))
+        sim = _cosine(intent_vec, centroid) if centroid else 0.0
+        policy, reason = _decide_dsn_policy(
+            caller_enterprise=caller_enterprise,
+            caller_group=caller_group,
+            cand_enterprise=snap.enterprise,
+            cand_group=snap.group,
+            consents=consents,
+            include_consented_cross_enterprise=True,
+        )
+        l2_id = sig.get("l2_id") or f"{snap.enterprise}/{snap.group}"
+        candidates.append(
+            DsnCandidate(
+                l2_id=l2_id,
+                enterprise=snap.enterprise,
+                group=snap.group,
+                sim_score=round(sim, 4),
+                ku_count_in_topic=int(sig.get("ku_count", 0)),
+                top_domains=[],
+                expert_personas=[],
+                policy_if_queried=policy,
+                policy_reason=reason,
+            )
+        )
+    candidates.sort(key=lambda c: c.sim_score, reverse=True)
+    response = DsnResolveResponse(
+        intent=intent,
+        embedding_dims=len(intent_vec),
+        candidates=candidates,
+        resolution_path=[],
+    )
+    return response, intent_vec, int((time.monotonic() - t0) * 1000)
+
+
+def _final_results_from_forward(body: dict[str, Any] | None) -> list[TraceFinalResult]:
+    """Translate a forward-query response body into the TraceFinalResult list."""
+    if not body:
+        return []
+    out: list[TraceFinalResult] = []
+    for hit in body.get("results", []):
+        out.append(
+            TraceFinalResult(
+                summary=hit.get("summary", ""),
+                redacted_fields=list(hit.get("redacted_fields") or []),
+                sim_score=float(hit.get("sim_score", 0.0)),
+            )
+        )
+    return out
+
+
+@router.post("/demo/{scenario}", response_model=TraceResponse)
+async def network_demo(
+    scenario: str,
+    request: DemoScenarioRequest,
+    _username: str = Depends(get_current_user),
+    store: RemoteStore = Depends(get_store),
+) -> TraceResponse:
+    """Run one of three named scenarios end-to-end against the live fleet.
+
+    The trace events returned are what the frontend animates as a
+    packet flow over the topology canvas. Each step is a real HTTP
+    call to a real L2 — the caller persona/L2 is taken from the
+    request body so a single demo shell can drive multiple personas.
+    """
+    if scenario not in _DEMO_INTENTS:
+        raise HTTPException(status_code=404, detail=f"unknown scenario: {scenario}")
+    requester = _l2_by_slug(request.requester_l2_slug)
+    if requester is None:
+        raise HTTPException(
+            status_code=422,
+            detail=f"unknown requester_l2_slug={request.requester_l2_slug!r}",
+        )
+
+    started_at = _now_iso()
+    started_mono = time.monotonic()
+    intent = _DEMO_INTENTS[scenario]
+    trace: list[TraceEvent] = []
+    final_results: list[TraceFinalResult] = []
+
+    # Pre-flight gate for the consented variant: a row must exist or we
+    # 412 so the demo button can show "sign consent first".
+    if scenario == "cross-enterprise-consented":
+        consent = store.find_cross_enterprise_consent(
+            requester_enterprise=requester["enterprise"],
+            responder_enterprise=("orion" if requester["enterprise"] == "acme" else "acme"),
+            requester_group=requester["group"],
+            responder_group="engineering",
+            now_iso=_now_iso(),
+        )
+        if consent is None:
+            raise HTTPException(
+                status_code=412,
+                detail={
+                    "error": "no_consent",
+                    "hint": "POST /api/v1/consents/sign first",
+                },
+            )
+
+    timeout = httpx.Timeout(L2_FANOUT_TIMEOUT_SECONDS)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        # Step 1 — local /aigrp/lookup against the requester's own L2.
+        lookup_body, lookup_ms = await _call_aigrp_lookup(
+            client, requester, intent=intent, persona=request.requester_persona
+        )
+        local_hits = len((lookup_body or {}).get("results", []))
+        trace.append(
+            _trace_event(
+                1,
+                l2_id=f"{requester['enterprise']}/{requester['group']}",
+                action="aigrp_lookup",
+                payload_preview=f"intent={intent!r}",
+                result_summary=(
+                    f"{local_hits} local hits; routing via DSN to find expert L2"
+                ),
+                latency_ms=lookup_ms,
+            )
+        )
+
+        # Step 2 — DSN resolve.
+        dsn_resp, intent_vec, dsn_ms = await _resolve_dsn_internal(
+            intent, requester["enterprise"], requester["group"], store
+        )
+        if dsn_resp is None or not intent_vec:
+            raise HTTPException(status_code=503, detail="embedding unavailable")
+        # Pick top non-self candidate.
+        self_l2_id = f"{requester['enterprise']}/{requester['group']}"
+        top: DsnCandidate | None = None
+        for c in dsn_resp.candidates:
+            if c.l2_id == self_l2_id:
+                continue
+            # Scenario-specific routing constraints — keep the demo
+            # deterministic by only selecting the expected target type.
+            if scenario == "cross-group-query" and c.enterprise != requester["enterprise"]:
+                continue
+            if scenario.startswith("cross-enterprise") and c.enterprise == requester["enterprise"]:
+                continue
+            top = c
+            break
+        if top is None:
+            raise HTTPException(
+                status_code=503,
+                detail=f"no candidate L2 found for scenario={scenario}",
+            )
+        trace.append(
+            _trace_event(
+                2,
+                l2_id="dsn",
+                action="dsn_resolve",
+                payload_preview=f"intent={intent!r}",
+                result_summary=(
+                    f"top candidate={top.l2_id} sim={top.sim_score:.3f} "
+                    f"policy={top.policy_if_queried} reason={top.policy_reason}"
+                ),
+                latency_ms=dsn_ms,
+            )
+        )
+
+        # Step 3 — forward-query the chosen target.
+        target_slug_map = {
+            "orion/engineering": "orion-eng",
+            "orion/solutions": "orion-sol",
+            "orion/gtm": "orion-gtm",
+            "acme/engineering": "acme-eng",
+            "acme/solutions": "acme-sol",
+            "acme/finance": "acme-fin",
+        }
+        target_slug = target_slug_map.get(top.l2_id)
+        target = _l2_by_slug(target_slug) if target_slug else None
+        if target is None:
+            raise HTTPException(
+                status_code=503, detail=f"no fleet row for l2_id={top.l2_id}"
+            )
+        fq_body, fq_ms = await _call_forward_query(
+            client,
+            target,
+            requester=requester,
+            requester_persona=request.requester_persona,
+            query_vec=intent_vec,
+            query_text=intent,
+        )
+        result_count = len((fq_body or {}).get("results", []))
+        policy_applied = (fq_body or {}).get("policy_applied", "denied")
+        trace.append(
+            _trace_event(
+                3,
+                l2_id=top.l2_id,
+                action="aigrp_forward_query",
+                payload_preview=(
+                    f"requester={requester['enterprise']}/{requester['group']} "
+                    f"persona={request.requester_persona}"
+                ),
+                result_summary=(
+                    f"{result_count} hits returned; policy_applied={policy_applied}"
+                ),
+                latency_ms=fq_ms,
+            )
+        )
+        final_results = _final_results_from_forward(fq_body)
+
+    completed_at = _now_iso()
+    total_ms = int((time.monotonic() - started_mono) * 1000)
+    return TraceResponse(
+        scenario=scenario,
+        started_at=started_at,
+        completed_at=completed_at,
+        total_latency_ms=total_ms,
+        trace=trace,
+        final_results=final_results,
+    )

--- a/server/backend/tests/test_demo_scenarios.py
+++ b/server/backend/tests/test_demo_scenarios.py
@@ -1,0 +1,321 @@
+"""Phase 6 step 4 / Lane J: POST /network/demo/{scenario} tests.
+
+Pins:
+  - cross-group-query: trace has 3 events (lookup, dsn, forward-query),
+    target is same-Enterprise different-Group.
+  - cross-enterprise-blocked: trace shows policy_if_queried=denied at
+    DSN; final results empty.
+  - cross-enterprise-consented: 412 when no consent row, 200 with
+    summary_only forward-query result when consent exists.
+  - 404 on unknown scenario; 422 on unknown requester slug.
+"""
+
+from __future__ import annotations
+
+import struct
+from collections.abc import Iterator
+from pathlib import Path
+
+import bcrypt
+import pytest
+from fastapi.testclient import TestClient
+
+from cq_server import network
+from cq_server.app import _get_store, app
+
+ALICE = "alice"
+
+
+def _pack(vec: list[float]) -> bytes:
+    return struct.pack(f"<{len(vec)}f", *vec)
+
+
+def _b64_centroid(axis: int, dim: int = 8) -> str:
+    import base64
+
+    v = [0.0] * dim
+    v[axis] = 1.0
+    return base64.b64encode(_pack(v)).decode("ascii")
+
+
+def _stub_embed(monkeypatch: pytest.MonkeyPatch, axis: int = 0, dim: int = 8) -> None:
+    v = [0.0] * dim
+    v[axis] = 1.0
+
+    def _fake(text: str):
+        return _pack(v), "stub-model"
+
+    monkeypatch.setattr(network, "embed_text", _fake)
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "demo.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    network._TOPOLOGY_CACHE["value"] = None
+    network._TOPOLOGY_CACHE["expires_at"] = 0.0
+    network._PEER_KEY_OVERRIDES.clear()
+    network._PEER_KEY_OVERRIDES["orion"] = "stub-orion-key"
+    network._PEER_KEY_OVERRIDES["acme"] = "stub-acme-key"
+    with TestClient(app) as c:
+        store = _get_store()
+        pw = bcrypt.hashpw(b"pw", bcrypt.gensalt()).decode()
+        store.create_user(ALICE, pw)
+        yield c
+
+
+def _login(client: TestClient) -> str:
+    resp = client.post(
+        "/api/v1/auth/login", json={"username": ALICE, "password": "pw"}
+    )
+    return resp.json()["token"]
+
+
+def _patch_fleet_calls(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    target_axis_for: dict[str, int],
+    forward_query_response: dict | None = None,
+    forward_query_status: int = 200,
+) -> dict[str, list]:
+    """Patch httpx.AsyncClient at the per-call helpers so the demo flow
+    runs without any real ALB. Captures forward-query targets so tests
+    can assert what the orchestrator chose.
+
+    ``target_axis_for`` maps slug -> axis index for the L2's centroid.
+    ``forward_query_response`` is what the responder L2 returns for the
+    /aigrp/forward-query call; defaults to a single summary_only KU.
+    """
+    captured: dict[str, list] = {"forward_query_targets": [], "lookups": []}
+
+    async def _fake_fan_out(fleet):
+        snaps = []
+        for l2 in fleet:
+            snap = network._L2Snapshot(
+                slug=l2["slug"],
+                enterprise=l2["enterprise"],
+                group=l2["group"],
+                endpoint=l2["endpoint"],
+                reachable=True,
+            )
+            snap.peers = []
+            snap.signature = {
+                "l2_id": f"{l2['enterprise']}/{l2['group']}",
+                "ku_count": 3,
+                "domain_count": 4,
+                "computed_at": "2026-04-30T01:00:00+00:00",
+                "embedding_centroid_b64": _b64_centroid(target_axis_for[l2["slug"]]),
+                "embedding_model": "amazon.titan-embed-text-v2:0",
+            }
+            snap.active_personas = []
+            snaps.append(snap)
+        return snaps
+
+    monkeypatch.setattr(network, "_fan_out_all", _fake_fan_out)
+
+    async def _fake_lookup(client, l2, *, intent, persona):
+        captured["lookups"].append(l2["slug"])
+        return ({"results": []}, 5)
+
+    async def _fake_forward(
+        client, target, *, requester, requester_persona, query_vec, query_text
+    ):
+        captured["forward_query_targets"].append(target["slug"])
+        if forward_query_status != 200:
+            return None, 7
+        body = forward_query_response or {
+            "responder_l2_id": f"{target['enterprise']}/{target['group']}",
+            "responder_enterprise": target["enterprise"],
+            "responder_group": target["group"],
+            "policy_applied": "summary_only",
+            "results": [
+                {
+                    "ku_id": "ku_demo_1",
+                    "summary": "CloudFront cache key omits query strings by default",
+                    "detail": None,
+                    "action": None,
+                    "domains": ["aws", "cloudfront"],
+                    "sim_score": 0.91,
+                    "redacted_fields": ["detail", "action"],
+                }
+            ],
+            "result_count": 1,
+        }
+        return body, 9
+
+    monkeypatch.setattr(network, "_call_aigrp_lookup", _fake_lookup)
+    monkeypatch.setattr(network, "_call_forward_query", _fake_forward)
+    return captured
+
+
+class TestCrossGroupScenario:
+    def test_routes_to_same_enterprise_different_group(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _stub_embed(monkeypatch, axis=0)
+        # Make acme/solutions the top candidate (axis 0); requester is acme/eng.
+        captured = _patch_fleet_calls(
+            monkeypatch,
+            target_axis_for={
+                "orion-eng": 1, "orion-sol": 2, "orion-gtm": 3,
+                "acme-eng": 5, "acme-sol": 0, "acme-fin": 6,
+            },
+        )
+        jwt = _login(client)
+        resp = client.post(
+            "/api/v1/network/demo/cross-group-query",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={
+                "requester_persona": "persona-cloudfront-asker",
+                "requester_l2_slug": "acme-eng",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["scenario"] == "cross-group-query"
+        assert len(body["trace"]) == 3
+        actions = [e["action"] for e in body["trace"]]
+        assert actions == ["aigrp_lookup", "dsn_resolve", "aigrp_forward_query"]
+        # forward-query was sent to acme-sol (same Enterprise, different Group).
+        assert captured["forward_query_targets"] == ["acme-sol"]
+        # final_results carry redaction info so the frontend can render.
+        assert body["final_results"]
+        assert body["final_results"][0]["redacted_fields"] == ["detail", "action"]
+
+
+class TestCrossEnterpriseBlocked:
+    def test_top_candidate_is_orion_with_denied_policy(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _stub_embed(monkeypatch, axis=0)
+        captured = _patch_fleet_calls(
+            monkeypatch,
+            target_axis_for={
+                "orion-eng": 0, "orion-sol": 2, "orion-gtm": 3,
+                "acme-eng": 5, "acme-sol": 4, "acme-fin": 6,
+            },
+            forward_query_response={
+                "responder_l2_id": "orion/engineering",
+                "responder_enterprise": "orion",
+                "responder_group": "engineering",
+                "policy_applied": "denied",
+                "results": [],
+                "result_count": 0,
+            },
+        )
+        jwt = _login(client)
+        resp = client.post(
+            "/api/v1/network/demo/cross-enterprise-blocked",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={
+                "requester_persona": "persona-bedrock-asker",
+                "requester_l2_slug": "acme-eng",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert captured["forward_query_targets"] == ["orion-eng"]
+        # DSN step exposes the denied policy in its result_summary.
+        dsn_step = body["trace"][1]
+        assert "denied" in dsn_step["result_summary"]
+        assert body["final_results"] == []
+
+
+class TestCrossEnterpriseConsentedPrecondition:
+    def test_412_when_no_consent_row(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _stub_embed(monkeypatch, axis=0)
+        _patch_fleet_calls(
+            monkeypatch,
+            target_axis_for={
+                "orion-eng": 0, "orion-sol": 2, "orion-gtm": 3,
+                "acme-eng": 5, "acme-sol": 4, "acme-fin": 6,
+            },
+        )
+        jwt = _login(client)
+        resp = client.post(
+            "/api/v1/network/demo/cross-enterprise-consented",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={
+                "requester_persona": "persona-bedrock-asker",
+                "requester_l2_slug": "acme-eng",
+            },
+        )
+        assert resp.status_code == 412, resp.text
+        body = resp.json()
+        # FastAPI wraps custom dict detail under "detail".
+        detail = body["detail"]
+        assert detail["error"] == "no_consent"
+
+    def test_200_when_consent_exists(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Seed a consent row from acme/eng -> orion/eng.
+        store = _get_store()
+        store.insert_cross_enterprise_consent(
+            consent_id="consent_test_xx",
+            requester_enterprise="acme",
+            responder_enterprise="orion",
+            requester_group="engineering",
+            responder_group="engineering",
+            policy="summary_only",
+            signed_by_admin="test-admin",
+            signed_at="2026-04-30T00:00:00+00:00",
+            expires_at=None,
+            audit_log_id="aud_test_xx",
+        )
+        _stub_embed(monkeypatch, axis=0)
+        _patch_fleet_calls(
+            monkeypatch,
+            target_axis_for={
+                "orion-eng": 0, "orion-sol": 2, "orion-gtm": 3,
+                "acme-eng": 5, "acme-sol": 4, "acme-fin": 6,
+            },
+        )
+        jwt = _login(client)
+        resp = client.post(
+            "/api/v1/network/demo/cross-enterprise-consented",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={
+                "requester_persona": "persona-bedrock-asker",
+                "requester_l2_slug": "acme-eng",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        # Final results carry the summary_only redaction.
+        assert body["final_results"]
+        assert body["final_results"][0]["redacted_fields"] == ["detail", "action"]
+
+
+class TestUnknownScenario:
+    def test_unknown_scenario_returns_404(self, client: TestClient) -> None:
+        jwt = _login(client)
+        resp = client.post(
+            "/api/v1/network/demo/not-a-real-scenario",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={
+                "requester_persona": "persona-x",
+                "requester_l2_slug": "acme-eng",
+            },
+        )
+        assert resp.status_code == 404
+
+
+class TestUnknownRequesterSlug:
+    def test_422_on_unknown_slug(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _stub_embed(monkeypatch, axis=0)
+        jwt = _login(client)
+        resp = client.post(
+            "/api/v1/network/demo/cross-group-query",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={
+                "requester_persona": "persona-x",
+                "requester_l2_slug": "not-a-fleet-l2",
+            },
+        )
+        assert resp.status_code == 422

--- a/server/backend/tests/test_dsn_resolve.py
+++ b/server/backend/tests/test_dsn_resolve.py
@@ -1,0 +1,239 @@
+"""Phase 6 step 4 / Lane I: POST /network/dsn/resolve tests.
+
+Pins:
+  - Embed + fan-out + cosine ranking pipeline runs end-to-end.
+  - Same-Enterprise + same-Group candidate -> ``full_body`` policy.
+  - Cross-Enterprise without consent -> ``denied`` + ``cross_enterprise_no_consent``.
+  - resolution_path is populated with three timing steps (embed, fan_out, rank).
+  - 503 when embedding is unavailable.
+"""
+
+from __future__ import annotations
+
+import struct
+from collections.abc import Iterator
+from pathlib import Path
+
+import bcrypt
+import pytest
+from fastapi.testclient import TestClient
+
+from cq_server import network
+from cq_server.app import _get_store, app
+
+ALICE = "alice"  # acme/engineering
+
+
+def _pack(vec: list[float]) -> bytes:
+    return struct.pack(f"<{len(vec)}f", *vec)
+
+
+def _b64_centroid(axis: int, dim: int = 8) -> str:
+    """Build a base64 centroid that points along a unit axis — easy cosine arithmetic."""
+    import base64
+
+    v = [0.0] * dim
+    v[axis] = 1.0
+    return base64.b64encode(_pack(v)).decode("ascii")
+
+
+def _snapshot_with_centroid(
+    *, slug: str, enterprise: str, group: str, axis: int, ku_count: int = 5
+) -> network._L2Snapshot:
+    snap = network._L2Snapshot(
+        slug=slug,
+        enterprise=enterprise,
+        group=group,
+        endpoint=f"http://stub-{slug}.local",
+        reachable=True,
+    )
+    snap.peers = []
+    snap.signature = {
+        "l2_id": f"{enterprise}/{group}",
+        "ku_count": ku_count,
+        "domain_count": 4,
+        "computed_at": "2026-04-30T01:00:00+00:00",
+        "embedding_centroid_b64": _b64_centroid(axis),
+        "embedding_model": "amazon.titan-embed-text-v2:0",
+    }
+    snap.active_personas = []
+    return snap
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "dsn.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    network._TOPOLOGY_CACHE["value"] = None
+    network._TOPOLOGY_CACHE["expires_at"] = 0.0
+    network._PEER_KEY_OVERRIDES.clear()
+    network._PEER_KEY_OVERRIDES["orion"] = "stub-orion-key"
+    network._PEER_KEY_OVERRIDES["acme"] = "stub-acme-key"
+    with TestClient(app) as c:
+        store = _get_store()
+        pw = bcrypt.hashpw(b"pw", bcrypt.gensalt()).decode()
+        store.create_user(ALICE, pw)
+        with store._lock, store._conn:
+            store._conn.execute(
+                "UPDATE users SET enterprise_id = 'acme', group_id = 'engineering' WHERE username = ?",
+                (ALICE,),
+            )
+        yield c
+
+
+def _login(client: TestClient) -> str:
+    resp = client.post(
+        "/api/v1/auth/login", json={"username": ALICE, "password": "pw"}
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _stub_fanout_six_l2s(monkeypatch: pytest.MonkeyPatch, target_axis: int = 0) -> None:
+    """Stub the fleet so acme/solutions has the highest cosine to query axis 0."""
+    # Configure each L2 with a distinct axis. acme/solutions on the target
+    # axis, others scattered.
+    axis_map = {
+        "orion-eng": 1,
+        "orion-sol": 2,
+        "orion-gtm": 3,
+        "acme-eng": 4,
+        "acme-sol": target_axis,  # match the query
+        "acme-fin": 5,
+    }
+
+    async def _fake(fleet):
+        return [
+            _snapshot_with_centroid(
+                slug=l2["slug"],
+                enterprise=l2["enterprise"],
+                group=l2["group"],
+                axis=axis_map[l2["slug"]],
+            )
+            for l2 in fleet
+        ]
+
+    monkeypatch.setattr(network, "_fan_out_all", _fake)
+
+
+def _stub_embed(monkeypatch: pytest.MonkeyPatch, axis: int = 0, dim: int = 8) -> None:
+    """Stub embed_text in the network module so we can drive cosine deterministically."""
+    v = [0.0] * dim
+    v[axis] = 1.0
+
+    def _fake_embed(text: str):
+        return _pack(v), "stub-model"
+
+    monkeypatch.setattr(network, "embed_text", _fake_embed)
+
+
+class TestDsnResolveHappyPath:
+    def test_returns_ranked_candidates_with_resolution_path(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _stub_embed(monkeypatch, axis=0)
+        _stub_fanout_six_l2s(monkeypatch, target_axis=0)
+        jwt = _login(client)
+        resp = client.post(
+            "/api/v1/network/dsn/resolve",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={"intent": "I need help with CloudFront", "max_candidates": 3},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["intent"] == "I need help with CloudFront"
+        assert body["embedding_dims"] == 8
+        candidates = body["candidates"]
+        assert len(candidates) == 3
+        # acme/solutions sits on the same axis, so it ranks first.
+        assert candidates[0]["l2_id"] == "acme/solutions"
+        # resolution_path has three steps.
+        steps = [s["step"] for s in body["resolution_path"]]
+        assert steps == ["embed", "fan_out_signatures", "rank"]
+        # fan_out step exposes the L2 count.
+        fan_step = next(s for s in body["resolution_path"] if s["step"] == "fan_out_signatures")
+        assert fan_step["l2_count"] == 6
+
+
+class TestDsnPolicyDecisions:
+    def test_same_enterprise_same_group_is_full_body(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Alice = acme/engineering. Make her own L2 the top candidate.
+        _stub_embed(monkeypatch, axis=0)
+
+        async def _fake(fleet):
+            return [
+                _snapshot_with_centroid(
+                    slug=l2["slug"],
+                    enterprise=l2["enterprise"],
+                    group=l2["group"],
+                    axis=(0 if l2["slug"] == "acme-eng" else 1 + i),
+                )
+                for i, l2 in enumerate(fleet)
+            ]
+
+        monkeypatch.setattr(network, "_fan_out_all", _fake)
+        jwt = _login(client)
+        resp = client.post(
+            "/api/v1/network/dsn/resolve",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={"intent": "anything", "max_candidates": 6},
+        )
+        body = resp.json()
+        own = next(c for c in body["candidates"] if c["l2_id"] == "acme/engineering")
+        assert own["policy_if_queried"] == "full_body"
+        assert own["policy_reason"] == "same_enterprise_same_group"
+
+    def test_cross_enterprise_no_consent_is_denied(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _stub_embed(monkeypatch, axis=0)
+        _stub_fanout_six_l2s(monkeypatch, target_axis=0)
+        jwt = _login(client)
+        resp = client.post(
+            "/api/v1/network/dsn/resolve",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={
+                "intent": "anything",
+                "max_candidates": 6,
+                "include_consented_cross_enterprise": True,
+            },
+        )
+        body = resp.json()
+        # Find an orion candidate from Alice's POV (acme/engineering).
+        orion = next(c for c in body["candidates"] if c["enterprise"] == "orion")
+        assert orion["policy_if_queried"] == "denied"
+        assert orion["policy_reason"] == "cross_enterprise_no_consent"
+
+    def test_same_enterprise_xgroup_is_summary_only(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _stub_embed(monkeypatch, axis=0)
+        _stub_fanout_six_l2s(monkeypatch, target_axis=0)
+        jwt = _login(client)
+        resp = client.post(
+            "/api/v1/network/dsn/resolve",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={"intent": "anything", "max_candidates": 6},
+        )
+        body = resp.json()
+        # acme/solutions vs Alice (acme/engineering) -> summary_only.
+        sol = next(c for c in body["candidates"] if c["l2_id"] == "acme/solutions")
+        assert sol["policy_if_queried"] == "summary_only"
+        assert sol["policy_reason"] == "same_enterprise_xgroup_summary"
+
+
+class TestDsnEmbedFailure:
+    def test_503_when_embedding_unavailable(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(network, "embed_text", lambda text: None)
+        jwt = _login(client)
+        resp = client.post(
+            "/api/v1/network/dsn/resolve",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={"intent": "anything"},
+        )
+        assert resp.status_code == 503

--- a/server/backend/tests/test_network_topology.py
+++ b/server/backend/tests/test_network_topology.py
@@ -1,0 +1,198 @@
+"""Phase 6 step 4 / Lane J: POST /network/topology aggregator tests.
+
+Pins:
+  - Happy path: all 6 L2s reachable -> grouped-by-Enterprise response
+    with peer/persona counts populated.
+  - Partial-fleet failure: a single L2 returning 500 yields a row with
+    ``peer_count=null`` rather than failing the whole call.
+  - 3-second in-process cache: a second call within the TTL returns the
+    same generated_at without re-fanning out.
+
+The tests stub network.fan_out via a monkeypatched
+``_fan_out_all`` so we don't need a live ALB to exercise the aggregator.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import bcrypt
+import pytest
+from fastapi.testclient import TestClient
+
+from cq_server import network
+from cq_server.app import _get_store, app
+
+ALICE = "alice"
+
+
+def _snapshot(
+    *,
+    slug: str,
+    enterprise: str,
+    group: str,
+    ku_count: int = 7,
+    peer_count: int | None = 5,
+    active: list[dict] | None = None,
+    reachable: bool = True,
+) -> network._L2Snapshot:
+    """Build an _L2Snapshot stub mirroring what _fetch_one_l2 would yield."""
+    snap = network._L2Snapshot(
+        slug=slug,
+        enterprise=enterprise,
+        group=group,
+        endpoint=f"http://stub-{slug}.local",
+        reachable=reachable,
+    )
+    if peer_count is not None:
+        snap.peers = [
+            {"l2_id": f"{enterprise}/peer-{i}", "last_signature_at": "2026-04-30T00:00:00+00:00"}
+            for i in range(peer_count)
+        ]
+        snap.signature = {
+            "l2_id": f"{enterprise}/{group}",
+            "ku_count": ku_count,
+            "domain_count": 12,
+            "computed_at": "2026-04-30T01:00:00+00:00",
+            "embedding_centroid_b64": None,
+            "embedding_model": "amazon.titan-embed-text-v2:0",
+        }
+    snap.active_personas = active or []
+    return snap
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "topology.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    # Reset the in-process topology cache between tests.
+    network._TOPOLOGY_CACHE["value"] = None
+    network._TOPOLOGY_CACHE["expires_at"] = 0.0
+    network._PEER_KEY_OVERRIDES.clear()
+    network._PEER_KEY_OVERRIDES["orion"] = "stub-orion-key"
+    network._PEER_KEY_OVERRIDES["acme"] = "stub-acme-key"
+    with TestClient(app) as c:
+        store = _get_store()
+        pw = bcrypt.hashpw(b"pw", bcrypt.gensalt()).decode()
+        store.create_user(ALICE, pw)
+        yield c
+
+
+def _login(client: TestClient, username: str = ALICE) -> str:
+    resp = client.post(
+        "/api/v1/auth/login", json={"username": username, "password": "pw"}
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+class TestTopologyHappyPath:
+    def test_all_six_l2s_aggregated(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def _fake_fan_out(fleet):
+            return [
+                _snapshot(slug=l2["slug"], enterprise=l2["enterprise"], group=l2["group"])
+                for l2 in fleet
+            ]
+
+        monkeypatch.setattr(network, "_fan_out_all", _fake_fan_out)
+        jwt = _login(client)
+        resp = client.post(
+            "/api/v1/network/topology",
+            headers={"Authorization": f"Bearer {jwt}"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert "generated_at" in body
+        # 2 enterprises, 3 L2s each.
+        names = {e["enterprise"] for e in body["enterprises"]}
+        assert names == {"orion", "acme"}
+        for ent in body["enterprises"]:
+            assert len(ent["l2s"]) == 3
+            for l2 in ent["l2s"]:
+                assert l2["peer_count"] == 5
+                assert l2["ku_count"] == 7
+                assert l2["l2_id"].startswith(ent["enterprise"] + "/")
+                assert isinstance(l2["peers"], list)
+                assert isinstance(l2["active_personas"], list)
+        assert isinstance(body["cross_enterprise_consents"], list)
+
+
+class TestPartialFleetFailure:
+    def test_one_l2_down_yields_null_peer_count_not_500(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def _fake_fan_out(fleet):
+            snaps = []
+            for l2 in fleet:
+                if l2["slug"] == "acme-fin":
+                    # Unreachable — no peers, no signature.
+                    snap = network._L2Snapshot(
+                        slug=l2["slug"],
+                        enterprise=l2["enterprise"],
+                        group=l2["group"],
+                        endpoint=l2["endpoint"],
+                        reachable=False,
+                    )
+                    snaps.append(snap)
+                else:
+                    snaps.append(
+                        _snapshot(slug=l2["slug"], enterprise=l2["enterprise"], group=l2["group"])
+                    )
+            return snaps
+
+        monkeypatch.setattr(network, "_fan_out_all", _fake_fan_out)
+        jwt = _login(client)
+        resp = client.post(
+            "/api/v1/network/topology",
+            headers={"Authorization": f"Bearer {jwt}"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        # Find acme/finance — must have peer_count=null + ku_count=0.
+        acme = next(e for e in body["enterprises"] if e["enterprise"] == "acme")
+        fin = next(row for row in acme["l2s"] if row["group"] == "finance")
+        assert fin["peer_count"] is None
+        assert fin["ku_count"] == 0
+        # Other rows still healthy.
+        eng = next(row for row in acme["l2s"] if row["group"] == "engineering")
+        assert eng["peer_count"] == 5
+
+
+class TestTopologyCache:
+    def test_second_call_within_ttl_returns_cached_response(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        call_count = {"n": 0}
+
+        async def _fake_fan_out(fleet):
+            call_count["n"] += 1
+            return [
+                _snapshot(slug=l2["slug"], enterprise=l2["enterprise"], group=l2["group"])
+                for l2 in fleet
+            ]
+
+        monkeypatch.setattr(network, "_fan_out_all", _fake_fan_out)
+        jwt = _login(client)
+        r1 = client.post(
+            "/api/v1/network/topology",
+            headers={"Authorization": f"Bearer {jwt}"},
+        )
+        r2 = client.post(
+            "/api/v1/network/topology",
+            headers={"Authorization": f"Bearer {jwt}"},
+        )
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        # generated_at is identical because the second call hit the cache.
+        assert r1.json()["generated_at"] == r2.json()["generated_at"]
+        assert call_count["n"] == 1
+
+
+class TestTopologyAuth:
+    def test_missing_jwt_returns_401(self, client: TestClient) -> None:
+        resp = client.post("/api/v1/network/topology")
+        assert resp.status_code == 401


### PR DESCRIPTION
## Summary

Adds three POST endpoints under a new `cq_server/network.py` module to power the live `/network` page (Lane H/I/J of `docs/plans/2026-03-04-craic-mvp-poc-design.md`).

- **`/api/v1/network/topology`** — Lane J. Fan-out aggregator over the 6 fleet L2s' `/aigrp/peers`, `/aigrp/signature`, `/peers/active`. Groups by Enterprise, returns per-L2 ku/peer/persona counts plus the active cross-Enterprise consent edges. Tolerates per-L2 failures by setting `peer_count=null` rather than 500'ing. 3-second in-process cache damps the frontend's 5-second poll.

- **`/api/v1/network/dsn/resolve`** — Lane I. Embeds the caller's intent via Bedrock Titan, fans out to each L2's `/aigrp/signature` to recover the centroid, ranks by cosine similarity. Each candidate carries `policy_if_queried` (`full_body` / `summary_only` / `denied`) and `policy_reason` so the frontend can pre-render boundary edges before any cross-Enterprise call fires. Resolution path includes timing for embed / fan-out / rank.

- **`/api/v1/network/demo/{scenario}`** — Lane J. Three deterministic packet-trace scenarios (`cross-group-query`, `cross-enterprise-blocked`, `cross-enterprise-consented`). Each runs the real `lookup → DSN → forward-query` flow against the live fleet and returns a `TraceResponse` with one `TraceEvent` per step for the frontend to animate. The consented variant 412s with `{error: no_consent}` when no consent row exists.

## Implementation notes

- Fan-out uses `httpx.AsyncClient` with a 10s per-L2 timeout and `asyncio.gather`. Per-L2 errors are swallowed individually so a single ALB outage can't dark-out the whole topology call.
- Per-Enterprise peer keys are resolved from SSM SecureStrings at `/8l-aigrp/<enterprise>/peer-key`, cached in module globals on first call. `_PEER_KEY_OVERRIDES` is monkeypatchable from tests; `CQ_AIGRP_PEER_KEY_<ENTERPRISE>` env vars work as a dev shortcut. The admin service JWT for `/peers/active` is minted via the existing `create_token` helper with a 1-hour TTL.
- `FLEET_L2S` is a hardcoded module constant for now (the 6 ALB endpoints). A follow-up PR can move it to env-var or DB config without changing the surface.
- Auth: all three endpoints use `get_current_user` (JWT) — these surface metadata, not raw KU bodies, so any logged-in user can see them.
- Pydantic response models everywhere so the OpenAPI schema is right.

## Test plan

- [x] tests/test_network_topology.py — happy path, partial-fleet failure, cache hit, missing JWT 401.
- [x] tests/test_dsn_resolve.py — embed + fan-out + ranking; same-Enterprise same-Group -> full_body; same-Enterprise different-Group -> summary_only; cross-Enterprise no consent -> denied; embed unavailable -> 503; resolution_path populated.
- [x] tests/test_demo_scenarios.py — cross-group-query routes to same-Enterprise different-Group target; cross-enterprise-blocked shows denied policy; cross-enterprise-consented 412s without consent and 200s with one; 404 on unknown scenario; 422 on unknown requester slug.
- [x] All existing 293 tests still pass (293 -> 308 total).
- [x] ruff check clean across network.py and the three new test files.

## Known divergence (follow-up)

The frontend's `TopologyResponse.peer_count` is typed `number`, but the backend returns `int | null` per the spec's partial-fleet requirement. Trivial type-only follow-up to mark it nullable in `server/frontend/src/network/types.ts`.

## Out of scope

- Frontend wiring (Lane H consumes these endpoints).
- Real-time SSE/WebSocket streaming — polling-based for v1.
- Per-L2 service tokens to replace the shared `CQ_JWT_SECRET`-signed admin JWT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)