### PR TITLE
[server] L3 consults · same-L2 path · sprint 2 part 1 of #20

### DIFF
--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -28,6 +28,7 @@ from .deps import API_KEY_PEPPER_ENV, require_api_key
 from .embed import compose_text, embed_text
 from .embed import model_id as embed_model_id
 from .network import router as network_router
+from .consults import router as consults_router
 from .quality import check_propose_quality
 from .review import router as review_router
 from .scoring import apply_confirmation, apply_flag
@@ -227,6 +228,7 @@ api_router = APIRouter()
 api_router.include_router(auth_router)
 api_router.include_router(review_router)
 api_router.include_router(network_router)
+api_router.include_router(consults_router)
 
 
 @api_router.get("/health")

--- a/server/backend/src/cq_server/consults.py
+++ b/server/backend/src/cq_server/consults.py
@@ -1,0 +1,319 @@
+"""L3 consults — agent-to-agent live consult endpoints.
+
+Sprint 2 (issue #20). Same-L2 path only — both agents are on the same
+cq-server instance. Cross-L2 routing (intra-Enterprise via AIGRP +
+inter-Enterprise via AI-BGP) lands in a follow-up PR; the wire shape
+here is forward-compatible.
+
+L3 IS crosstalk evolved across the substrate (`docs/decisions/10`).
+The endpoint vocabulary maps 1:1 with claude-mux's existing crosstalk
+MCP primitives, just lifted onto HTTP. Routing through the L2 is the
+corporate-IP audit point: every consult lives durably in the
+``consults`` + ``consult_messages`` tables.
+
+Auth: bearer JWT issued by /auth/login. The token's username is mapped
+to ``{enterprise}/{group}/{persona}`` via the users table at request
+time. Cross-L2 calls in the future will use a separate inter-L2
+service token; out of scope here.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from .auth import get_current_user
+from .deps import get_store
+from .store import RemoteStore
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/consults", tags=["consults"])
+
+
+# ---------------------------------------------------------------------------
+# Wire models
+# ---------------------------------------------------------------------------
+
+
+class ConsultRequest(BaseModel):
+    """Body of POST /consults/request — open a new thread."""
+
+    to_l2_id: str = Field(min_length=1, description="Target L2 in {enterprise}/{group} form")
+    to_persona: str = Field(min_length=1)
+    subject: str | None = Field(default=None, max_length=200)
+    content: str = Field(min_length=1, description="The opening message of the thread")
+
+
+class ConsultMessage(BaseModel):
+    """Body of POST /consults/{thread_id}/messages — append a reply."""
+
+    content: str = Field(min_length=1)
+
+
+class CloseRequest(BaseModel):
+    """Body of POST /consults/{thread_id}/close."""
+
+    reason: str = Field(min_length=1)
+    resolution_summary: str | None = Field(default=None, max_length=4000)
+
+
+class ConsultThreadOut(BaseModel):
+    """One thread's metadata — appears in inbox listings + after open."""
+
+    thread_id: str
+    from_l2_id: str
+    from_persona: str
+    to_l2_id: str
+    to_persona: str
+    subject: str | None
+    status: str
+    claimed_by: str | None
+    created_at: str
+    closed_at: str | None
+    resolution_summary: str | None
+
+
+class ConsultMessageOut(BaseModel):
+    message_id: str
+    thread_id: str
+    from_l2_id: str
+    from_persona: str
+    content: str
+    created_at: str
+
+
+class InboxResponse(BaseModel):
+    self_l2_id: str
+    self_persona: str
+    threads: list[ConsultThreadOut]
+
+
+class MessagesResponse(BaseModel):
+    thread_id: str
+    messages: list[ConsultMessageOut]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _self_identity(store: RemoteStore, username: str) -> tuple[str, str]:
+    """Map the JWT subject to ``(l2_id, persona)``.
+
+    L2 id is ``{enterprise}/{group}`` (same shape as everywhere else
+    in the system). Persona defaults to the username; a future PR can
+    add per-user persona aliasing if needed (e.g. multiple personas
+    per human operator).
+    """
+    user = store.get_user(username)
+    if user is None:
+        raise HTTPException(status_code=401, detail="user not found")
+    enterprise = str(user.get("enterprise_id") or "default-enterprise")
+    group = str(user.get("group_id") or "default-group")
+    return f"{enterprise}/{group}", username
+
+
+def _to_thread_out(row: dict[str, Any]) -> ConsultThreadOut:
+    return ConsultThreadOut(
+        thread_id=row["thread_id"],
+        from_l2_id=row["from_l2_id"],
+        from_persona=row["from_persona"],
+        to_l2_id=row["to_l2_id"],
+        to_persona=row["to_persona"],
+        subject=row.get("subject"),
+        status=row["status"],
+        claimed_by=row.get("claimed_by"),
+        created_at=row["created_at"],
+        closed_at=row.get("closed_at"),
+        resolution_summary=row.get("resolution_summary"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/request", response_model=ConsultThreadOut, status_code=201)
+def request_consult(
+    body: ConsultRequest,
+    store: RemoteStore = Depends(get_store),
+    username: str = Depends(get_current_user),
+) -> ConsultThreadOut:
+    """Open a new consult thread. Caller becomes the ``from_*`` side.
+
+    Same-L2 path only (sprint 2). When ``to_l2_id`` doesn't match this
+    L2's identity, returns 501 — cross-L2 routing is the next PR.
+    Drops the opening message into ``consult_messages`` immediately so
+    a single round-trip is sufficient for the asker.
+    """
+    self_l2_id, self_persona = _self_identity(store, username)
+
+    # Same-L2 guard. Cross-L2 routing comes next.
+    if body.to_l2_id != self_l2_id:
+        raise HTTPException(
+            status_code=501,
+            detail=(
+                "cross-L2 consult routing is on the roadmap (issue #20 next PR); "
+                "this PR ships same-L2 only. "
+                f"This L2 is {self_l2_id!r}, request targeted {body.to_l2_id!r}."
+            ),
+        )
+
+    thread_id = f"th_{uuid4().hex[:16]}"
+    now = _now_iso()
+    store.create_consult(
+        thread_id=thread_id,
+        from_l2_id=self_l2_id,
+        from_persona=self_persona,
+        to_l2_id=body.to_l2_id,
+        to_persona=body.to_persona,
+        subject=body.subject,
+        created_at=now,
+    )
+    store.append_consult_message(
+        message_id=f"msg_{uuid4().hex[:16]}",
+        thread_id=thread_id,
+        from_l2_id=self_l2_id,
+        from_persona=self_persona,
+        content=body.content,
+        created_at=now,
+    )
+    row = store.get_consult(thread_id)
+    assert row is not None  # just inserted
+    return _to_thread_out(row)
+
+
+@router.post("/{thread_id}/messages", response_model=ConsultMessageOut, status_code=201)
+def post_consult_message(
+    thread_id: str,
+    body: ConsultMessage,
+    store: RemoteStore = Depends(get_store),
+    username: str = Depends(get_current_user),
+) -> ConsultMessageOut:
+    """Append a message to an existing thread.
+
+    The caller must be one of the two participants (from_persona or
+    to_persona on the matching L2). Closed threads reject with 409.
+    """
+    self_l2_id, self_persona = _self_identity(store, username)
+    thread = store.get_consult(thread_id)
+    if thread is None:
+        raise HTTPException(status_code=404, detail="thread not found")
+
+    # Authz: caller must be one of the two participants on this L2.
+    is_from = thread["from_l2_id"] == self_l2_id and thread["from_persona"] == self_persona
+    is_to = thread["to_l2_id"] == self_l2_id and thread["to_persona"] == self_persona
+    if not (is_from or is_to):
+        raise HTTPException(status_code=403, detail="not a participant in this thread")
+
+    if thread["status"] == "closed":
+        raise HTTPException(status_code=409, detail="thread is closed")
+
+    msg_id = f"msg_{uuid4().hex[:16]}"
+    now = _now_iso()
+    store.append_consult_message(
+        message_id=msg_id,
+        thread_id=thread_id,
+        from_l2_id=self_l2_id,
+        from_persona=self_persona,
+        content=body.content,
+        created_at=now,
+    )
+    return ConsultMessageOut(
+        message_id=msg_id,
+        thread_id=thread_id,
+        from_l2_id=self_l2_id,
+        from_persona=self_persona,
+        content=body.content,
+        created_at=now,
+    )
+
+
+@router.get("/{thread_id}/messages", response_model=MessagesResponse)
+def get_consult_messages(
+    thread_id: str,
+    store: RemoteStore = Depends(get_store),
+    username: str = Depends(get_current_user),
+) -> MessagesResponse:
+    """Read every message on a thread the caller participates in."""
+    self_l2_id, self_persona = _self_identity(store, username)
+    thread = store.get_consult(thread_id)
+    if thread is None:
+        raise HTTPException(status_code=404, detail="thread not found")
+    is_from = thread["from_l2_id"] == self_l2_id and thread["from_persona"] == self_persona
+    is_to = thread["to_l2_id"] == self_l2_id and thread["to_persona"] == self_persona
+    if not (is_from or is_to):
+        raise HTTPException(status_code=403, detail="not a participant in this thread")
+    msgs = store.list_consult_messages(thread_id)
+    return MessagesResponse(
+        thread_id=thread_id,
+        messages=[ConsultMessageOut(**m) for m in msgs],
+    )
+
+
+@router.post("/{thread_id}/close", response_model=ConsultThreadOut)
+def close_consult(
+    thread_id: str,
+    body: CloseRequest,
+    store: RemoteStore = Depends(get_store),
+    username: str = Depends(get_current_user),
+) -> ConsultThreadOut:
+    """Mark the thread closed. Either participant can close."""
+    self_l2_id, self_persona = _self_identity(store, username)
+    thread = store.get_consult(thread_id)
+    if thread is None:
+        raise HTTPException(status_code=404, detail="thread not found")
+    is_from = thread["from_l2_id"] == self_l2_id and thread["from_persona"] == self_persona
+    is_to = thread["to_l2_id"] == self_l2_id and thread["to_persona"] == self_persona
+    if not (is_from or is_to):
+        raise HTTPException(status_code=403, detail="not a participant in this thread")
+
+    closed = store.close_consult(
+        thread_id=thread_id,
+        closed_at=_now_iso(),
+        resolution_summary=body.resolution_summary,
+    )
+    if not closed:
+        # Already closed; just return current state without erroring
+        logger.info("close_consult on already-closed thread_id=%s", thread_id)
+    row = store.get_consult(thread_id)
+    assert row is not None
+    return _to_thread_out(row)
+
+
+@router.get("/inbox", response_model=InboxResponse)
+def get_inbox(
+    include_closed: bool = False,
+    limit: int = 50,
+    store: RemoteStore = Depends(get_store),
+    username: str = Depends(get_current_user),
+) -> InboxResponse:
+    """Threads addressed to the caller on this L2.
+
+    Default excludes closed threads. `include_closed=true` returns the
+    audit view (all threads, sorted by created_at DESC).
+    """
+    self_l2_id, self_persona = _self_identity(store, username)
+    rows = store.list_inbox(
+        to_l2_id=self_l2_id,
+        to_persona=self_persona,
+        include_closed=include_closed,
+        limit=max(1, min(limit, 200)),
+    )
+    return InboxResponse(
+        self_l2_id=self_l2_id,
+        self_persona=self_persona,
+        threads=[_to_thread_out(r) for r in rows],
+    )

--- a/server/backend/src/cq_server/store/__init__.py
+++ b/server/backend/src/cq_server/store/__init__.py
@@ -22,6 +22,7 @@ from ..tables import (
     DEFAULT_GROUP_ID,
     ensure_aigrp_peers_table,
     ensure_api_keys_table,
+    ensure_consults_schema,
     ensure_embedding_columns,
     ensure_peers_schema,
     ensure_review_columns,
@@ -102,6 +103,9 @@ class RemoteStore:
         ensure_users_table(self._conn)
         ensure_api_keys_table(self._conn)
         ensure_aigrp_peers_table(self._conn)
+        # Sprint 2 (issue #20) — L3 consult tables. Same idempotent
+        # shape; safe to call on every startup.
+        ensure_consults_schema(self._conn)
         # Phase 6 step 1 — additive tenancy columns. Idempotent; safe to
         # run on every startup. Backfills legacy rows so the columns can
         # be queried without NULL handling once enforcement lands.
@@ -1631,3 +1635,187 @@ class RemoteStore:
                 (revoked_at, consent_id),
             )
         return cur.rowcount > 0
+
+    # ---------------------------------------------------------------
+    # L3 consults (issue #20). Sprint 2 — same-L2 path. Cross-L2
+    # routing comes in a follow-up PR.
+    # ---------------------------------------------------------------
+
+    def create_consult(
+        self,
+        *,
+        thread_id: str,
+        from_l2_id: str,
+        from_persona: str,
+        to_l2_id: str,
+        to_persona: str,
+        subject: str | None,
+        created_at: str,
+    ) -> None:
+        """Open a new consult thread. Status starts at 'open'."""
+        self._check_open()
+        with self._lock, self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO consults (
+                    thread_id, from_l2_id, from_persona,
+                    to_l2_id, to_persona, subject,
+                    status, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, 'open', ?)
+                """,
+                (
+                    thread_id, from_l2_id, from_persona,
+                    to_l2_id, to_persona, subject,
+                    created_at,
+                ),
+            )
+
+    def get_consult(self, thread_id: str) -> dict[str, Any] | None:
+        self._check_open()
+        with self._lock:
+            row = self._conn.execute(
+                """
+                SELECT thread_id, from_l2_id, from_persona,
+                       to_l2_id, to_persona, subject,
+                       status, claimed_by, created_at,
+                       closed_at, resolution_summary
+                FROM consults WHERE thread_id = ?
+                """,
+                (thread_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return {
+            "thread_id": row[0],
+            "from_l2_id": row[1],
+            "from_persona": row[2],
+            "to_l2_id": row[3],
+            "to_persona": row[4],
+            "subject": row[5],
+            "status": row[6],
+            "claimed_by": row[7],
+            "created_at": row[8],
+            "closed_at": row[9],
+            "resolution_summary": row[10],
+        }
+
+    def append_consult_message(
+        self,
+        *,
+        message_id: str,
+        thread_id: str,
+        from_l2_id: str,
+        from_persona: str,
+        content: str,
+        created_at: str,
+    ) -> None:
+        """Append a message to an existing thread.
+
+        Caller is responsible for verifying the thread exists and is
+        not closed (raise 404 / 409 at the API layer).
+        """
+        self._check_open()
+        with self._lock, self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO consult_messages (
+                    message_id, thread_id, from_l2_id,
+                    from_persona, content, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    message_id, thread_id, from_l2_id,
+                    from_persona, content, created_at,
+                ),
+            )
+
+    def list_consult_messages(self, thread_id: str) -> list[dict[str, Any]]:
+        self._check_open()
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT message_id, thread_id, from_l2_id,
+                       from_persona, content, created_at
+                FROM consult_messages
+                WHERE thread_id = ?
+                ORDER BY created_at ASC
+                """,
+                (thread_id,),
+            ).fetchall()
+        return [
+            {
+                "message_id": r[0],
+                "thread_id": r[1],
+                "from_l2_id": r[2],
+                "from_persona": r[3],
+                "content": r[4],
+                "created_at": r[5],
+            }
+            for r in rows
+        ]
+
+    def close_consult(
+        self,
+        *,
+        thread_id: str,
+        closed_at: str,
+        resolution_summary: str | None,
+    ) -> bool:
+        """Mark a thread closed. Returns True if it was open before."""
+        self._check_open()
+        with self._lock, self._conn:
+            cur = self._conn.execute(
+                """
+                UPDATE consults
+                SET status = 'closed', closed_at = ?, resolution_summary = ?
+                WHERE thread_id = ? AND status != 'closed'
+                """,
+                (closed_at, resolution_summary, thread_id),
+            )
+        return cur.rowcount > 0
+
+    def list_inbox(
+        self,
+        *,
+        to_l2_id: str,
+        to_persona: str,
+        include_closed: bool = False,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Return threads addressed to (l2_id, persona).
+
+        Default excludes closed threads; pass include_closed=True for an
+        audit-style view.
+        """
+        self._check_open()
+        sql = """
+            SELECT thread_id, from_l2_id, from_persona,
+                   to_l2_id, to_persona, subject,
+                   status, claimed_by, created_at,
+                   closed_at, resolution_summary
+            FROM consults
+            WHERE to_l2_id = ? AND to_persona = ?
+        """
+        params: list[Any] = [to_l2_id, to_persona]
+        if not include_closed:
+            sql += " AND status != 'closed'"
+        sql += " ORDER BY created_at DESC LIMIT ?"
+        params.append(limit)
+        with self._lock:
+            rows = self._conn.execute(sql, params).fetchall()
+        return [
+            {
+                "thread_id": r[0],
+                "from_l2_id": r[1],
+                "from_persona": r[2],
+                "to_l2_id": r[3],
+                "to_persona": r[4],
+                "subject": r[5],
+                "status": r[6],
+                "claimed_by": r[7],
+                "created_at": r[8],
+                "closed_at": r[9],
+                "resolution_summary": r[10],
+            }
+            for r in rows
+        ]

--- a/server/backend/src/cq_server/tables.py
+++ b/server/backend/src/cq_server/tables.py
@@ -93,6 +93,38 @@ CREATE TABLE IF NOT EXISTS aigrp_peers (
 CREATE INDEX IF NOT EXISTS idx_aigrp_peers_enterprise ON aigrp_peers(enterprise);
 """
 
+CONSULTS_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS consults (
+    thread_id          TEXT PRIMARY KEY,
+    from_l2_id         TEXT NOT NULL,
+    from_persona       TEXT NOT NULL,
+    to_l2_id           TEXT NOT NULL,
+    to_persona         TEXT NOT NULL,
+    subject            TEXT,
+    status             TEXT NOT NULL DEFAULT 'open',
+    claimed_by         TEXT,
+    created_at         TEXT NOT NULL,
+    closed_at          TEXT,
+    resolution_summary TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_consults_to_l2_persona ON consults(to_l2_id, to_persona, status);
+CREATE INDEX IF NOT EXISTS idx_consults_from_l2_persona ON consults(from_l2_id, from_persona);
+CREATE INDEX IF NOT EXISTS idx_consults_created ON consults(created_at);
+"""
+
+CONSULT_MESSAGES_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS consult_messages (
+    message_id   TEXT PRIMARY KEY,
+    thread_id    TEXT NOT NULL,
+    from_l2_id   TEXT NOT NULL,
+    from_persona TEXT NOT NULL,
+    content      TEXT NOT NULL,
+    created_at   TEXT NOT NULL,
+    FOREIGN KEY (thread_id) REFERENCES consults(thread_id)
+);
+CREATE INDEX IF NOT EXISTS idx_consult_messages_thread ON consult_messages(thread_id, created_at);
+"""
+
 USERS_TABLE_SQL = f"""
 CREATE TABLE IF NOT EXISTS users (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -187,6 +219,24 @@ def ensure_aigrp_peers_table(conn: sqlite3.Connection) -> None:
 def ensure_users_table(conn: sqlite3.Connection) -> None:
     """Create the users table if it does not exist."""
     conn.executescript(USERS_TABLE_SQL)
+
+
+def ensure_consults_schema(conn: sqlite3.Connection) -> None:
+    """Create the L3 consult tables if they do not exist.
+
+    Sprint 2 (issue #20). Two tables:
+      - consults: one row per agent-to-agent thread (subject, status,
+        from/to addressing, timestamps).
+      - consult_messages: append-only message log per thread.
+
+    Same shape as claude-mux's existing crosstalk MCP schema — L3 IS
+    crosstalk evolved across the substrate (`docs/decisions/10`).
+    Routing through the L2 is the corporate-IP audit point: every
+    consult lives durably on at least one L2 (same-team) or two L2s
+    (cross-team / cross-enterprise).
+    """
+    conn.executescript(CONSULTS_TABLE_SQL)
+    conn.executescript(CONSULT_MESSAGES_TABLE_SQL)
 
 
 def ensure_tenancy_columns(conn: sqlite3.Connection) -> None:

--- a/server/backend/tests/test_consults.py
+++ b/server/backend/tests/test_consults.py
@@ -1,0 +1,287 @@
+"""Sprint 2 / Issue #20 — L3 consults · same-L2 path.
+
+Pins:
+  - Open thread + drop opening message in one POST /consults/request.
+  - Inbox of recipient shows the open thread.
+  - Either participant can append messages on /consults/{id}/messages.
+  - Non-participants get 403.
+  - Either participant can close; closing a thread blocks further messages (409).
+  - Cross-L2 target returns 501 (next PR).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import bcrypt
+import pytest
+from fastapi.testclient import TestClient
+
+from cq_server import network
+from cq_server.app import _get_store, app
+
+ALICE = "alice"  # acme/engineering
+BOB = "bob"      # acme/engineering — same L2 as Alice
+CARLA = "carla"  # acme/solutions  — different L2 from Alice (cross-team)
+DAN = "dan"      # also acme/engineering — third-party for participant gating
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "consults.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    network._signature_cache.clear()
+    network._signature_cache_filled_at = 0.0
+    monkeypatch.setattr(network, "DSN_CACHE_REFRESH_SECS", 86_400)
+
+    async def _initial_noop(fleet):
+        return []
+
+    monkeypatch.setattr(network, "_fan_out_all", _initial_noop)
+
+    with TestClient(app) as c:
+        store = _get_store()
+        for user, ent, grp in [
+            (ALICE, "acme", "engineering"),
+            (BOB, "acme", "engineering"),
+            (CARLA, "acme", "solutions"),
+            (DAN, "acme", "engineering"),
+        ]:
+            pw = bcrypt.hashpw(b"pw", bcrypt.gensalt()).decode()
+            store.create_user(user, pw)
+            with store._lock, store._conn:
+                store._conn.execute(
+                    "UPDATE users SET enterprise_id = ?, group_id = ? WHERE username = ?",
+                    (ent, grp, user),
+                )
+        yield c
+
+
+def _login(client: TestClient, who: str) -> str:
+    r = client.post("/api/v1/auth/login", json={"username": who, "password": "pw"})
+    assert r.status_code == 200, r.text
+    return r.json()["token"]
+
+
+def _headers(client: TestClient, who: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {_login(client, who)}"}
+
+
+# ---------------------------------------------------------------------------
+# Happy path — same-L2 consult between Alice and Bob
+# ---------------------------------------------------------------------------
+
+
+def test_alice_opens_thread_to_bob_drops_opening_message(client: TestClient) -> None:
+    r = client.post(
+        "/api/v1/consults/request",
+        headers=_headers(client, ALICE),
+        json={
+            "to_l2_id": "acme/engineering",
+            "to_persona": BOB,
+            "subject": "have you seen the cloudfront origin failover thing?",
+            "content": "We're hitting a 503 cascade when origin-shield expires.",
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["from_persona"] == ALICE
+    assert body["to_persona"] == BOB
+    assert body["from_l2_id"] == "acme/engineering"
+    assert body["to_l2_id"] == "acme/engineering"
+    assert body["status"] == "open"
+    thread_id = body["thread_id"]
+
+    # The opening message landed in /messages
+    msgs = client.get(
+        f"/api/v1/consults/{thread_id}/messages",
+        headers=_headers(client, ALICE),
+    )
+    assert msgs.status_code == 200, msgs.text
+    msg_list = msgs.json()["messages"]
+    assert len(msg_list) == 1
+    assert msg_list[0]["from_persona"] == ALICE
+    assert "503 cascade" in msg_list[0]["content"]
+
+
+def test_recipient_sees_thread_in_inbox(client: TestClient) -> None:
+    # Alice opens
+    r = client.post(
+        "/api/v1/consults/request",
+        headers=_headers(client, ALICE),
+        json={
+            "to_l2_id": "acme/engineering",
+            "to_persona": BOB,
+            "content": "ping",
+        },
+    )
+    assert r.status_code == 201
+    thread_id = r.json()["thread_id"]
+
+    # Bob's inbox includes it
+    inbox = client.get("/api/v1/consults/inbox", headers=_headers(client, BOB))
+    assert inbox.status_code == 200, inbox.text
+    body = inbox.json()
+    assert body["self_l2_id"] == "acme/engineering"
+    assert body["self_persona"] == BOB
+    thread_ids = [t["thread_id"] for t in body["threads"]]
+    assert thread_id in thread_ids
+
+
+def test_either_participant_can_reply(client: TestClient) -> None:
+    open_resp = client.post(
+        "/api/v1/consults/request",
+        headers=_headers(client, ALICE),
+        json={"to_l2_id": "acme/engineering", "to_persona": BOB, "content": "hi"},
+    )
+    thread_id = open_resp.json()["thread_id"]
+
+    # Bob replies
+    bob_reply = client.post(
+        f"/api/v1/consults/{thread_id}/messages",
+        headers=_headers(client, BOB),
+        json={"content": "saw your runbook — origin-shield TTL?"},
+    )
+    assert bob_reply.status_code == 201, bob_reply.text
+    assert bob_reply.json()["from_persona"] == BOB
+
+    # Alice replies again
+    alice_reply = client.post(
+        f"/api/v1/consults/{thread_id}/messages",
+        headers=_headers(client, ALICE),
+        json={"content": "yeah, set 48h — but pin the secondary first"},
+    )
+    assert alice_reply.status_code == 201
+
+    # Three messages total (open + Bob + Alice)
+    msgs = client.get(
+        f"/api/v1/consults/{thread_id}/messages",
+        headers=_headers(client, ALICE),
+    ).json()["messages"]
+    assert len(msgs) == 3
+    assert [m["from_persona"] for m in msgs] == [ALICE, BOB, ALICE]
+
+
+def test_non_participant_403_on_messages(client: TestClient) -> None:
+    open_resp = client.post(
+        "/api/v1/consults/request",
+        headers=_headers(client, ALICE),
+        json={"to_l2_id": "acme/engineering", "to_persona": BOB, "content": "hi"},
+    )
+    thread_id = open_resp.json()["thread_id"]
+
+    # Dan (same L2 as alice/bob, but not a participant) tries to reply
+    r = client.post(
+        f"/api/v1/consults/{thread_id}/messages",
+        headers=_headers(client, DAN),
+        json={"content": "eavesdrop"},
+    )
+    assert r.status_code == 403, r.text
+
+    # Dan tries to read messages
+    r = client.get(
+        f"/api/v1/consults/{thread_id}/messages",
+        headers=_headers(client, DAN),
+    )
+    assert r.status_code == 403, r.text
+
+
+# ---------------------------------------------------------------------------
+# Closing
+# ---------------------------------------------------------------------------
+
+
+def test_either_participant_can_close_blocks_further_messages(client: TestClient) -> None:
+    open_resp = client.post(
+        "/api/v1/consults/request",
+        headers=_headers(client, ALICE),
+        json={"to_l2_id": "acme/engineering", "to_persona": BOB, "content": "hi"},
+    )
+    thread_id = open_resp.json()["thread_id"]
+
+    # Bob closes
+    close = client.post(
+        f"/api/v1/consults/{thread_id}/close",
+        headers=_headers(client, BOB),
+        json={"reason": "got what I needed", "resolution_summary": "set TTL=48h, pin secondary"},
+    )
+    assert close.status_code == 200, close.text
+    assert close.json()["status"] == "closed"
+    assert close.json()["resolution_summary"] == "set TTL=48h, pin secondary"
+
+    # Alice tries to reply on closed thread
+    r = client.post(
+        f"/api/v1/consults/{thread_id}/messages",
+        headers=_headers(client, ALICE),
+        json={"content": "one more thing"},
+    )
+    assert r.status_code == 409, r.text
+
+
+def test_closed_thread_excluded_from_inbox_by_default(client: TestClient) -> None:
+    open_resp = client.post(
+        "/api/v1/consults/request",
+        headers=_headers(client, ALICE),
+        json={"to_l2_id": "acme/engineering", "to_persona": BOB, "content": "hi"},
+    )
+    thread_id = open_resp.json()["thread_id"]
+    client.post(
+        f"/api/v1/consults/{thread_id}/close",
+        headers=_headers(client, BOB),
+        json={"reason": "done"},
+    )
+
+    # Default — closed not shown
+    inbox = client.get("/api/v1/consults/inbox", headers=_headers(client, BOB)).json()
+    assert thread_id not in [t["thread_id"] for t in inbox["threads"]]
+
+    # include_closed=true — audit view includes it
+    inbox_all = client.get(
+        "/api/v1/consults/inbox?include_closed=true", headers=_headers(client, BOB)
+    ).json()
+    assert thread_id in [t["thread_id"] for t in inbox_all["threads"]]
+
+
+# ---------------------------------------------------------------------------
+# Cross-L2 → 501 (next PR will implement this)
+# ---------------------------------------------------------------------------
+
+
+def test_cross_l2_target_returns_501(client: TestClient) -> None:
+    """Alice on acme/engineering tries to reach Carla on acme/solutions.
+
+    Today: 501 with a clear message about the next PR. After cross-L2
+    routing lands, this test should be updated to assert 201 + the
+    forwarded thread.
+    """
+    r = client.post(
+        "/api/v1/consults/request",
+        headers=_headers(client, ALICE),
+        json={
+            "to_l2_id": "acme/solutions",
+            "to_persona": CARLA,
+            "content": "hi from engineering",
+        },
+    )
+    assert r.status_code == 501, r.text
+    assert "cross-L2" in r.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Auth — anonymous calls rejected
+# ---------------------------------------------------------------------------
+
+
+def test_anonymous_request_rejected(client: TestClient) -> None:
+    r = client.post(
+        "/api/v1/consults/request",
+        json={"to_l2_id": "acme/engineering", "to_persona": BOB, "content": "hi"},
+    )
+    assert r.status_code in (401, 403)
+
+
+def test_anonymous_inbox_rejected(client: TestClient) -> None:
+    r = client.get("/api/v1/consults/inbox")
+    assert r.status_code in (401, 403)


### PR DESCRIPTION
Sprint 2 first cut at L3. Wire shape ported from claude-mux crosstalk per decisions/10. Same-L2 path; cross-L2 next PR. New `consults` + `consult_messages` tables, 5 endpoints under `/consults/*`, 9 tests, 331/331 suite green. Refs #20.