### PR TITLE
[sec] /query auth gate + tenant scope · CRITICAL #33

### DIFF
--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -1196,15 +1196,28 @@ def query_units(
     frameworks: Annotated[list[str] | None, Query()] = None,
     pattern: Annotated[str | None, Query()] = None,
     limit: Annotated[int, Query(gt=0)] = 5,
+    username: str = Depends(require_api_key),
 ) -> list[KnowledgeUnit]:
-    """Search knowledge units by domain tags with relevance ranking."""
+    """Search knowledge units by domain tags with relevance ranking.
+
+    Auth: API key required. Tenancy scope (``enterprise_id`` /
+    ``group_id``) is resolved from the authenticated user's row — the
+    request never carries scope. Results are restricted to the caller's
+    Enterprise (own Group plus cross-group-allowed KUs); cross-Enterprise
+    discovery flows through ``/aigrp/forward-query`` (consent + audit).
+    """
     store = _get_store()
+    user = store.get_user(username)
+    if user is None:
+        raise HTTPException(status_code=401, detail="User not found")
     return store.query(
         domains,
         languages=languages,
         frameworks=frameworks,
         pattern=pattern or "",
         limit=limit,
+        enterprise_id=user["enterprise_id"],
+        group_id=user["group_id"],
     )
 
 

--- a/server/backend/src/cq_server/store/__init__.py
+++ b/server/backend/src/cq_server/store/__init__.py
@@ -418,6 +418,8 @@ class RemoteStore:
         frameworks: list[str] | None = None,
         pattern: str = "",
         limit: int = 5,
