### PR TITLE
[server] DSN routed-hop · in-memory signature cache · closes #23

### DIFF
--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -199,14 +199,25 @@ async def lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
     if aigrp.aigrp_enabled():
         aigrp_task = asyncio.create_task(_aigrp_bootstrap_and_poll(_store))
 
+    # DSN signature cache loop (issue #23). Runs on every cq-server
+    # process — for the marketing aggregator it keeps the public DSN
+    # resolver fast (cache reads, not fan-outs); for fleet L2s it's a
+    # no-op because the resolver isn't hit from outside the aggregator.
+    # We start it unconditionally because the marketing aggregator runs
+    # the same image as fleet L2s.
+    from .network import _signature_cache_loop
+
+    dsn_cache_task = asyncio.create_task(_signature_cache_loop())
+
     yield
 
-    if aigrp_task is not None:
-        aigrp_task.cancel()
-        try:
-            await aigrp_task
-        except (asyncio.CancelledError, Exception):
-            pass
+    for task in (aigrp_task, dsn_cache_task):
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
     _store.close()
 
 

--- a/server/backend/src/cq_server/network.py
+++ b/server/backend/src/cq_server/network.py
@@ -105,6 +105,83 @@ TOPOLOGY_CACHE_TTL_SECONDS = 3.0
 
 
 # ---------------------------------------------------------------------------
+# DSN signature cache (issue #23 — "routed hop" refactor).
+#
+# The marketing-aggregator's public DSN resolver used to fan out to every
+# fleet L2 on every visitor query. The marketing copy says we do "a routed
+# hop, not a fan-out" — turning that into truth means the resolver reads
+# from a locally-maintained signature table that a background task fills
+# on a polling cadence. That's the routing-table model the AIGRP thesis
+# describes.
+#
+# Populated by `_signature_cache_loop` (started in `app.lifespan`) every
+# DSN_CACHE_REFRESH_SECS. DSN resolve reads from here. If the cache is
+# empty (cold boot) or stale (>STALE secs), the resolver falls back to
+# one live `_fan_out_all` and warms the cache for the next request.
+# ---------------------------------------------------------------------------
+
+_signature_cache: dict[str, "_L2Snapshot"] = {}
+_signature_cache_filled_at: float = 0.0  # monotonic; 0.0 means never
+_SIGNATURE_CACHE_LOCK: asyncio.Lock | None = None  # lazily created in async context
+
+DSN_CACHE_REFRESH_SECS = int(os.environ.get("DSN_CACHE_REFRESH_SECS", "60"))
+DSN_CACHE_STALE_SECS = int(os.environ.get("DSN_CACHE_STALE_SECS", "180"))
+
+
+def _signature_cache_lock() -> asyncio.Lock:
+    """Create the cache lock lazily so module import doesn't require an event loop."""
+    global _SIGNATURE_CACHE_LOCK  # noqa: PLW0603
+    if _SIGNATURE_CACHE_LOCK is None:
+        _SIGNATURE_CACHE_LOCK = asyncio.Lock()
+    return _SIGNATURE_CACHE_LOCK
+
+
+async def _refill_signature_cache() -> tuple[int, int]:
+    """One refill pass: fan out to every fleet L2, write snapshots into cache.
+
+    Returns ``(filled, total)`` so callers can log refresh quality.
+    Failures on individual L2s are tolerated (they're omitted from the
+    cache and re-tried next cycle); only the overall fan-out exception
+    is logged at WARNING level.
+    """
+    global _signature_cache_filled_at  # noqa: PLW0603
+    snapshots = await _fan_out_all(FLEET_L2S)
+    async with _signature_cache_lock():
+        _signature_cache.clear()
+        for snap in snapshots:
+            if snap.signature is not None:
+                _signature_cache[snap.slug] = snap
+        _signature_cache_filled_at = time.monotonic()
+    return len(_signature_cache), len(FLEET_L2S)
+
+
+async def _signature_cache_loop() -> None:
+    """Background task: refill _signature_cache on a polling cadence.
+
+    Lives for the lifetime of the FastAPI process, started from
+    `app.lifespan`. Self-healing — any iteration's exception is logged
+    and the loop continues so a transient SSM/peer outage doesn't
+    permanently freeze the cache.
+    """
+    log = logging.getLogger("dsn-cache")
+    while True:
+        try:
+            t0 = time.monotonic()
+            filled, total = await _refill_signature_cache()
+            log.info(
+                "dsn cache refreshed: %d/%d L2s in %dms",
+                filled,
+                total,
+                int((time.monotonic() - t0) * 1000),
+            )
+        except asyncio.CancelledError:
+            return
+        except Exception:
+            log.exception("dsn cache refresh failed; will retry next cycle")
+        await asyncio.sleep(DSN_CACHE_REFRESH_SECS)
+
+
+# ---------------------------------------------------------------------------
 # SSM peer-key resolution.
 #
 # Per-Enterprise shared secrets live at /8l-aigrp/<enterprise>/peer-key as
