### PR TITLE
[server] L3 consults · cross-L2 routing via AIGRP · sprint 2 part 2 of #20

### DIFF
--- a/server/backend/src/cq_server/consults.py
+++ b/server/backend/src/cq_server/consults.py
@@ -20,13 +20,16 @@ service token; out of scope here.
 from __future__ import annotations
 
 import logging
+import os
 from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
+from . import aigrp as aigrp_mod
 from .auth import get_current_user
 from .deps import get_store
 from .store import RemoteStore
@@ -124,6 +127,88 @@ def _self_identity(store: RemoteStore, username: str) -> tuple[str, str]:
     return f"{enterprise}/{group}", username
 
 
+# Cross-L2 forwarding helpers. We reuse the AIGRP peer table the
+# 5-minute mesh poll already maintains — looking up a target L2's
+# endpoint_url + enterprise by l2_id, no separate routing config.
+# Cross-Enterprise is gated below with an explicit 501 (issue #19,
+# AI-BGP) — same-Enterprise different-Group works today.
+
+L2_FORWARD_TIMEOUT = float(os.environ.get("L3_FORWARD_TIMEOUT_SECS", "8"))
+
+
+def _resolve_peer(store: RemoteStore, l2_id: str) -> dict[str, Any] | None:
+    """Find a peer's row in this L2's AIGRP peer table by ``l2_id``."""
+    try:
+        ent, _grp = l2_id.split("/", 1)
+    except ValueError:
+        return None
+    for row in store.list_aigrp_peers(ent):
+        if row["l2_id"] == l2_id:
+            return row
+    return None
+
+
+def _self_l2_id() -> str:
+    """This process's identity — same shape AIGRP uses on the wire."""
+    return f"{aigrp_mod.enterprise()}/{aigrp_mod.group()}"
+
+
+def _forward_request(target: dict[str, Any], payload: dict[str, Any]) -> None:
+    """POST /consults/forward-request to a peer L2 with the peer-key bearer.
+
+    Best-effort: a forward failure does NOT roll back the local mirror
+    write. Callers see 502 if the peer is unreachable so they know the
+    remote side won't see the message until they reach the recipient L2
+    directly. Subsequent replies retry independently.
+    """
+    base = target["endpoint_url"].rstrip("/")
+    peer_key = os.environ.get("CQ_AIGRP_PEER_KEY", "")
+    if not peer_key:
+        raise HTTPException(503, detail="cross-L2 routing requires CQ_AIGRP_PEER_KEY")
+    try:
+        with httpx.Client(timeout=L2_FORWARD_TIMEOUT) as client:
+            r = client.post(
+                f"{base}/api/v1/consults/forward-request",
+                headers={"authorization": f"Bearer {peer_key}"},
+                json=payload,
+            )
+        if r.status_code >= 400:
+            raise HTTPException(
+                status_code=502,
+                detail=f"peer {target['l2_id']} returned {r.status_code} on /consults/forward-request: {r.text[:200]}",
+            )
+    except httpx.RequestError as e:
+        raise HTTPException(
+            status_code=502,
+            detail=f"peer {target['l2_id']} unreachable: {e}",
+        ) from e
+
+
+def _forward_message(target: dict[str, Any], payload: dict[str, Any]) -> None:
+    """POST /consults/forward-message — symmetric to _forward_request."""
+    base = target["endpoint_url"].rstrip("/")
+    peer_key = os.environ.get("CQ_AIGRP_PEER_KEY", "")
+    if not peer_key:
+        raise HTTPException(503, detail="cross-L2 routing requires CQ_AIGRP_PEER_KEY")
+    try:
+        with httpx.Client(timeout=L2_FORWARD_TIMEOUT) as client:
+            r = client.post(
+                f"{base}/api/v1/consults/forward-message",
+                headers={"authorization": f"Bearer {peer_key}"},
+                json=payload,
+            )
+        if r.status_code >= 400:
+            raise HTTPException(
+                status_code=502,
+                detail=f"peer {target['l2_id']} returned {r.status_code} on /consults/forward-message",
+            )
+    except httpx.RequestError as e:
+        raise HTTPException(
+            status_code=502,
+            detail=f"peer {target['l2_id']} unreachable: {e}",
+        ) from e
+
+
 def _to_thread_out(row: dict[str, Any]) -> ConsultThreadOut:
     return ConsultThreadOut(
         thread_id=row["thread_id"],
@@ -160,19 +245,41 @@ def request_consult(
     """
     self_l2_id, self_persona = _self_identity(store, username)
 
-    # Same-L2 guard. Cross-L2 routing comes next.
-    if body.to_l2_id != self_l2_id:
-        raise HTTPException(
-            status_code=501,
-            detail=(
-                "cross-L2 consult routing is on the roadmap (issue #20 next PR); "
-                "this PR ships same-L2 only. "
-                f"This L2 is {self_l2_id!r}, request targeted {body.to_l2_id!r}."
-            ),
-        )
-
     thread_id = f"th_{uuid4().hex[:16]}"
+    msg_id = f"msg_{uuid4().hex[:16]}"
     now = _now_iso()
+
+    # Resolve cross-L2 target if the recipient lives on a different L2.
+    is_same_l2 = body.to_l2_id == self_l2_id
+    target_peer: dict[str, Any] | None = None
+
+    if not is_same_l2:
+        target_peer = _resolve_peer(store, body.to_l2_id)
+        if target_peer is None:
+            raise HTTPException(
+                status_code=404,
+                detail=(
+                    f"target L2 {body.to_l2_id!r} is not in this L2's AIGRP peer "
+                    "table — either it's not in the same Enterprise or AIGRP "
+                    "hasn't converged yet. Cross-Enterprise consults will use "
+                    "AI-BGP (issue #19), not yet shipped."
+                ),
+            )
+        # Cross-Enterprise reach is gated on AI-BGP. Today it's just a
+        # peer-table lookup — same-Enterprise only by virtue of how the
+        # peer table is populated. Belt-and-braces guard:
+        if target_peer["enterprise"] != aigrp_mod.enterprise():
+            raise HTTPException(
+                status_code=501,
+                detail=(
+                    "cross-Enterprise consult routing is on the roadmap "
+                    "(issue #19 AI-BGP); same-Enterprise cross-Group works today."
+                ),
+            )
+
+    # Mirror-write the thread + opening message LOCALLY first. This is
+    # the asker's audit point: even if the forward fails, the asker's
+    # L2 has a durable record of "I tried to consult X on Y at T".
     store.create_consult(
         thread_id=thread_id,
         from_l2_id=self_l2_id,
@@ -183,13 +290,29 @@ def request_consult(
         created_at=now,
     )
     store.append_consult_message(
-        message_id=f"msg_{uuid4().hex[:16]}",
+        message_id=msg_id,
         thread_id=thread_id,
         from_l2_id=self_l2_id,
         from_persona=self_persona,
         content=body.content,
         created_at=now,
     )
+
+    # Forward to the recipient L2 if cross-L2. Both sides log = the
+    # routing-through-L2 corporate-IP audit point per decisions/10.
+    if target_peer is not None:
+        _forward_request(target_peer, {
+            "thread_id": thread_id,
+            "message_id": msg_id,
+            "from_l2_id": self_l2_id,
+            "from_persona": self_persona,
+            "to_l2_id": body.to_l2_id,
+            "to_persona": body.to_persona,
+            "subject": body.subject,
+            "content": body.content,
+            "created_at": now,
+        })
+
     row = store.get_consult(thread_id)
     assert row is not None  # just inserted
     return _to_thread_out(row)
@@ -223,6 +346,21 @@ def post_consult_message(
 
     msg_id = f"msg_{uuid4().hex[:16]}"
     now = _now_iso()
+
+    # Resolve the OTHER side's L2 for cross-L2 forward. The thread
+    # carries both endpoints; the side that's NOT us is where the
+    # message has to be mirrored.
+    other_l2_id = thread["to_l2_id"] if is_from else thread["from_l2_id"]
+    other_persona = thread["to_persona"] if is_from else thread["from_persona"]
+    target_peer = None
+    if other_l2_id != self_l2_id:
+        target_peer = _resolve_peer(store, other_l2_id)
+        if target_peer is None:
+            raise HTTPException(
+                status_code=502,
+                detail=f"peer L2 {other_l2_id!r} not in AIGRP peer table",
+            )
+
     store.append_consult_message(
         message_id=msg_id,
         thread_id=thread_id,
@@ -231,6 +369,28 @@ def post_consult_message(
         content=body.content,
         created_at=now,
     )
+
+    if target_peer is not None:
+        _forward_message(target_peer, {
+            "thread_id": thread_id,
+            "message_id": msg_id,
+            "from_l2_id": self_l2_id,
+            "from_persona": self_persona,
+            # Hand the thread shape back so the peer can lazily mirror
+            # the thread row if it's somehow missing (defensive — should
+            # always exist from the original /consults/forward-request).
+            "thread_subject": thread.get("subject"),
+            "thread_to_l2_id": thread["to_l2_id"],
+            "thread_to_persona": thread["to_persona"],
+            "thread_from_l2_id": thread["from_l2_id"],
+            "thread_from_persona": thread["from_persona"],
+            "thread_created_at": thread["created_at"],
+            "content": body.content,
+            "created_at": now,
+        })
+        # Kept side-note: cross-L2 unused var lint guard
+        del other_persona
+
     return ConsultMessageOut(
         message_id=msg_id,
         thread_id=thread_id,
@@ -291,6 +451,135 @@ def close_consult(
     row = store.get_consult(thread_id)
     assert row is not None
     return _to_thread_out(row)
+
+
+# ---------------------------------------------------------------------------
+# Internal forward endpoints (peer-key auth) — receive a mirrored thread
+# from a sibling L2 in the same Enterprise. Not called by clients.
+# ---------------------------------------------------------------------------
+
+
+class ForwardRequestBody(BaseModel):
+    thread_id: str
+    message_id: str
+    from_l2_id: str
+    from_persona: str
+    to_l2_id: str
+    to_persona: str
+    subject: str | None = None
+    content: str
+    created_at: str
+
+
+@router.post("/forward-request", status_code=201)
+def forward_consult_request(
+    body: ForwardRequestBody,
+    store: RemoteStore = Depends(get_store),
+    _peer: None = Depends(aigrp_mod.require_peer_key),
+) -> dict[str, str]:
+    """Mirror a remote consult request onto this L2.
+
+    Called by a sibling L2 in the same Enterprise after the originating
+    side did its local mirror-write. We re-do the same writes here so
+    BOTH L2s have the durable corporate-IP record per decisions/10.
+
+    Idempotent on thread_id collision: if the thread already exists
+    (re-delivery, retry), we skip the create and just append the message
+    if it's new. Same for message_id.
+    """
+    if store.get_consult(body.thread_id) is None:
+        store.create_consult(
+            thread_id=body.thread_id,
+            from_l2_id=body.from_l2_id,
+            from_persona=body.from_persona,
+            to_l2_id=body.to_l2_id,
+            to_persona=body.to_persona,
+            subject=body.subject,
+            created_at=body.created_at,
+        )
+    # Idempotent on message_id via PRIMARY KEY; sqlite raises IntegrityError.
+    # We swallow it because re-delivery should be a no-op, not a 500.
+    try:
+        store.append_consult_message(
+            message_id=body.message_id,
+            thread_id=body.thread_id,
+            from_l2_id=body.from_l2_id,
+            from_persona=body.from_persona,
+            content=body.content,
+            created_at=body.created_at,
+        )
+    except Exception as e:
+        # IntegrityError on duplicate message_id is fine; everything else re-raises.
+        if "UNIQUE constraint failed" not in str(e):
+            raise
+    return {"status": "mirrored", "thread_id": body.thread_id}
+
+
+class ForwardMessageBody(BaseModel):
+    thread_id: str
+    message_id: str
+    from_l2_id: str
+    from_persona: str
+    content: str
+    created_at: str
+    # Defensive: thread metadata so the receiver can lazily backfill if
+    # the original /forward-request was lost.
+    thread_subject: str | None = None
+    thread_to_l2_id: str | None = None
+    thread_to_persona: str | None = None
+    thread_from_l2_id: str | None = None
+    thread_from_persona: str | None = None
+    thread_created_at: str | None = None
+
+
+@router.post("/forward-message", status_code=201)
+def forward_consult_message(
+    body: ForwardMessageBody,
+    store: RemoteStore = Depends(get_store),
+    _peer: None = Depends(aigrp_mod.require_peer_key),
+) -> dict[str, str]:
+    """Mirror a reply onto this L2.
+
+    If the thread row is missing (e.g. /forward-request was lost), we
+    create it from the embedded thread metadata before appending. This
+    prevents a single dropped forward from permanently breaking the
+    audit trail on this side.
+    """
+    existing = store.get_consult(body.thread_id)
+    if existing is None:
+        if not (
+            body.thread_to_l2_id
+            and body.thread_to_persona
+            and body.thread_from_l2_id
+            and body.thread_from_persona
+            and body.thread_created_at
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="thread metadata missing and no existing thread to append to",
+            )
+        store.create_consult(
+            thread_id=body.thread_id,
+            from_l2_id=body.thread_from_l2_id,
+            from_persona=body.thread_from_persona,
+            to_l2_id=body.thread_to_l2_id,
+            to_persona=body.thread_to_persona,
+            subject=body.thread_subject,
+            created_at=body.thread_created_at,
+        )
+    try:
+        store.append_consult_message(
+            message_id=body.message_id,
+            thread_id=body.thread_id,
+            from_l2_id=body.from_l2_id,
+            from_persona=body.from_persona,
+            content=body.content,
+            created_at=body.created_at,
+        )
+    except Exception as e:
+        if "UNIQUE constraint failed" not in str(e):
+            raise
+    return {"status": "mirrored", "thread_id": body.thread_id}
 
 
 @router.get("/inbox", response_model=InboxResponse)

--- a/server/backend/tests/test_consults.py
+++ b/server/backend/tests/test_consults.py
@@ -249,12 +249,12 @@ def test_closed_thread_excluded_from_inbox_by_default(client: TestClient) -> Non
 # ---------------------------------------------------------------------------
 
 
-def test_cross_l2_target_returns_501(client: TestClient) -> None:
-    """Alice on acme/engineering tries to reach Carla on acme/solutions.
+def test_cross_l2_target_unknown_peer_returns_404(client: TestClient) -> None:
+    """Cross-L2 to a peer not in this L2's AIGRP table returns 404.
 
-    Today: 501 with a clear message about the next PR. After cross-L2
-    routing lands, this test should be updated to assert 201 + the
-    forwarded thread.
+    Same-Enterprise different-Group works once AIGRP has converged
+    (covered separately in test_cross_l2_routing.py with a stubbed
+    peer table). Cross-Enterprise still 501 — gated on AI-BGP (#19).
     """
     r = client.post(
         "/api/v1/consults/request",
@@ -265,8 +265,11 @@ def test_cross_l2_target_returns_501(client: TestClient) -> None:
             "content": "hi from engineering",
         },
     )
-    assert r.status_code == 501, r.text
-    assert "cross-L2" in r.json()["detail"]
+    # No peer in the AIGRP table for this test fixture's enterprise,
+    # so we get 404 not 201. The forward path itself is exercised in
+    # test_cross_l2_routing.py.
+    assert r.status_code == 404, r.text
+    assert "AIGRP peer table" in r.json()["detail"]
 
 
 # ---------------------------------------------------------------------------

--- a/server/backend/tests/test_cross_l2_routing.py
+++ b/server/backend/tests/test_cross_l2_routing.py
@@ -1,0 +1,414 @@
+"""Sprint 2 part 2 — cross-L2 consult routing via AIGRP.
+
+Pins:
+  - Same-Enterprise cross-Group: forwards to peer's /consults/forward-request
+    with peer-key bearer; thread mirrors locally first, then peer.
+  - Internal /consults/forward-request creates the local thread row +
+    appends opening message. Idempotent on duplicate thread_id /
+    message_id. Peer-key auth required.
+  - /consults/forward-message appends a reply, lazily creates the
+    thread row if missing.
+  - Replies on a cross-L2 thread forward to the OTHER side of the thread
+    (sender's side might be either from_ or to_).
+  - Peer not in AIGRP table → 404 from /consults/request.
+  - Peer key wrong → 401 on the internal /forward-* endpoints.
+  - Cross-Enterprise (peer in different Enterprise) → 501.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import bcrypt
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from cq_server import consults, network
+from cq_server.app import _get_store, app
+
+ALICE = "alice"  # acme/engineering — this L2
+DAN = "dan"      # acme/engineering — also this L2
+
+ACME_PEER_KEY = "test-acme-peer-key-thirty-two-chars"
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "xl2.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    monkeypatch.setenv("CQ_AIGRP_PEER_KEY", ACME_PEER_KEY)
+    monkeypatch.setenv("CQ_ENTERPRISE", "acme")
+    monkeypatch.setenv("CQ_GROUP", "engineering")
+    network._signature_cache.clear()
+    network._signature_cache_filled_at = 0.0
+    monkeypatch.setattr(network, "DSN_CACHE_REFRESH_SECS", 86_400)
+
+    async def _noop(fleet):
+        return []
+
+    monkeypatch.setattr(network, "_fan_out_all", _noop)
+
+    with TestClient(app) as c:
+        store = _get_store()
+        # Seed users
+        for u, ent, grp in [
+            (ALICE, "acme", "engineering"),
+            (DAN, "acme", "engineering"),
+        ]:
+            pw = bcrypt.hashpw(b"pw", bcrypt.gensalt()).decode()
+            store.create_user(u, pw)
+            with store._lock, store._conn:
+                store._conn.execute(
+                    "UPDATE users SET enterprise_id = ?, group_id = ? WHERE username = ?",
+                    (ent, grp, u),
+                )
+        # Seed AIGRP peer table with two siblings on the same Enterprise
+        # and one on a different Enterprise (cross-Enterprise should 501).
+        now = "2026-05-01T16:00:00+00:00"
+        store.upsert_aigrp_peer(
+            l2_id="acme/solutions",
+            enterprise="acme",
+            group="solutions",
+            endpoint_url="http://acme-solutions-l2.test:3000",
+            embedding_centroid=None,
+            domain_bloom=None,
+            ku_count=0,
+            domain_count=0,
+            embedding_model=None,
+            signature_received=False,
+        )
+        store.upsert_aigrp_peer(
+            l2_id="rival/eng",
+            enterprise="rival",
+            group="eng",
+            endpoint_url="http://rival-eng-l2.test:3000",
+            embedding_centroid=None,
+            domain_bloom=None,
+            ku_count=0,
+            domain_count=0,
+            embedding_model=None,
+            signature_received=False,
+        )
+        del now
+        yield c
+
+
+def _login(client: TestClient, who: str) -> str:
+    r = client.post("/api/v1/auth/login", json={"username": who, "password": "pw"})
+    assert r.status_code == 200, r.text
+    return r.json()["token"]
+
+
+def _headers(client: TestClient, who: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {_login(client, who)}"}
+
+
+# ---------------------------------------------------------------------------
+# Cross-L2 forward — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_cross_l2_request_mirrors_local_and_forwards_to_peer(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Alice on acme/engineering opens a thread to acme/solutions.
+
+    The asker's L2 (this one) writes the thread + opening message
+    locally, then POSTs /consults/forward-request to the peer with the
+    AIGRP peer key in the bearer.
+    """
+    forwarded: list[dict[str, Any]] = []
+
+    class StubResp:
+        status_code = 201
+        text = "{}"
+
+    class StubClient:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+        def __enter__(self) -> "StubClient":
+            return self
+
+        def __exit__(self, *a: Any) -> None:
+            return None
+
+        def post(self, url: str, *, headers: dict[str, str], json: dict[str, Any]) -> StubResp:
+            forwarded.append({"url": url, "headers": headers, "json": json})
+            return StubResp()
+
+    monkeypatch.setattr(consults.httpx, "Client", StubClient)
+
+    r = client.post(
+        "/api/v1/consults/request",
+        headers=_headers(client, ALICE),
+        json={
+            "to_l2_id": "acme/solutions",
+            "to_persona": "carla",
+            "subject": "cross-team",
+            "content": "saw the cdn runbook?",
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["to_l2_id"] == "acme/solutions"
+    assert body["from_l2_id"] == "acme/engineering"
+
+    # Forward happened to the peer's endpoint with the peer key bearer
+    assert len(forwarded) == 1
+    assert forwarded[0]["url"] == "http://acme-solutions-l2.test:3000/api/v1/consults/forward-request"
+    assert forwarded[0]["headers"]["authorization"] == f"Bearer {ACME_PEER_KEY}"
+    payload = forwarded[0]["json"]
+    assert payload["thread_id"] == body["thread_id"]
+    assert payload["content"] == "saw the cdn runbook?"
+    assert payload["from_l2_id"] == "acme/engineering"
+    assert payload["from_persona"] == ALICE
+
+
+def test_cross_l2_message_forwards_to_other_side(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When Alice replies on a cross-L2 thread, the reply forwards to the OTHER L2."""
+    forwarded: list[dict[str, Any]] = []
+
+    class StubResp:
+        status_code = 201
+        text = "{}"
+
+    class StubClient:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        def __enter__(self) -> "StubClient":
+            return self
+
+        def __exit__(self, *a: Any) -> None:
+            return None
+
+        def post(self, url: str, *, headers: dict[str, str], json: dict[str, Any]) -> StubResp:
+            forwarded.append({"url": url, "json": json})
+            return StubResp()
+
+    monkeypatch.setattr(consults.httpx, "Client", StubClient)
+
+    # Alice opens a cross-L2 thread
+    open_resp = client.post(
+        "/api/v1/consults/request",
+        headers=_headers(client, ALICE),
+        json={"to_l2_id": "acme/solutions", "to_persona": "carla", "content": "hi"},
+    )
+    assert open_resp.status_code == 201
+    thread_id = open_resp.json()["thread_id"]
+
+    forwarded.clear()  # ignore the open's forward; assert on reply's
+
+    # Alice replies — should forward
+    reply = client.post(
+        f"/api/v1/consults/{thread_id}/messages",
+        headers=_headers(client, ALICE),
+        json={"content": "follow up"},
+    )
+    assert reply.status_code == 201, reply.text
+
+    assert len(forwarded) == 1
+    assert forwarded[0]["url"].endswith("/consults/forward-message")
+    assert forwarded[0]["json"]["thread_id"] == thread_id
+    assert forwarded[0]["json"]["from_persona"] == ALICE
+
+
+def test_cross_enterprise_target_returns_501(client: TestClient) -> None:
+    """A peer in a different Enterprise is gated until AI-BGP (issue #19)."""
+    r = client.post(
+        "/api/v1/consults/request",
+        headers=_headers(client, ALICE),
+        json={
+            "to_l2_id": "rival/eng",
+            "to_persona": "their_alice",
+            "content": "hi from across the boundary",
+        },
+    )
+    assert r.status_code == 501, r.text
+    assert "AI-BGP" in r.json()["detail"]
+
+
+def test_unknown_peer_returns_404(client: TestClient) -> None:
+    r = client.post(
+        "/api/v1/consults/request",
+        headers=_headers(client, ALICE),
+        json={
+            "to_l2_id": "acme/nowhere",
+            "to_persona": "ghost",
+            "content": "?",
+        },
+    )
+    assert r.status_code == 404, r.text
+
+
+# ---------------------------------------------------------------------------
+# Internal /forward-request endpoint — peer-key auth + idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_forward_request_mirrors_thread_and_message(client: TestClient) -> None:
+    payload = {
+        "thread_id": "th_cross_a",
+        "message_id": "msg_cross_a",
+        "from_l2_id": "acme/solutions",
+        "from_persona": "carla",
+        "to_l2_id": "acme/engineering",
+        "to_persona": ALICE,
+        "subject": "from solutions",
+        "content": "saw your alert?",
+        "created_at": "2026-05-01T16:30:00+00:00",
+    }
+    r = client.post(
+        "/api/v1/consults/forward-request",
+        headers={"Authorization": f"Bearer {ACME_PEER_KEY}"},
+        json=payload,
+    )
+    assert r.status_code == 201, r.text
+
+    # Now alice's inbox has the thread
+    inbox = client.get("/api/v1/consults/inbox", headers=_headers(client, ALICE)).json()
+    thread_ids = [t["thread_id"] for t in inbox["threads"]]
+    assert "th_cross_a" in thread_ids
+
+
+def test_forward_request_idempotent_on_redelivery(client: TestClient) -> None:
+    payload = {
+        "thread_id": "th_dup_a",
+        "message_id": "msg_dup_a",
+        "from_l2_id": "acme/solutions",
+        "from_persona": "carla",
+        "to_l2_id": "acme/engineering",
+        "to_persona": ALICE,
+        "subject": "dupe-test",
+        "content": "first",
+        "created_at": "2026-05-01T17:00:00+00:00",
+    }
+    h = {"Authorization": f"Bearer {ACME_PEER_KEY}"}
+    r1 = client.post("/api/v1/consults/forward-request", headers=h, json=payload)
+    r2 = client.post("/api/v1/consults/forward-request", headers=h, json=payload)
+    assert r1.status_code == 201
+    assert r2.status_code == 201  # duplicate is a no-op, not a 500
+
+
+def test_forward_request_rejects_wrong_peer_key(client: TestClient) -> None:
+    r = client.post(
+        "/api/v1/consults/forward-request",
+        headers={"Authorization": "Bearer wrong-key"},
+        json={
+            "thread_id": "x",
+            "message_id": "x",
+            "from_l2_id": "a",
+            "from_persona": "x",
+            "to_l2_id": "b",
+            "to_persona": "x",
+            "content": "x",
+            "created_at": "x",
+        },
+    )
+    assert r.status_code == 401
+
+
+def test_forward_request_rejects_anonymous(client: TestClient) -> None:
+    r = client.post(
+        "/api/v1/consults/forward-request",
+        json={
+            "thread_id": "x",
+            "message_id": "x",
+            "from_l2_id": "a",
+            "from_persona": "x",
+            "to_l2_id": "b",
+            "to_persona": "x",
+            "content": "x",
+            "created_at": "x",
+        },
+    )
+    assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# /forward-message — appends, lazily creates thread if missing
+# ---------------------------------------------------------------------------
+
+
+def test_forward_message_appends_to_existing_thread(client: TestClient) -> None:
+    h = {"Authorization": f"Bearer {ACME_PEER_KEY}"}
+    # First, mirror the thread via /forward-request
+    client.post("/api/v1/consults/forward-request", headers=h, json={
+        "thread_id": "th_msg_a",
+        "message_id": "msg_msg_a_1",
+        "from_l2_id": "acme/solutions",
+        "from_persona": "carla",
+        "to_l2_id": "acme/engineering",
+        "to_persona": ALICE,
+        "content": "open",
+        "created_at": "2026-05-01T18:00:00+00:00",
+    })
+    # Append a reply via /forward-message
+    r = client.post("/api/v1/consults/forward-message", headers=h, json={
+        "thread_id": "th_msg_a",
+        "message_id": "msg_msg_a_2",
+        "from_l2_id": "acme/engineering",
+        "from_persona": ALICE,
+        "content": "reply",
+        "created_at": "2026-05-01T18:05:00+00:00",
+    })
+    assert r.status_code == 201, r.text
+
+    # Both messages visible to alice
+    msgs = client.get(
+        "/api/v1/consults/th_msg_a/messages",
+        headers=_headers(client, ALICE),
+    ).json()["messages"]
+    assert [m["message_id"] for m in msgs] == ["msg_msg_a_1", "msg_msg_a_2"]
+
+
+def test_forward_message_lazily_creates_missing_thread(client: TestClient) -> None:
+    """If /forward-request was lost, /forward-message backfills the thread row."""
+    h = {"Authorization": f"Bearer {ACME_PEER_KEY}"}
+    r = client.post("/api/v1/consults/forward-message", headers=h, json={
+        "thread_id": "th_lazy_a",
+        "message_id": "msg_lazy_a",
+        "from_l2_id": "acme/solutions",
+        "from_persona": "carla",
+        "content": "reply (asker-side init lost)",
+        "created_at": "2026-05-01T19:00:00+00:00",
+        "thread_subject": "recovered",
+        "thread_to_l2_id": "acme/engineering",
+        "thread_to_persona": ALICE,
+        "thread_from_l2_id": "acme/solutions",
+        "thread_from_persona": "carla",
+        "thread_created_at": "2026-05-01T18:55:00+00:00",
+    })
+    assert r.status_code == 201, r.text
+
+    # Alice's inbox has the lazily-created thread
+    inbox = client.get("/api/v1/consults/inbox", headers=_headers(client, ALICE)).json()
+    assert "th_lazy_a" in [t["thread_id"] for t in inbox["threads"]]
+
+
+def test_forward_message_missing_thread_no_metadata_400(client: TestClient) -> None:
+    h = {"Authorization": f"Bearer {ACME_PEER_KEY}"}
+    r = client.post("/api/v1/consults/forward-message", headers=h, json={
+        "thread_id": "th_missing",
+        "message_id": "msg_x",
+        "from_l2_id": "acme/solutions",
+        "from_persona": "carla",
+        "content": "no thread no metadata",
+        "created_at": "2026-05-01T20:00:00+00:00",
+    })
+    assert r.status_code == 400
+
+
+# Use _ to suppress unused-import lint
+_ = MagicMock
+_ = os
+_ = httpx


### PR DESCRIPTION
Same-Enterprise different-Group cross-L2 consult routing. Cross-Enterprise still 501 (waits for AI-BGP #19). New /consults/forward-{request,message} internal endpoints (peer-key auth). 11 new tests, 342/342 suite green. Per decisions/10 — both L2s log on cross-team consult = corporate-IP audit point. Refs #20.