### PR TITLE
[server] /api/v1/network/topology: drop auth + add GET for public marketing site

### DIFF
--- a/server/backend/src/cq_server/network.py
+++ b/server/backend/src/cq_server/network.py
@@ -565,11 +565,16 @@ router = APIRouter(prefix="/network", tags=["network"])
 
 
 @router.post("/topology", response_model=TopologyResponse)
+@router.get("/topology", response_model=TopologyResponse)
 async def network_topology(
-    _username: str = Depends(get_current_user),
     store: RemoteStore = Depends(get_store),
 ) -> TopologyResponse:
     """Aggregate per-L2 metadata + consent edges into the topology view.
+
+    Public read — no auth. Returns only operator-authorized topology
+    metadata (L2 names, KU counts, peer table, declared-discoverable
+    presence rows, active consent edges). The data is intended for the
+    public marketing site at 8thlayer.onezero1.ai.
 
     Cached in-process for ``TOPOLOGY_CACHE_TTL_SECONDS`` to damp the
     frontend's 5s poll loop. Per-L2 failures are tolerated (rendered

--- a/server/backend/tests/test_network_topology.py
+++ b/server/backend/tests/test_network_topology.py
@@ -193,6 +193,14 @@ class TestTopologyCache:
 
 
 class TestTopologyAuth:
-    def test_missing_jwt_returns_401(self, client: TestClient) -> None:
+    def test_no_auth_required_public_read(self, client: TestClient) -> None:
+        # Topology is intentionally public for the marketing site at
+        # 8thlayer.onezero1.ai — no JWT required.
         resp = client.post("/api/v1/network/topology")
-        assert resp.status_code == 401
+        assert resp.status_code == 200
+
+    def test_get_method_also_works(self, client: TestClient) -> None:
+        # GET supported alongside POST so the marketing site can poll
+        # without preflight CORS gymnastics.
+        resp = client.get("/api/v1/network/topology")
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary

Makes `/api/v1/network/topology` public-readable so the marketing site at https://8thlayer.onezero1.ai/ can render the live multi-Enterprise topology without an auth gate.

- Removes `Depends(get_current_user)` from the endpoint
- Adds `@router.get` alongside `@router.post` so the static frontend can fetch without preflight CORS
- Updates the auth test to assert public access

## Why

The topology data is operator-authorized metadata (L2 names, KU counts, peer-table, declared-discoverable presence, active consent edges). All of it is intentionally summary-only, no KU bodies, no PII. Same threat model as a status page.

The /network demo lived behind login on the cq-server frontend; investors hitting an admin login form is the wrong UX. The new marketing-site frontend at the public URL fetches this directly.

## Test plan

- [x] `pytest tests/test_network_topology.py` — 5/5 pass (was 4 before; updated auth test + added GET test)