@@ -279,11 +356,19 @@ class DsnCandidate(BaseModel):
 
 
 class DsnPathStep(BaseModel):
-    """One step in the DSN resolution timing breakdown."""
+    """One step in the DSN resolution timing breakdown.
+
+    `cache_hit` and `cache_age_ms` are populated for the `cache_lookup`
+    step so the frontend can show "served from cache · 7s old · 6 L2s"
+    vs "cache miss · live fetch" honestly. -1 cache_age_ms means the
+    cache has never been filled yet (first request after process boot).
+    """
 
     step: str
     latency_ms: int
     l2_count: int | None = None
+    cache_hit: bool | None = None
+    cache_age_ms: int | None = None
 
 
 class DsnResolveResponse(BaseModel):
@@ -653,11 +738,41 @@ async def network_dsn_resolve(
     intent_vec = unpack(payload[0])
     path.append(DsnPathStep(step="embed", latency_ms=embed_ms))
 
+    # Routed-hop read (issue #23): consult the locally-maintained signature
+    # cache instead of fanning out to every fleet L2 per request. The cache
+    # is filled by `_signature_cache_loop` every DSN_CACHE_REFRESH_SECS
+    # (default 60s). On cold boot or stale cache we fall back to one live
+    # fan-out and warm — that's marked cache_hit=False in the trace so
+    # the frontend can show "cache miss · live fetch" honestly.
     t1 = time.monotonic()
-    snapshots = await _fan_out_all(FLEET_L2S)
-    fan_ms = int((time.monotonic() - t1) * 1000)
+    async with _signature_cache_lock():
+        cached_snapshots = list(_signature_cache.values())
+        cache_age_ms = (
+            int((time.monotonic() - _signature_cache_filled_at) * 1000)
+            if _signature_cache_filled_at
+            else -1
+        )
+    cache_hit = (
+        len(cached_snapshots) > 0
+        and 0 <= cache_age_ms <= DSN_CACHE_STALE_SECS * 1000
+    )
+    if cache_hit:
+        snapshots = cached_snapshots
+    else:
+        # Cold start or stale: warm the cache via one live fan-out.
+        await _refill_signature_cache()
+        async with _signature_cache_lock():
+            snapshots = list(_signature_cache.values())
+            cache_age_ms = int((time.monotonic() - _signature_cache_filled_at) * 1000)
+    lookup_ms = int((time.monotonic() - t1) * 1000)
     path.append(
-        DsnPathStep(step="fan_out_signatures", latency_ms=fan_ms, l2_count=len(FLEET_L2S))
+        DsnPathStep(
+            step="cache_lookup",
+            latency_ms=lookup_ms,
+            l2_count=len(snapshots),
+            cache_hit=cache_hit,
+            cache_age_ms=cache_age_ms,
+        )
     )
 
     t2 = time.monotonic()

--- a/server/backend/src/cq_server/network.py
+++ b/server/backend/src/cq_server/network.py
@@ -114,6 +114,11 @@ TOPOLOGY_CACHE_TTL_SECONDS = 3.0
 
 _PEER_KEY_CACHE: dict[str, str] = {}
 _PEER_KEY_OVERRIDES: dict[str, str] = {}
+# Negative cache: how long to back off after a failed lookup before retrying.
+# Prior bug: failures cached as empty string forever, so a transient
+# AccessDenied / throttle would silently dark-out the resolver until restart.
+_PEER_KEY_FAIL_AT: dict[str, float] = {}
+_PEER_KEY_RETRY_AFTER_SECS = 30.0
 
 
 def _peer_key_for(enterprise: str) -> str:
@@ -122,17 +127,25 @@ def _peer_key_for(enterprise: str) -> str:
     Returns an empty string when the key cannot be resolved — callers
     treat that as "skip this L2" rather than failing the whole fan-out
     so a one-Enterprise SSM outage doesn't dark-out the demo for the
-    other Enterprise.
+    other Enterprise. Failures are cached only for ``_PEER_KEY_RETRY_AFTER_SECS``
+    so a transient AccessDenied or throttle self-heals on the next request
+    without requiring a service restart.
     """
     if enterprise in _PEER_KEY_OVERRIDES:
         return _PEER_KEY_OVERRIDES[enterprise]
-    if enterprise in _PEER_KEY_CACHE:
-        return _PEER_KEY_CACHE[enterprise]
+    cached = _PEER_KEY_CACHE.get(enterprise)
+    if cached:
+        return cached
+    # Negative cache: only short-circuit if the recent failure is still warm.
+    failed_at = _PEER_KEY_FAIL_AT.get(enterprise)
+    if failed_at is not None and (time.time() - failed_at) < _PEER_KEY_RETRY_AFTER_SECS:
+        return ""
     # Local override via env (for one-shot dev, e.g. running both L2 keys
     # under the same value during smoke tests).
     env_key = os.environ.get(f"CQ_AIGRP_PEER_KEY_{enterprise.upper()}", "")
     if env_key:
         _PEER_KEY_CACHE[enterprise] = env_key
+        _PEER_KEY_FAIL_AT.pop(enterprise, None)
         return env_key
     try:
         import boto3
@@ -146,10 +159,11 @@ def _peer_key_for(enterprise: str) -> str:
         )
         value = resp["Parameter"]["Value"]
         _PEER_KEY_CACHE[enterprise] = value
+        _PEER_KEY_FAIL_AT.pop(enterprise, None)
         return value
     except Exception:
         logger.warning("failed to resolve peer key for enterprise=%s", enterprise)
-        _PEER_KEY_CACHE[enterprise] = ""
+        _PEER_KEY_FAIL_AT[enterprise] = time.time()
         return ""
 
 

--- a/server/backend/tests/test_dsn_resolve.py
+++ b/server/backend/tests/test_dsn_resolve.py
@@ -150,10 +150,15 @@ class TestDsnResolveHappyPath:
         assert candidates[0]["l2_id"] == "acme/solutions"
         # resolution_path has three steps.
         steps = [s["step"] for s in body["resolution_path"]]
-        assert steps == ["embed", "fan_out_signatures", "rank"]
-        # fan_out step exposes the L2 count.
-        fan_step = next(s for s in body["resolution_path"] if s["step"] == "fan_out_signatures")
-        assert fan_step["l2_count"] == 6
+        # Post-issue-#23: the resolver reads from the in-memory signature
+        # cache instead of fanning out per request. First request after
+        # process boot is a cache-miss → live fetch → warm; subsequent
+        # requests hit the cache. The step name reflects that.
+        assert steps == ["embed", "cache_lookup", "rank"]
+        cache_step = next(s for s in body["resolution_path"] if s["step"] == "cache_lookup")
+        assert cache_step["l2_count"] == 6
+        assert "cache_hit" in cache_step
+        assert "cache_age_ms" in cache_step
 
 
 class TestDsnPolicyDecisions:

--- a/server/backend/tests/test_network_dsn_cache.py
+++ b/server/backend/tests/test_network_dsn_cache.py
@@ -1,0 +1,309 @@
+"""Issue #23 — DSN routed-hop · in-memory signature cache.
+
+Pins:
+  - Pre-warmed cache: resolver reads it, NO live fan-out per request,
+    cache_hit=True in the trace.
+  - Cold start: first request triggers live fan-out, cache_hit=False,
+    cache populated for next time.
+  - Stale cache (older than DSN_CACHE_STALE_SECS): refresh on next request,
+    cache_hit=False.
+  - Partial cache (some L2s' last poll didn't return a signature): rank
+    only the available ones, no live fan-out.
+  - Background refill loop replaces stale entries on each cycle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import struct
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import bcrypt
+import pytest
+from fastapi.testclient import TestClient
+
+from cq_server import network
+from cq_server.app import _get_store, app
+
+ALICE = "alice"
+
+
+def _pack(vec: list[float]) -> bytes:
+    return struct.pack(f"<{len(vec)}f", *vec)
+
+
+def _b64_centroid(axis: int, dim: int = 8) -> str:
+    import base64
+
+    v = [0.0] * dim
+    v[axis] = 1.0
+    return base64.b64encode(_pack(v)).decode("ascii")
+
+
+def _snap(*, slug: str, enterprise: str, group: str, axis: int) -> network._L2Snapshot:
+    s = network._L2Snapshot(
+        slug=slug,
+        enterprise=enterprise,
+        group=group,
+        endpoint=f"http://stub-{slug}.local",
+        reachable=True,
+    )
+    s.peers = []
+    s.signature = {
+        "l2_id": f"{enterprise}/{group}",
+        "ku_count": 5,
+        "domain_count": 4,
+        "computed_at": "2026-05-01T00:00:00+00:00",
+        "embedding_centroid_b64": _b64_centroid(axis),
+        "embedding_model": "amazon.titan-embed-text-v2:0",
+    }
+    s.active_personas = []
+    return s
+
+
+def _stub_embed(monkeypatch: pytest.MonkeyPatch, axis: int = 0, dim: int = 8) -> None:
+    v = [0.0] * dim
+    v[axis] = 1.0
+
+    def _fake_embed(text: str):
+        return _pack(v), "stub-model"
+
+    monkeypatch.setattr(network, "embed_text", _fake_embed)
+
+
+def _seed_cache(snapshots: list[network._L2Snapshot], age_seconds: float = 0.0) -> None:
+    """Pre-fill the module-level signature cache as if the loop ran ``age_seconds`` ago."""
+    network._signature_cache.clear()
+    for s in snapshots:
+        network._signature_cache[s.slug] = s
+    network._signature_cache_filled_at = time.monotonic() - age_seconds
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "dsn-cache.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    network._TOPOLOGY_CACHE["value"] = None
+    network._TOPOLOGY_CACHE["expires_at"] = 0.0
+    network._signature_cache.clear()
+    network._signature_cache_filled_at = 0.0
+    network._PEER_KEY_OVERRIDES.clear()
+    network._PEER_KEY_OVERRIDES["orion"] = "stub-orion-key"
+    network._PEER_KEY_OVERRIDES["acme"] = "stub-acme-key"
+
+    # Park the background cache loop on a long sleep so it doesn't
+    # interleave with the test body's _fan_out_all monkeypatches. Tests
+    # that exercise the loop directly (test_refill_replaces_stale_entries)
+    # call _refill_signature_cache themselves and don't use this fixture.
+    monkeypatch.setattr(network, "DSN_CACHE_REFRESH_SECS", 86_400)
+
+    # Pre-monkeypatch _fan_out_all to an empty no-op so the lifespan's
+    # initial refill doesn't try to hit real ALBs. Tests then override
+    # this with their own stub.
+    async def _initial_noop(fleet):
+        return []
+
+    monkeypatch.setattr(network, "_fan_out_all", _initial_noop)
+
+    with TestClient(app) as c:
+        store = _get_store()
+        pw = bcrypt.hashpw(b"pw", bcrypt.gensalt()).decode()
+        store.create_user(ALICE, pw)
+        with store._lock, store._conn:
+            store._conn.execute(
+                "UPDATE users SET enterprise_id = 'acme', group_id = 'engineering' WHERE username = ?",
+                (ALICE,),
+            )
+        yield c
+
+
+def _login(client: TestClient) -> str:
+    resp = client.post(
+        "/api/v1/auth/login", json={"username": ALICE, "password": "pw"}
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _full_fleet_snapshots(target_axis: int = 0) -> list[network._L2Snapshot]:
+    axis_map = {
+        "orion-eng": 1,
+        "orion-sol": 2,
+        "orion-gtm": 3,
+        "acme-eng": 4,
+        "acme-sol": target_axis,
+        "acme-fin": 5,
+    }
+    return [
+        _snap(slug=l2["slug"], enterprise=l2["enterprise"], group=l2["group"], axis=axis_map[l2["slug"]])
+        for l2 in network.FLEET_L2S
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Cache-hit path: pre-warm cache, observe NO live fan-out, cache_hit=True
+# ---------------------------------------------------------------------------
+
+
+def test_cache_hit_skips_live_fetch(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_embed(monkeypatch, axis=0)
+    _seed_cache(_full_fleet_snapshots(target_axis=0), age_seconds=10.0)
+
+    # Tripwire: if _fan_out_all is invoked, this test should fail.
+    fan_out_called = {"count": 0}
+
+    async def _no_fanout(fleet):
+        fan_out_called["count"] += 1
+        return []
+
+    monkeypatch.setattr(network, "_fan_out_all", _no_fanout)
+
+    jwt = _login(client)
+    resp = client.post(
+        "/api/v1/network/dsn/resolve",
+        headers={"Authorization": f"Bearer {jwt}"},
+        json={"intent": "anything", "max_candidates": 3},
+    )
+    assert resp.status_code == 200, resp.text
+    assert fan_out_called["count"] == 0, "cache hit should not trigger live fan-out"
+
+    body = resp.json()
+    cache_step = next(s for s in body["resolution_path"] if s["step"] == "cache_lookup")
+    assert cache_step["cache_hit"] is True
+    assert cache_step["l2_count"] == 6
+    assert 9_000 <= cache_step["cache_age_ms"] <= 12_000  # ~10s seeded
+    assert cache_step["latency_ms"] < 50  # cache reads should be µs
+
+
+# ---------------------------------------------------------------------------
+# Cache-miss path: cold cache, falls back to live fan-out, warms cache
+# ---------------------------------------------------------------------------
+
+
+def test_cache_miss_falls_back_to_live_fetch(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_embed(monkeypatch, axis=0)
+    # Cache is empty (the fixture's initial-noop refill writes nothing);
+    # filled_at may be set by that initial refill but cache_hit gates on
+    # len() > 0, so empty-with-stamp still falls back to live fetch.
+    assert len(network._signature_cache) == 0
+
+    fan_out_called = {"count": 0}
+
+    async def _fake_fanout(fleet):
+        fan_out_called["count"] += 1
+        return _full_fleet_snapshots(target_axis=0)
+
+    monkeypatch.setattr(network, "_fan_out_all", _fake_fanout)
+
+    jwt = _login(client)
+    resp = client.post(
+        "/api/v1/network/dsn/resolve",
+        headers={"Authorization": f"Bearer {jwt}"},
+        json={"intent": "anything", "max_candidates": 3},
+    )
+    assert resp.status_code == 200, resp.text
+    assert fan_out_called["count"] == 1, "cold-start should trigger one live fan-out"
+
+    body = resp.json()
+    cache_step = next(s for s in body["resolution_path"] if s["step"] == "cache_lookup")
+    assert cache_step["cache_hit"] is False
+    assert cache_step["l2_count"] == 6  # warmed during the request
+    # Cache is now populated for the next request
+    assert len(network._signature_cache) == 6
+
+
+# ---------------------------------------------------------------------------
+# Stale cache: filled long ago, treated as miss, refreshes on next request
+# ---------------------------------------------------------------------------
+
+
+def test_stale_cache_falls_back(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_embed(monkeypatch, axis=0)
+    _seed_cache(_full_fleet_snapshots(target_axis=0), age_seconds=network.DSN_CACHE_STALE_SECS + 60.0)
+
+    fan_out_called = {"count": 0}
+
+    async def _fake_fanout(fleet):
+        fan_out_called["count"] += 1
+        return _full_fleet_snapshots(target_axis=0)
+
+    monkeypatch.setattr(network, "_fan_out_all", _fake_fanout)
+
+    jwt = _login(client)
+    resp = client.post(
+        "/api/v1/network/dsn/resolve",
+        headers={"Authorization": f"Bearer {jwt}"},
+        json={"intent": "anything", "max_candidates": 3},
+    )
+    assert resp.status_code == 200, resp.text
+    assert fan_out_called["count"] == 1, "stale cache should trigger live fan-out"
+    body = resp.json()
+    cache_step = next(s for s in body["resolution_path"] if s["step"] == "cache_lookup")
+    assert cache_step["cache_hit"] is False
+
+
+# ---------------------------------------------------------------------------
+# Partial cache: only 4 of 6 L2s have signatures cached. Resolver ranks
+# the available ones, does not trigger fan-out.
+# ---------------------------------------------------------------------------
+
+
+def test_partial_cache_ranks_available_l2s(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_embed(monkeypatch, axis=0)
+    # Only 4 of the 6 L2s have signatures cached; 2 were unreachable last poll.
+    snapshots = _full_fleet_snapshots(target_axis=0)
+    _seed_cache(snapshots[:4], age_seconds=5.0)
+
+    async def _no_fanout(fleet):
+        raise AssertionError("partial cache hit should still skip live fan-out")
+
+    monkeypatch.setattr(network, "_fan_out_all", _no_fanout)
+
+    jwt = _login(client)
+    resp = client.post(
+        "/api/v1/network/dsn/resolve",
+        headers={"Authorization": f"Bearer {jwt}"},
+        json={"intent": "anything", "max_candidates": 6},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # Up to 4 candidates, since 2 L2s aren't in the cache.
+    assert len(body["candidates"]) <= 4
+    cache_step = next(s for s in body["resolution_path"] if s["step"] == "cache_lookup")
+    assert cache_step["cache_hit"] is True
+    assert cache_step["l2_count"] == 4
+
+
+# ---------------------------------------------------------------------------
+# Background refill: _refill_signature_cache replaces stale entries
+# ---------------------------------------------------------------------------
+
+
+def test_refill_replaces_stale_entries(monkeypatch: pytest.MonkeyPatch) -> None:
+    network._signature_cache.clear()
+    network._signature_cache_filled_at = 0.0
+
+    snapshots_v1 = _full_fleet_snapshots(target_axis=0)
+    snapshots_v2 = _full_fleet_snapshots(target_axis=1)  # different "freshness"
+
+    # First refill: 6 L2s
+    async def _v1(fleet):
+        return snapshots_v1
+
+    monkeypatch.setattr(network, "_fan_out_all", _v1)
+    filled, total = asyncio.run(network._refill_signature_cache())
+    assert filled == 6 and total == 6
+    assert len(network._signature_cache) == 6
+
+    # Simulate one L2 going dark: only 5 snapshots returned next cycle
+    async def _v2(fleet):
+        return [s for s in snapshots_v2 if s.slug != "orion-gtm"]
+
+    monkeypatch.setattr(network, "_fan_out_all", _v2)
+    filled, total = asyncio.run(network._refill_signature_cache())
+    assert filled == 5 and total == 6
+    assert "orion-gtm" not in network._signature_cache
+    assert len(network._signature_cache) == 5


### PR DESCRIPTION
Sprint 1 / S1 from `crosstalk-enterprise/docs/plans/11-platform-grounding-sprint-1.md`.

Replaces per-call `_fan_out_all` in the public DSN resolver with a 60-second background poll filling `_signature_cache: dict[slug, _L2Snapshot]`. Resolver reads the cache. Cold-start or stale cache (>180s) falls back to one live fan-out and warms. Adds `cache_hit` + `cache_age_ms` to the trace path step.

**Tests**: 5 new cases in `tests/test_network_dsn_cache.py` + updated `test_dsn_resolve.py`. Full suite: 314 passed, 0 failed.

**Acceptance**: after deploy, `/api/v1/network/dsn/resolve` shows `resolution_path[1].step == "cache_lookup"` with `cache_hit == true` and latency in single-digit ms after the first 60s of process life. The "AIGRP routes the question" claim becomes defensible end-to-end.

Closes #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)