+        enterprise_id: str | None = None,
+        group_id: str | None = None,
     ) -> list[KnowledgeUnit]:
         """Search for knowledge units by domain tags with relevance ranking.
 
@@ -430,6 +432,12 @@ class RemoteStore:
             pattern: Optional pattern ranking signal. KUs whose context.pattern
                 matches rank higher but non-matching KUs are still returned.
             limit: Maximum number of results to return. Must be positive.
+            enterprise_id: When provided, restrict results to KUs in this Enterprise.
+                Cross-Enterprise discovery flows through /aigrp/forward-query
+                (consent + audit), not the local /query.
+            group_id: When ``enterprise_id`` is also provided, restrict results
+                to KUs in this Group OR KUs flagged ``cross_group_allowed=1``.
+                Cross-Group access without the flag flows through forward-query.
 
         Returns:
             Knowledge units ranked by relevance * confidence, descending.
@@ -448,18 +456,22 @@ class RemoteStore:
             return []
         # Safe: placeholders is only '?' characters, never user input.
         placeholders = ",".join("?" for _ in normalized)
-        sql = f"""
-            SELECT ku.data
-            FROM knowledge_units ku
-            WHERE ku.status = 'approved'
-            AND ku.id IN (
-                SELECT DISTINCT unit_id
-                FROM knowledge_unit_domains
-                WHERE domain IN ({placeholders})
-            )
-        """
+        where_clauses = [
+            "ku.status = 'approved'",
+            f"ku.id IN ("
+            f"SELECT DISTINCT unit_id FROM knowledge_unit_domains "
+            f"WHERE domain IN ({placeholders}))",
+        ]
+        params: list[Any] = list(normalized)
+        if enterprise_id is not None:
+            where_clauses.append("ku.enterprise_id = ?")
+            params.append(enterprise_id)
+            if group_id is not None:
+                where_clauses.append("(ku.group_id = ? OR ku.cross_group_allowed = 1)")
+                params.append(group_id)
+        sql = f"SELECT ku.data FROM knowledge_units ku WHERE {' AND '.join(where_clauses)}"
         with self._lock:
-            rows = self._conn.execute(sql, normalized).fetchall()
+            rows = self._conn.execute(sql, params).fetchall()
 
         # PoC: all filtering and scoring is in-memory after deserialization.
         # For larger stores, push coarse filters into SQL.

--- a/server/backend/tests/test_app.py
+++ b/server/backend/tests/test_app.py
@@ -20,6 +20,15 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
     monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
     app.dependency_overrides[require_api_key] = lambda: TEST_USERNAME
     with TestClient(app) as c:
+        # Endpoints that resolve tenancy from the user row (e.g. /query,
+        # /peers/heartbeat) need the test user to exist. Seeded in the
+        # default tenancy scope so existing tests see their own KUs.
+        from cq_server.app import _get_store
+        from cq_server.auth import hash_password
+
+        store = _get_store()
+        if store.get_user(TEST_USERNAME) is None:
+            store.create_user(TEST_USERNAME, hash_password("test-pw"))
         yield c
     app.dependency_overrides.pop(require_api_key, None)
 
@@ -242,6 +251,79 @@ class TestQuery:
         results = resp.json()
         assert len(results) == 2
         assert results[0]["context"]["pattern"] == "api-client"
+
+
+class TestQueryTenantScope:
+    """SEC-CRIT #33 — /query is auth-gated and scoped to caller's tenancy."""
+
+    def _set_ku_tenancy(
+        self,
+        unit_id: str,
+        *,
+        enterprise_id: str,
+        group_id: str,
+        cross_group_allowed: bool = False,
+    ) -> None:
+        from cq_server.app import _get_store
+
+        store = _get_store()
+        with store._lock, store._conn:
+            store._conn.execute(
+                "UPDATE knowledge_units SET enterprise_id = ?, group_id = ?, "
+                "cross_group_allowed = ? WHERE id = ?",
+                (enterprise_id, group_id, 1 if cross_group_allowed else 0, unit_id),
+            )
+
+    def _set_user_tenancy(self, username: str, *, enterprise_id: str, group_id: str) -> None:
+        from cq_server.app import _get_store
+
+        store = _get_store()
+        with store._lock, store._conn:
+            store._conn.execute(
+                "UPDATE users SET enterprise_id = ?, group_id = ? WHERE username = ?",
+                (enterprise_id, group_id, username),
+            )
+
+    def _seed_unit(self, client: TestClient, **overrides: Any) -> dict[str, Any]:
+        resp = client.post("/propose", json=_propose_payload(**overrides))
+        assert resp.status_code == 201
+        body = resp.json()
+        _approve_unit(client, body["id"])
+        return body
+
+    def test_anonymous_query_rejected(self, enforced_client: TestClient) -> None:
+        resp = enforced_client.get("/query", params={"domains": ["anything"]})
+        assert resp.status_code == 401
+
+    def test_caller_sees_own_tenant_kus(self, client: TestClient) -> None:
+        unit = self._seed_unit(client, domains=["scoped"])
+        self._set_ku_tenancy(unit["id"], enterprise_id="acme", group_id="engineering")
+        self._set_user_tenancy(TEST_USERNAME, enterprise_id="acme", group_id="engineering")
+        resp = client.get("/query", params={"domains": ["scoped"]})
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+
+    def test_cross_tenant_kus_filtered_out(self, client: TestClient) -> None:
+        unit = self._seed_unit(client, domains=["secret"])
+        self._set_ku_tenancy(unit["id"], enterprise_id="rival", group_id="engineering")
+        self._set_user_tenancy(TEST_USERNAME, enterprise_id="acme", group_id="engineering")
+        resp = client.get("/query", params={"domains": ["secret"]})
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_cross_group_blocked_unless_flag_set(self, client: TestClient) -> None:
+        blocked = self._seed_unit(client, domains=["xgroup-test"])
+        allowed = self._seed_unit(client, domains=["xgroup-test"])
+        self._set_ku_tenancy(blocked["id"], enterprise_id="acme", group_id="finance")
+        self._set_ku_tenancy(
+            allowed["id"], enterprise_id="acme", group_id="finance", cross_group_allowed=True
+        )
+        self._set_user_tenancy(TEST_USERNAME, enterprise_id="acme", group_id="engineering")
+        resp = client.get("/query", params={"domains": ["xgroup-test"]})
+        assert resp.status_code == 200
+        ids = [u["id"] for u in resp.json()]
+        assert allowed["id"] in ids
+        assert blocked["id"] not in ids
 
 
 class TestConfirm:
@@ -485,9 +567,9 @@ class TestApiKeyEnforcement:
         )
         assert resp.status_code == 401
 
-    def test_query_stays_open_under_enforcement(self, enforced_client: TestClient) -> None:
+    def test_query_requires_auth_under_enforcement(self, enforced_client: TestClient) -> None:
         resp = enforced_client.get("/query", params={"domains": ["anything"]})
-        assert resp.status_code == 200
+        assert resp.status_code == 401
 
     def test_stats_stays_open_under_enforcement(self, enforced_client: TestClient) -> None:
         resp = enforced_client.get("/stats")

--- a/server/backend/tests/test_review.py
+++ b/server/backend/tests/test_review.py
@@ -18,6 +18,12 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
     monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
     app.dependency_overrides[require_api_key] = lambda: "test-user"
     with TestClient(app) as c:
+        from cq_server.app import _get_store
+        from cq_server.auth import hash_password
+
+        store = _get_store()
+        if store.get_user("test-user") is None:
+            store.create_user("test-user", hash_password("test-pw"))
         yield c
     app.dependency_overrides.pop(require_api_key, None)
 


### PR DESCRIPTION
Closes #33. Auth-gates /api/v1/query and scopes results to caller's Enterprise (own Group + cross_group_allowed KUs). Audit found anonymous curl against any fleet ALB was leaking full KU bodies. 346 tests passing (+4 new tenant-scope tests).