### PR TITLE
[server] DSN bloom prefilter at query time · closes #22

### DIFF
--- a/server/backend/src/cq_server/aigrp.py
+++ b/server/backend/src/cq_server/aigrp.py
@@ -118,6 +118,41 @@ def compute_domain_bloom(domains: Iterable[str]) -> bytes:
     return bytes(bitmap)
 
 
+def bloom_contains(bloom: bytes, domain: str) -> bool:
+    """Test whether ``domain`` is plausibly present in ``bloom``.
+
+    Returns True when every BLOOM_HASHES bit position for ``domain`` is
+    set — meaning either the domain was added or this is a false
+    positive (target rate <1% at design size). False negatives are
+    impossible by Bloom-filter construction.
+
+    Used by the DSN resolver's prefilter step (issue #22): peers whose
+    Bloom doesn't claim ANY of the query's domain tags are dropped
+    before cosine ranking, since their corpus can't have a relevant
+    KU.
+    """
+    if not bloom or not domain:
+        return False
+    if len(bloom) * 8 < BLOOM_BITS:
+        # Defensive: caller passed a truncated buffer. Treat as miss
+        # rather than IndexError.
+        return False
+    for h in _bloom_hashes(domain.strip().lower()):
+        byte_idx = h // 8
+        bit_idx = h % 8
+        if not (bloom[byte_idx] & (1 << bit_idx)):
+            return False
+    return True
+
+
+def bloom_matches_any(bloom: bytes, domains: Iterable[str]) -> bool:
+    """True iff at least one of ``domains`` is plausibly in the Bloom."""
+    for d in domains:
+        if bloom_contains(bloom, d):
+            return True
+    return False
+
+
 def compute_centroid(embeddings_iter: Iterable[bytes]) -> bytes | None:
     """Compute the L2-normalized centroid of an iterable of packed-float32 LE
     embedding blobs. Returns packed-float32 LE bytes, or None if no embeddings.

--- a/server/backend/src/cq_server/network.py
+++ b/server/backend/src/cq_server/network.py
@@ -339,6 +339,11 @@ class DsnResolveRequest(BaseModel):
     # their actual scope to get accurate policy hints.
     caller_enterprise: str = ""
     caller_group: str = ""
+    # Optional domain tags carried by the query. When non-empty, the
+    # resolver consults each peer's Bloom filter (already exchanged via
+    # AIGRP) and drops peers whose Bloom doesn't claim any of these
+    # domains BEFORE cosine ranking. Issue #22.
+    query_domains: list[str] = Field(default_factory=list)
 
 
 class DsnCandidate(BaseModel):
@@ -369,6 +374,9 @@ class DsnPathStep(BaseModel):
     l2_count: int | None = None
     cache_hit: bool | None = None
     cache_age_ms: int | None = None
+    # Number of peers dropped by the Bloom prefilter (only set on the
+    # `bloom_prefilter` step when query_domains is non-empty).
+    bloom_dropped: int | None = None
 
 
 class DsnResolveResponse(BaseModel):
@@ -610,6 +618,16 @@ def _cosine(a: list[float], b: list[float]) -> float:
     return dot / (na * nb)
 
 
+def _decode_bloom(b64_str: str | None) -> bytes | None:
+    """Decode a base64-encoded Bloom filter blob to bytes, or None on miss."""
+    if not b64_str:
+        return None
+    try:
+        return base64.b64decode(b64_str)
+    except Exception:
+        return None
+
+
 def _decode_centroid(b64_str: str | None) -> list[float] | None:
     """Decode a base64-encoded packed-float32 centroid back into a Python list."""
     if not b64_str:
@@ -774,6 +792,42 @@ async def network_dsn_resolve(
             cache_age_ms=cache_age_ms,
         )
     )
+
+    # Bloom prefilter (issue #22). When the query carries domain tags,
+    # drop peers whose Bloom doesn't claim ANY of those domains BEFORE
+    # cosine ranking. False negatives are impossible by Bloom-filter
+    # construction; false positives are <1% at design size, so we err
+    # toward keeping peers and just rely on cosine to deprioritize.
+    # When query_domains is empty (the public marketing case), the
+    # prefilter is a no-op and behavior is unchanged.
+    t_bloom = time.monotonic()
+    bloom_dropped = 0
+    if request.query_domains:
+        from . import aigrp as _aigrp_mod
+        kept: list[_L2Snapshot] = []
+        for snap in snapshots:
+            sig = snap.signature or {}
+            bloom = _decode_bloom(sig.get("domain_bloom_b64"))
+            if bloom is None:
+                # Peer didn't ship a bloom (older signature shape) — keep
+                # it, let cosine decide. Bloom is only ever a tightener.
+                kept.append(snap)
+                continue
+            if _aigrp_mod.bloom_matches_any(bloom, request.query_domains):
+                kept.append(snap)
+            else:
+                bloom_dropped += 1
+        snapshots = kept
+    bloom_ms = int((time.monotonic() - t_bloom) * 1000)
+    if request.query_domains:
+        path.append(
+            DsnPathStep(
+                step="bloom_prefilter",
+                latency_ms=bloom_ms,
+                l2_count=len(snapshots),
+                bloom_dropped=bloom_dropped,
+            )
+        )
 
     t2 = time.monotonic()
     consents = store.list_cross_enterprise_consents(

--- a/server/backend/tests/test_bloom_prefilter.py
+++ b/server/backend/tests/test_bloom_prefilter.py
@@ -1,0 +1,279 @@
+"""Issue #22 — Bloom prefilter at DSN query time.
+
+Pins:
+  - bloom_contains/bloom_matches_any helpers in aigrp.py work on real blooms.
+  - When DsnResolveRequest.query_domains is empty, behavior unchanged
+    (no prefilter step in resolution_path).
+  - When non-empty, peers whose Bloom doesn't claim ANY of the query
+    domains are dropped before ranking; trace step records dropped count.
+  - False-negative impossibility: a peer that DID add a domain is never
+    dropped for that query.
+  - Peers with no Bloom field (older signature shape) are kept — Bloom
+    is only ever a tightener, never a hard gate.
+"""
+
+from __future__ import annotations
+
+import base64
+import struct
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import bcrypt
+import pytest
+from fastapi.testclient import TestClient
+
+from cq_server import aigrp, network
+from cq_server.app import _get_store, app
+
+ALICE = "alice"
+
+
+def _pack(vec: list[float]) -> bytes:
+    return struct.pack(f"<{len(vec)}f", *vec)
+
+
+def _b64_centroid(axis: int, dim: int = 8) -> str:
+    v = [0.0] * dim
+    v[axis] = 1.0
+    return base64.b64encode(_pack(v)).decode("ascii")
+
+
+def _snap_with_bloom(
+    *,
+    slug: str,
+    enterprise: str,
+    group: str,
+    axis: int,
+    domains: list[str],
+) -> network._L2Snapshot:
+    s = network._L2Snapshot(
+        slug=slug,
+        enterprise=enterprise,
+        group=group,
+        endpoint=f"http://stub-{slug}.local",
+        reachable=True,
+    )
+    s.peers = []
+    bloom = aigrp.compute_domain_bloom(domains)
+    s.signature = {
+        "l2_id": f"{enterprise}/{group}",
+        "ku_count": 5,
+        "domain_count": len(domains),
+        "computed_at": "2026-05-01T00:00:00+00:00",
+        "embedding_centroid_b64": _b64_centroid(axis),
+        "domain_bloom_b64": base64.b64encode(bloom).decode("ascii"),
+        "embedding_model": "amazon.titan-embed-text-v2:0",
+    }
+    s.active_personas = []
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Helper-level tests — no FastAPI plumbing needed
+# ---------------------------------------------------------------------------
+
+
+class TestBloomHelpers:
+    def test_added_domain_is_contained(self) -> None:
+        bloom = aigrp.compute_domain_bloom(["cloudfront", "lambda", "cdn"])
+        assert aigrp.bloom_contains(bloom, "cloudfront") is True
+        assert aigrp.bloom_contains(bloom, "lambda") is True
+        # Case-insensitive
+        assert aigrp.bloom_contains(bloom, "CDN") is True
+
+    def test_unrelated_domain_likely_misses(self) -> None:
+        bloom = aigrp.compute_domain_bloom(["cloudfront", "lambda"])
+        # With 8192 bits and 5 hashes for ~2 entries, false-positive rate is
+        # essentially zero. 'kubernetes' should miss.
+        assert aigrp.bloom_contains(bloom, "kubernetes") is False
+
+    def test_matches_any_returns_on_first_hit(self) -> None:
+        bloom = aigrp.compute_domain_bloom(["cloudfront"])
+        assert aigrp.bloom_matches_any(bloom, ["kubernetes", "cloudfront"]) is True
+        assert aigrp.bloom_matches_any(bloom, ["kubernetes", "redis"]) is False
+
+    def test_empty_or_truncated_bloom_returns_false(self) -> None:
+        assert aigrp.bloom_contains(b"", "anything") is False
+        assert aigrp.bloom_contains(b"\x00" * 5, "anything") is False  # truncated
+
+
+# ---------------------------------------------------------------------------
+# Resolver-level tests — full /network/dsn/resolve roundtrip
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "bloom-prefilter.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    network._TOPOLOGY_CACHE["value"] = None
+    network._TOPOLOGY_CACHE["expires_at"] = 0.0
+    network._signature_cache.clear()
+    network._signature_cache_filled_at = 0.0
+    network._PEER_KEY_OVERRIDES.clear()
+    network._PEER_KEY_OVERRIDES["orion"] = "stub-orion-key"
+    network._PEER_KEY_OVERRIDES["acme"] = "stub-acme-key"
+
+    monkeypatch.setattr(network, "DSN_CACHE_REFRESH_SECS", 86_400)
+
+    async def _initial_noop(fleet):
+        return []
+
+    monkeypatch.setattr(network, "_fan_out_all", _initial_noop)
+
+    with TestClient(app) as c:
+        store = _get_store()
+        pw = bcrypt.hashpw(b"pw", bcrypt.gensalt()).decode()
+        store.create_user(ALICE, pw)
+        with store._lock, store._conn:
+            store._conn.execute(
+                "UPDATE users SET enterprise_id = 'acme', group_id = 'engineering' WHERE username = ?",
+                (ALICE,),
+            )
+        yield c
+
+
+def _login(client: TestClient) -> str:
+    resp = client.post("/api/v1/auth/login", json={"username": ALICE, "password": "pw"})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _stub_embed(monkeypatch: pytest.MonkeyPatch, axis: int = 0, dim: int = 8) -> None:
+    v = [0.0] * dim
+    v[axis] = 1.0
+
+    def _fake_embed(text: str):
+        return _pack(v), "stub-model"
+
+    monkeypatch.setattr(network, "embed_text", _fake_embed)
+
+
+def _seed_diverse_fleet() -> list[network._L2Snapshot]:
+    """6 L2s, each with a distinct domain set so the prefilter is exercised."""
+    return [
+        _snap_with_bloom(slug="orion-eng", enterprise="orion", group="engineering",
+                         axis=0, domains=["cloudfront", "lambda"]),
+        _snap_with_bloom(slug="orion-sol", enterprise="orion", group="solutions",
+                         axis=1, domains=["bedrock", "titan"]),
+        _snap_with_bloom(slug="orion-gtm", enterprise="orion", group="gtm",
+                         axis=2, domains=["sales", "outbound"]),
+        _snap_with_bloom(slug="acme-eng", enterprise="acme", group="engineering",
+                         axis=3, domains=["kubernetes", "istio"]),
+        _snap_with_bloom(slug="acme-sol", enterprise="acme", group="solutions",
+                         axis=4, domains=["cloudfront", "edge", "cdn"]),
+        _snap_with_bloom(slug="acme-fin", enterprise="acme", group="finance",
+                         axis=5, domains=["sap", "quickbooks"]),
+    ]
+
+
+def test_no_query_domains_means_no_prefilter_step(client, monkeypatch) -> None:
+    """Public visitor case: empty query_domains = pure cosine, no Bloom step."""
+    _stub_embed(monkeypatch, axis=0)
+    network._signature_cache.clear()
+    for s in _seed_diverse_fleet():
+        network._signature_cache[s.slug] = s
+    network._signature_cache_filled_at = time.monotonic()
+
+    jwt = _login(client)
+    resp = client.post(
+        "/api/v1/network/dsn/resolve",
+        headers={"Authorization": f"Bearer {jwt}"},
+        json={"intent": "anything"},  # no query_domains
+    )
+    assert resp.status_code == 200
+    steps = [s["step"] for s in resp.json()["resolution_path"]]
+    assert "bloom_prefilter" not in steps
+
+
+def test_query_domains_drops_peers_whose_bloom_doesnt_match(client, monkeypatch) -> None:
+    _stub_embed(monkeypatch, axis=0)
+    network._signature_cache.clear()
+    for s in _seed_diverse_fleet():
+        network._signature_cache[s.slug] = s
+    network._signature_cache_filled_at = time.monotonic()
+
+    jwt = _login(client)
+    # Only orion-eng (cloudfront,lambda) and acme-sol (cloudfront,edge,cdn) have cloudfront.
+    resp = client.post(
+        "/api/v1/network/dsn/resolve",
+        headers={"Authorization": f"Bearer {jwt}"},
+        json={"intent": "cloudfront origin failover", "query_domains": ["cloudfront"], "max_candidates": 10},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    # Bloom prefilter step is present, dropped 4 peers (kept 2)
+    bloom_step = next(s for s in body["resolution_path"] if s["step"] == "bloom_prefilter")
+    assert bloom_step["bloom_dropped"] == 4
+    assert bloom_step["l2_count"] == 2
+
+    # The candidates are exactly the two L2s that include cloudfront
+    candidate_l2s = sorted(c["l2_id"] for c in body["candidates"])
+    assert candidate_l2s == ["acme/solutions", "orion/engineering"]
+
+
+def test_added_domain_never_dropped_false_negative_safety(client, monkeypatch) -> None:
+    """Ensures no peer that ACTUALLY has a domain gets dropped for that domain.
+
+    Bloom filters guarantee no false negatives. We exercise this by
+    asking each peer's primary domain in turn and asserting it's kept.
+    """
+    _stub_embed(monkeypatch, axis=0)
+    network._signature_cache.clear()
+    fleet = _seed_diverse_fleet()
+    for s in fleet:
+        network._signature_cache[s.slug] = s
+    network._signature_cache_filled_at = time.monotonic()
+
+    jwt = _login(client)
+    for snap in fleet:
+        first_domain = snap.signature["l2_id"].split("/")[0]  # not the actual domain — fix
+        # Take the first actual domain we know we encoded
+        domain = {
+            "orion-eng": "cloudfront",
+            "orion-sol": "bedrock",
+            "orion-gtm": "sales",
+            "acme-eng": "kubernetes",
+            "acme-sol": "edge",
+            "acme-fin": "sap",
+        }[snap.slug]
+        del first_domain
+        resp = client.post(
+            "/api/v1/network/dsn/resolve",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={"intent": "x", "query_domains": [domain], "max_candidates": 10},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        candidate_l2s = [c["l2_id"] for c in body["candidates"]]
+        assert snap.signature["l2_id"] in candidate_l2s, (
+            f"peer {snap.slug} (domains include {domain!r}) was dropped — false negative!"
+        )
+
+
+def test_peer_without_bloom_is_kept(client, monkeypatch) -> None:
+    """Older signature shape (no domain_bloom_b64) must not be dropped — bloom is a tightener."""
+    _stub_embed(monkeypatch, axis=0)
+    fleet = _seed_diverse_fleet()
+    # Strip the bloom from one peer to simulate older signature shape
+    fleet[0].signature.pop("domain_bloom_b64", None)
+    network._signature_cache.clear()
+    for s in fleet:
+        network._signature_cache[s.slug] = s
+    network._signature_cache_filled_at = time.monotonic()
+
+    jwt = _login(client)
+    resp = client.post(
+        "/api/v1/network/dsn/resolve",
+        headers={"Authorization": f"Bearer {jwt}"},
+        json={"intent": "x", "query_domains": ["random-unrelated-domain"], "max_candidates": 10},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    candidate_l2s = [c["l2_id"] for c in body["candidates"]]
+    # The peer without a bloom (orion-eng) is kept regardless of query_domains
+    assert "orion/engineering" in candidate_l2s


### PR DESCRIPTION
Sprint 1 / S2. Adds `bloom_contains` / `bloom_matches_any` helpers in aigrp.py, an optional `query_domains` field on `DsnResolveRequest`, and a `bloom_prefilter` step in the resolution path that drops peers whose Bloom does not claim any of the query domains before cosine ranking. Empty `query_domains` (the public marketing case) = unchanged behavior. 9 new tests in `test_bloom_prefilter.py`, 322/322 suite green. Closes #22.