### PR TITLE
[sec] /review/* admin gate + tenant scope · CRITICAL #32

### DIFF
--- a/server/backend/src/cq_server/review.py
+++ b/server/backend/src/cq_server/review.py
@@ -1,12 +1,29 @@
-"""Review queue endpoints for the review API."""
+"""Review queue endpoints for the review API.
+
+SEC-CRIT #32 — every route requires admin role and is scoped to the
+caller's Enterprise. Tenant scope is resolved from the user row, never
+the request, matching the pattern used by /peers/heartbeat.
+"""
 
 from cq.models import KnowledgeUnit
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
-from .auth import get_current_user
+from .auth import require_admin
 from .deps import get_store
 from .store import RemoteStore
+
+
+def _admin_enterprise(username: str, store: RemoteStore) -> str:
+    """Resolve the admin caller's enterprise_id from the user row.
+
+    Raises 401 if the row vanished between auth and request handling
+    (revoked admin, race with delete, etc.).
+    """
+    user = store.get_user(username)
+    if user is None:
+        raise HTTPException(status_code=401, detail="User not found")
+    return user["enterprise_id"]
 
 
 class ReviewItem(BaseModel):
@@ -88,22 +105,13 @@ router = APIRouter(prefix="/review", tags=["review"])
 def review_queue(
     limit: int = 20,
     offset: int = 0,
-    _user: str = Depends(get_current_user),
+    username: str = Depends(require_admin),
     store: RemoteStore = Depends(get_store),
 ) -> ReviewQueueResponse:
-    """Return pending KUs for review.
-
-    Args:
-        limit: Maximum number of items to return.
-        offset: Number of items to skip.
-        _user: The authenticated user (unused, enforces auth).
-        store: The remote store dependency.
-
-    Returns:
-        A paginated list of pending knowledge units with review metadata.
-    """
-    items = store.pending_queue(limit=limit, offset=offset)
-    total = store.pending_count()
+    """Return pending KUs for review, scoped to the caller's Enterprise."""
+    enterprise_id = _admin_enterprise(username, store)
+    items = store.pending_queue(limit=limit, offset=offset, enterprise_id=enterprise_id)
+    total = store.pending_count(enterprise_id=enterprise_id)
     return ReviewQueueResponse(
         items=[
             ReviewItem(
@@ -123,30 +131,18 @@ def review_queue(
 @router.post("/{unit_id}/approve")
 def approve_unit(
     unit_id: str,
-    username: str = Depends(get_current_user),
+    username: str = Depends(require_admin),
     store: RemoteStore = Depends(get_store),
 ) -> ReviewDecisionResponse:
-    """Approve a pending KU.
-
-    Args:
-        unit_id: The knowledge unit identifier.
-        username: The authenticated reviewer's username.
-        store: The remote store dependency.
-
-    Returns:
-        The updated review decision with status and reviewer details.
-
-    Raises:
-        HTTPException: With status 404 if the unit does not exist.
-        HTTPException: With status 409 if the unit has already been reviewed.
-    """
-    status = store.get_review_status(unit_id)
+    """Approve a pending KU in the admin's Enterprise."""
+    enterprise_id = _admin_enterprise(username, store)
+    status = store.get_review_status(unit_id, enterprise_id=enterprise_id)
     if status is None:
         raise HTTPException(status_code=404, detail="Knowledge unit not found")
     if status["status"] != "pending":
         raise HTTPException(status_code=409, detail=f"Knowledge unit already {status['status']}")
-    store.set_review_status(unit_id, "approved", username)
-    updated = store.get_review_status(unit_id)
+    store.set_review_status(unit_id, "approved", username, enterprise_id=enterprise_id)
+    updated = store.get_review_status(unit_id, enterprise_id=enterprise_id)
     assert updated is not None  # Unit exists; we just wrote to it.
     return _build_decision(unit_id, updated)
 
@@ -154,30 +150,18 @@ def approve_unit(
 @router.post("/{unit_id}/reject")
 def reject_unit(
     unit_id: str,
-    username: str = Depends(get_current_user),
+    username: str = Depends(require_admin),
     store: RemoteStore = Depends(get_store),
 ) -> ReviewDecisionResponse:
-    """Reject a pending KU.
-
-    Args:
-        unit_id: The knowledge unit identifier.
-        username: The authenticated reviewer's username.
-        store: The remote store dependency.
-
-    Returns:
-        The updated review decision with status and reviewer details.
-
-    Raises:
-        HTTPException: With status 404 if the unit does not exist.
-        HTTPException: With status 409 if the unit has already been reviewed.
-    """
-    status = store.get_review_status(unit_id)
+    """Reject a pending KU in the admin's Enterprise."""
+    enterprise_id = _admin_enterprise(username, store)
+    status = store.get_review_status(unit_id, enterprise_id=enterprise_id)
     if status is None:
         raise HTTPException(status_code=404, detail="Knowledge unit not found")
     if status["status"] != "pending":
         raise HTTPException(status_code=409, detail=f"Knowledge unit already {status['status']}")
-    store.set_review_status(unit_id, "rejected", username)
-    updated = store.get_review_status(unit_id)
+    store.set_review_status(unit_id, "rejected", username, enterprise_id=enterprise_id)
+    updated = store.get_review_status(unit_id, enterprise_id=enterprise_id)
     assert updated is not None  # Unit exists; we just wrote to it.
     return _build_decision(unit_id, updated)
 
@@ -185,63 +169,40 @@ def reject_unit(
 @router.delete("/{unit_id}", status_code=204)
 def delete_unit(
     unit_id: str,
-    username: str = Depends(get_current_user),
+    username: str = Depends(require_admin),
     store: RemoteStore = Depends(get_store),
 ) -> None:
-    """Hard-delete a knowledge unit (admin-only — already enforced by JWT).
+    """Hard-delete a KU in the admin's Enterprise (irreversible).
 
-    Used to remove KUs that should never have been approved (smoke-test garbage,
-    pre-quality-guard pollution, etc.). Confidence-flagging via /flag is the
-    soft path; this is the irreversible nuclear option.
-
-    Args:
-        unit_id: The knowledge unit identifier.
-        username: The authenticated reviewer's username (audit only).
-        store: The remote store dependency.
-
-    Returns:
-        204 No Content on successful delete.
-
-    Raises:
-        HTTPException: With status 404 if the unit does not exist.
+    Cross-tenant DELETEs return 404 — same shape as missing-id, so
+    enumeration probes can't fingerprint other tenants' KU IDs.
     """
-    deleted = store.delete(unit_id)
+    enterprise_id = _admin_enterprise(username, store)
+    deleted = store.delete(unit_id, enterprise_id=enterprise_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Knowledge unit not found")
-    # Audit context: username is captured implicitly via FastAPI logs;
-    # the review_records table (if populated) preserves prior approve/reject
-    # decisions. We deliberately do not insert a synthetic delete-record;
-    # the absence of the KU + the surviving review trail is the audit shape.
     return None
 
 
 @router.get("/stats")
 def review_stats(
-    _user: str = Depends(get_current_user),
+    username: str = Depends(require_admin),
     store: RemoteStore = Depends(get_store),
 ) -> ReviewStatsResponse:
-    """Return dashboard metrics.
-
-    Args:
-        _user: The authenticated user (unused, enforces auth).
-        store: The remote store dependency.
-
-    Returns:
-        Aggregated counts by status, domain distribution, confidence
-        distribution, recent activity, and daily trend data.
-    """
-    counts = store.counts_by_status()
+    """Return dashboard metrics, scoped to the caller's Enterprise."""
+    enterprise_id = _admin_enterprise(username, store)
+    counts = store.counts_by_status(enterprise_id=enterprise_id)
     return ReviewStatsResponse(
         counts={
             "pending": counts.get("pending", 0),
             "approved": counts.get("approved", 0),
             "rejected": counts.get("rejected", 0),
         },
-        domains=store.domain_counts(),
-        confidence_distribution=store.confidence_distribution(),
-        recent_activity=store.recent_activity(),
+        domains=store.domain_counts(enterprise_id=enterprise_id),
+        confidence_distribution=store.confidence_distribution(enterprise_id=enterprise_id),
+        recent_activity=store.recent_activity(enterprise_id=enterprise_id),
         trends=TrendsResponse(
-            daily=[DailyCount(**d) for d in store.daily_counts()],
+            daily=[DailyCount(**d) for d in store.daily_counts(enterprise_id=enterprise_id)],
         ),
     )
 
@@ -253,30 +214,18 @@ def list_units(
     confidence_max: float | None = None,
     status: str | None = None,
     limit: int = 100,
-    _user: str = Depends(get_current_user),
+    username: str = Depends(require_admin),
     store: RemoteStore = Depends(get_store),
 ) -> list[ReviewItem]:
-    """Return KUs filtered by domain, confidence range, or status.
-
-    Args:
-        domain: Optional domain tag to filter by.
-        confidence_min: Optional minimum confidence (inclusive).
-        confidence_max: Optional maximum confidence (exclusive when < 1.0,
-            inclusive at 1.0).
-        status: Optional review status (e.g. "approved", "rejected").
-        limit: Maximum number of results to return.
-        _user: The authenticated user (unused, enforces auth).
-        store: The remote store dependency.
-
-    Returns:
-        List of knowledge units with review metadata.
-    """
+    """List KUs in the admin's Enterprise, filtered by domain/confidence/status."""
+    enterprise_id = _admin_enterprise(username, store)
     items = store.list_units(
         domain=domain,
         confidence_min=confidence_min,
         confidence_max=confidence_max,
         status=status,
         limit=limit,
+        enterprise_id=enterprise_id,
     )
     return [
         ReviewItem(
@@ -292,26 +241,18 @@ def list_units(
 @router.get("/{unit_id}")
 def get_unit(
     unit_id: str,
-    _user: str = Depends(get_current_user),
+    username: str = Depends(require_admin),
     store: RemoteStore = Depends(get_store),
 ) -> ReviewItem:
-    """Return a single knowledge unit with its review metadata.
+    """Return one KU's review row, scoped to the admin's Enterprise.
 
-    Args:
-        unit_id: The knowledge unit identifier.
-        _user: The authenticated user (unused, enforces auth).
-        store: The remote store dependency.
-
-    Returns:
-        The knowledge unit with review status, reviewer, and timestamp.
-
-    Raises:
-        HTTPException: With status 404 if the unit does not exist.
+    Cross-tenant GETs return 404 — same shape as missing-id.
     """
-    ku = store.get_any(unit_id)
+    enterprise_id = _admin_enterprise(username, store)
+    ku = store.get_any(unit_id, enterprise_id=enterprise_id)
     if ku is None:
         raise HTTPException(status_code=404, detail="Knowledge unit not found")
-    review = store.get_review_status(unit_id)
+    review = store.get_review_status(unit_id, enterprise_id=enterprise_id)
     assert review is not None  # Unit exists; get_any just returned it.
     return ReviewItem(
         knowledge_unit=ku,

--- a/server/backend/src/cq_server/store/__init__.py
+++ b/server/backend/src/cq_server/store/__init__.py
@@ -272,19 +272,27 @@ class RemoteStore:
         scored.sort(key=lambda pair: pair[1], reverse=True)
         return scored[:limit]
 
-    def delete(self, unit_id: str) -> bool:
+    def delete(self, unit_id: str, *, enterprise_id: str | None = None) -> bool:
         """Hard-delete a knowledge unit by ID.
 
-        Removes the row from knowledge_units and cascades to
-        knowledge_unit_domains. Does NOT touch review_records — the audit
-        trail of why each KU was approved/rejected/now-deleted should
-        survive the deletion of the underlying KU.
+        When ``enterprise_id`` is provided, the row is only deleted if it
+        belongs to that Enterprise — cross-tenant deletes return False
+        (same shape as missing-id, so probes can't fingerprint other
+        tenants' IDs).
 
-        Returns True if a row was deleted, False if no such ID existed.
+        Returns True if a row was deleted, False if no such ID existed
+        (or it was out of tenant scope).
         """
         self._check_open()
         with self._lock, self._conn:
-            cur = self._conn.execute(
+            if enterprise_id is not None:
+                row = self._conn.execute(
+                    "SELECT 1 FROM knowledge_units WHERE id = ? AND enterprise_id = ?",
+                    (unit_id, enterprise_id),
+                ).fetchone()
+                if row is None:
+                    return False
+            self._conn.execute(
                 "DELETE FROM knowledge_unit_domains WHERE unit_id = ?",
                 (unit_id,),
             )
@@ -316,65 +324,91 @@ class RemoteStore:
             return None
         return KnowledgeUnit.model_validate_json(row[0])
 
-    def get_any(self, unit_id: str) -> KnowledgeUnit | None:
+    def get_any(
+        self,
+        unit_id: str,
+        *,
+        enterprise_id: str | None = None,
+    ) -> KnowledgeUnit | None:
         """Retrieve a knowledge unit by ID regardless of review status.
 
-        Internal use only — review endpoints and activity feed.
-
-        Args:
-            unit_id: The knowledge unit identifier.
-
-        Returns:
-            The knowledge unit, or None if not found.
+        Internal use only — review endpoints and activity feed. When
+        ``enterprise_id`` is provided, returns None for KUs in other
+        tenants (same shape as missing-id, no fingerprinting).
         """
         self._check_open()
         with self._lock:
-            row = self._conn.execute(
-                "SELECT data FROM knowledge_units WHERE id = ?",
-                (unit_id,),
-            ).fetchone()
+            if enterprise_id is None:
+                row = self._conn.execute(
+                    "SELECT data FROM knowledge_units WHERE id = ?",
+                    (unit_id,),
+                ).fetchone()
+            else:
+                row = self._conn.execute(
+                    "SELECT data FROM knowledge_units WHERE id = ? AND enterprise_id = ?",
+                    (unit_id, enterprise_id),
+                ).fetchone()
         if row is None:
             return None
         return KnowledgeUnit.model_validate_json(row[0])
 
-    def get_review_status(self, unit_id: str) -> dict[str, str | None] | None:
+    def get_review_status(
+        self,
+        unit_id: str,
+        *,
+        enterprise_id: str | None = None,
+    ) -> dict[str, str | None] | None:
         """Return review metadata for a knowledge unit.
 
-        Args:
-            unit_id: The knowledge unit identifier.
-
-        Returns:
-            A dict with status, reviewed_by, and reviewed_at keys, or None
-            if the unit does not exist.
+        When ``enterprise_id`` is provided, returns None for KUs in other
+        tenants.
         """
         self._check_open()
         with self._lock:
-            row = self._conn.execute(
-                "SELECT status, reviewed_by, reviewed_at FROM knowledge_units WHERE id = ?",
-                (unit_id,),
-            ).fetchone()
+            if enterprise_id is None:
+                row = self._conn.execute(
+                    "SELECT status, reviewed_by, reviewed_at "
+                    "FROM knowledge_units WHERE id = ?",
+                    (unit_id,),
+                ).fetchone()
+            else:
+                row = self._conn.execute(
+                    "SELECT status, reviewed_by, reviewed_at "
+                    "FROM knowledge_units WHERE id = ? AND enterprise_id = ?",
+                    (unit_id, enterprise_id),
+                ).fetchone()
         if row is None:
             return None
         return {"status": row[0], "reviewed_by": row[1], "reviewed_at": row[2]}
 
-    def set_review_status(self, unit_id: str, status: str, reviewed_by: str) -> None:
+    def set_review_status(
+        self,
+        unit_id: str,
+        status: str,
+        reviewed_by: str,
+        *,
+        enterprise_id: str | None = None,
+    ) -> None:
         """Update the review status of a knowledge unit.
 
-        Args:
-            unit_id: The knowledge unit identifier.
-            status: The new review status (e.g. "approved", "rejected").
-            reviewed_by: Username of the reviewer.
-
-        Raises:
-            KeyError: If no unit with the given ID exists.
+        When ``enterprise_id`` is provided, the row is only updated if it
+        belongs to that Enterprise — cross-tenant updates raise KeyError.
         """
         self._check_open()
         now = datetime.now(UTC).isoformat()
         with self._lock, self._conn:
-            cursor = self._conn.execute(
-                "UPDATE knowledge_units SET status = ?, reviewed_by = ?, reviewed_at = ? WHERE id = ?",
-                (status, reviewed_by, now, unit_id),
-            )
+            if enterprise_id is None:
+                cursor = self._conn.execute(
+                    "UPDATE knowledge_units SET status = ?, reviewed_by = ?, "
+                    "reviewed_at = ? WHERE id = ?",
+                    (status, reviewed_by, now, unit_id),
+                )
+            else:
+                cursor = self._conn.execute(
+                    "UPDATE knowledge_units SET status = ?, reviewed_by = ?, "
+                    "reviewed_at = ? WHERE id = ? AND enterprise_id = ?",
+                    (status, reviewed_by, now, unit_id, enterprise_id),
+                )
             if cursor.rowcount == 0:
                 raise KeyError(f"Knowledge unit not found: {unit_id}")
 
@@ -498,38 +532,51 @@ class RemoteStore:
             row = self._conn.execute("SELECT COUNT(*) FROM knowledge_units").fetchone()
         return row[0]
 
-    def domain_counts(self) -> dict[str, int]:
-        """Return the count of approved knowledge units per domain tag."""
-        self._check_open()
-        with self._lock:
-            rows = self._conn.execute(
-                "SELECT d.domain, COUNT(*) "
-                "FROM knowledge_unit_domains d "
-                "JOIN knowledge_units ku ON ku.id = d.unit_id "
-                "WHERE ku.status = 'approved' "
-                "GROUP BY d.domain ORDER BY COUNT(*) DESC"
-            ).fetchall()
-        return {row[0]: row[1] for row in rows}
+    def domain_counts(self, *, enterprise_id: str | None = None) -> dict[str, int]:
+        """Return the count of approved knowledge units per domain tag.
 
-    def pending_queue(self, *, limit: int = 20, offset: int = 0) -> list[dict[str, Any]]:
-        """Return pending KUs with review metadata, oldest first.
-
-        Args:
-            limit: Maximum number of results to return.
-            offset: Number of results to skip.
-
-        Returns:
-            List of dicts with knowledge_unit, status, reviewed_by,
-            and reviewed_at keys.
+        When ``enterprise_id`` is provided, restrict to that Enterprise.
         """
         self._check_open()
+        sql = (
+            "SELECT d.domain, COUNT(*) "
+            "FROM knowledge_unit_domains d "
+            "JOIN knowledge_units ku ON ku.id = d.unit_id "
+            "WHERE ku.status = 'approved' "
+        )
+        params: list[Any] = []
+        if enterprise_id is not None:
+            sql += "AND ku.enterprise_id = ? "
+            params.append(enterprise_id)
+        sql += "GROUP BY d.domain ORDER BY COUNT(*) DESC"
         with self._lock:
-            rows = self._conn.execute(
-                "SELECT data, status, reviewed_by, reviewed_at "
-                "FROM knowledge_units WHERE status = 'pending' "
-                "ORDER BY created_at ASC LIMIT ? OFFSET ?",
-                (limit, offset),
-            ).fetchall()
+            rows = self._conn.execute(sql, params).fetchall()
+        return {row[0]: row[1] for row in rows}
+
+    def pending_queue(
+        self,
+        *,
+        limit: int = 20,
+        offset: int = 0,
+        enterprise_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return pending KUs with review metadata, oldest first.
+
+        When ``enterprise_id`` is provided, restrict to that Enterprise.
+        """
+        self._check_open()
+        sql = (
+            "SELECT data, status, reviewed_by, reviewed_at "
+            "FROM knowledge_units WHERE status = 'pending' "
+        )
+        params: list[Any] = []
+        if enterprise_id is not None:
+            sql += "AND enterprise_id = ? "
+            params.append(enterprise_id)
+        sql += "ORDER BY created_at ASC LIMIT ? OFFSET ?"
+        params.extend([limit, offset])
+        with self._lock:
+            rows = self._conn.execute(sql, params).fetchall()
         return [
             {
                 "knowledge_unit": KnowledgeUnit.model_validate_json(row[0]),
@@ -540,18 +587,29 @@ class RemoteStore:
             for row in rows
         ]
 
-    def pending_count(self) -> int:
-        """Return the number of pending KUs."""
+    def pending_count(self, *, enterprise_id: str | None = None) -> int:
+        """Return the number of pending KUs (optionally Enterprise-scoped)."""
         self._check_open()
+        sql = "SELECT COUNT(*) FROM knowledge_units WHERE status = 'pending'"
+        params: list[Any] = []
+        if enterprise_id is not None:
+            sql += " AND enterprise_id = ?"
+            params.append(enterprise_id)
         with self._lock:
-            row = self._conn.execute("SELECT COUNT(*) FROM knowledge_units WHERE status = 'pending'").fetchone()
+            row = self._conn.execute(sql, params).fetchone()
         return row[0]
 
-    def counts_by_status(self) -> dict[str, int]:
-        """Return KU counts grouped by review status."""
+    def counts_by_status(self, *, enterprise_id: str | None = None) -> dict[str, int]:
+        """Return KU counts grouped by review status (optionally Enterprise-scoped)."""
         self._check_open()
+        sql = "SELECT status, COUNT(*) FROM knowledge_units"
+        params: list[Any] = []
+        if enterprise_id is not None:
+            sql += " WHERE enterprise_id = ?"
+            params.append(enterprise_id)
+        sql += " GROUP BY status"
         with self._lock:
-            rows = self._conn.execute("SELECT status, COUNT(*) FROM knowledge_units GROUP BY status").fetchall()
+            rows = self._conn.execute(sql, params).fetchall()
         return {row[0]: row[1] for row in rows}
 
     def counts_by_tier(self) -> dict[str, int]:
@@ -571,25 +629,16 @@ class RemoteStore:
         confidence_max: float | None = None,
         status: str | None = None,
         limit: int = 100,
+        enterprise_id: str | None = None,
     ) -> list[dict[str, Any]]:
         """Return KUs with review metadata, filtered by domain, confidence, or status.
 
         Confidence filtering is applied in-memory after deserialization
-        since confidence lives in the JSON blob.
-
-        Args:
-            domain: Optional domain tag to filter by.
-            confidence_min: Optional minimum confidence (inclusive).
-            confidence_max: Optional maximum confidence (exclusive when < 1.0, inclusive at 1.0).
-            status: Optional review status to filter by (e.g. "approved", "rejected").
-            limit: Maximum number of results to return.
-
-        Returns:
-            List of dicts with knowledge_unit, status, reviewed_by,
-            and reviewed_at keys.
+        since confidence lives in the JSON blob. When ``enterprise_id``
+        is provided, restrict to that Enterprise.
         """
         self._check_open()
-        params: list[str] = []
+        params: list[Any] = []
         conditions: list[str] = []
 
         if status:
@@ -602,6 +651,10 @@ class RemoteStore:
                 return []
             conditions.append("ku.id IN (  SELECT DISTINCT unit_id FROM knowledge_unit_domains WHERE domain = ?)")
             params.append(normalized[0])
+
+        if enterprise_id is not None:
+            conditions.append("ku.enterprise_id = ?")
+            params.append(enterprise_id)
 
         has_confidence_filter = confidence_min is not None or confidence_max is not None
         where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
@@ -1285,11 +1338,19 @@ class RemoteStore:
             )
         return cur.rowcount > 0
 
-    def confidence_distribution(self) -> dict[str, int]:
-        """Return confidence distribution buckets for approved KUs."""
+    def confidence_distribution(self, *, enterprise_id: str | None = None) -> dict[str, int]:
+        """Return confidence distribution buckets for approved KUs.
+
+        When ``enterprise_id`` is provided, restrict to that Enterprise.
+        """
         self._check_open()
+        sql = "SELECT data FROM knowledge_units WHERE status = 'approved'"
+        params: list[Any] = []
+        if enterprise_id is not None:
+            sql += " AND enterprise_id = ?"
+            params.append(enterprise_id)
         with self._lock:
-            rows = self._conn.execute("SELECT data FROM knowledge_units WHERE status = 'approved'").fetchall()
+            rows = self._conn.execute(sql, params).fetchall()
         buckets = {"0.0-0.3": 0, "0.3-0.6": 0, "0.6-0.8": 0, "0.8-1.0": 0}
         for (data,) in rows:
             unit = KnowledgeUnit.model_validate_json(data)
@@ -1304,27 +1365,29 @@ class RemoteStore:
                 buckets["0.8-1.0"] += 1
         return buckets
 
-    def recent_activity(self, limit: int = 20) -> list[dict[str, Any]]:
+    def recent_activity(
+        self,
+        limit: int = 20,
+        *,
+        enterprise_id: str | None = None,
+    ) -> list[dict[str, Any]]:
         """Return recent activity as one event per knowledge unit.
 
         Each KU appears once: reviewed KUs show as approved/rejected,
-        pending KUs show as proposed.  Ordered by the most recent
+        pending KUs show as proposed. Ordered by the most recent
         timestamp (reviewed_at for reviewed KUs, created_at otherwise).
-
-        Args:
-            limit: Maximum number of activity entries to return.
-
-        Returns:
-            List of activity event dicts, newest first.
+        When ``enterprise_id`` is provided, restrict to that Enterprise.
         """
         self._check_open()
+        sql = "SELECT id, data, status, reviewed_by, reviewed_at FROM knowledge_units"
+        params: list[Any] = []
+        if enterprise_id is not None:
+            sql += " WHERE enterprise_id = ?"
+            params.append(enterprise_id)
+        sql += " ORDER BY COALESCE(reviewed_at, created_at) DESC LIMIT ?"
+        params.append(limit * 2)
         with self._lock:
-            rows = self._conn.execute(
-                "SELECT id, data, status, reviewed_by, reviewed_at "
-                "FROM knowledge_units "
-                "ORDER BY COALESCE(reviewed_at, created_at) DESC LIMIT ?",
-                (limit * 2,),
-            ).fetchall()
+            rows = self._conn.execute(sql, params).fetchall()
         activity = []
         for row in rows:
             unit = KnowledgeUnit.model_validate_json(row[1])
@@ -1353,19 +1416,15 @@ class RemoteStore:
         activity.sort(key=lambda e: e.get("timestamp", ""), reverse=True)
         return activity[:limit]
 
-    def daily_counts(self, *, days: int = 30) -> list[dict[str, Any]]:
+    def daily_counts(
+        self,
+        *,
+        days: int = 30,
+        enterprise_id: str | None = None,
+    ) -> list[dict[str, Any]]:
         """Return daily proposal and approval counts with contiguous dates.
 
-        Returns one entry per day from the earliest activity (within the
-        lookback window) through today, filling gaps with zero counts.
-        Pre-migration rows with NULL created_at are excluded.
-
-        Args:
-            days: Number of days to look back.
-
-        Returns:
-            List of dicts with date, proposed, approved, and rejected
-            counts, ordered ascending.
+        When ``enterprise_id`` is provided, restrict to that Enterprise.
 
         Raises:
             ValueError: If days is not positive.
@@ -1374,29 +1433,31 @@ class RemoteStore:
             raise ValueError("days must be positive")
         self._check_open()
         cutoff = f"-{days} days"
+        ent_clause = " AND enterprise_id = ?" if enterprise_id is not None else ""
+        ent_params: tuple[Any, ...] = (enterprise_id,) if enterprise_id is not None else ()
         with self._lock:
             proposed_rows = self._conn.execute(
                 "SELECT date(created_at) as day, COUNT(*) as cnt "
                 "FROM knowledge_units "
-                "WHERE created_at >= date('now', ?) "
+                "WHERE created_at >= date('now', ?)" + ent_clause + " "
                 "GROUP BY day",
-                (cutoff,),
+                (cutoff, *ent_params),
             ).fetchall()
             approved_rows = self._conn.execute(
                 "SELECT date(reviewed_at) as day, COUNT(*) as cnt "
                 "FROM knowledge_units "
                 "WHERE status = 'approved' "
-                "AND reviewed_at >= date('now', ?) "
+                "AND reviewed_at >= date('now', ?)" + ent_clause + " "
                 "GROUP BY day",
-                (cutoff,),
+                (cutoff, *ent_params),
             ).fetchall()
             rejected_rows = self._conn.execute(
                 "SELECT date(reviewed_at) as day, COUNT(*) as cnt "
                 "FROM knowledge_units "
                 "WHERE status = 'rejected' "
-                "AND reviewed_at >= date('now', ?) "
+                "AND reviewed_at >= date('now', ?)" + ent_clause + " "
                 "GROUP BY day",
-                (cutoff,),
+                (cutoff, *ent_params),
             ).fetchall()
         proposed = {row[0]: row[1] for row in proposed_rows}
         approved = {row[0]: row[1] for row in approved_rows}

--- a/server/backend/tests/test_admin_delete.py
+++ b/server/backend/tests/test_admin_delete.py
@@ -22,6 +22,12 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
     monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
     app.dependency_overrides[require_api_key] = lambda: TEST_USERNAME
     with TestClient(app) as c:
+        from cq_server.app import _get_store
+        from cq_server.auth import hash_password
+
+        store = _get_store()
+        if store.get_user(TEST_USERNAME) is None:
+            store.create_user(TEST_USERNAME, hash_password("test-pw"))
         yield c
     app.dependency_overrides.pop(require_api_key, None)
 
@@ -48,6 +54,7 @@ def _admin_jwt(client: TestClient) -> str:
         store.create_user("admin", pw_hash)
     except Exception:
         pass  # already exists
+    store.set_user_role("admin", "admin")
     resp = client.post("/auth/login", json={"username": "admin", "password": "admin"})
     assert resp.status_code == 200, resp.text
     return resp.json()["token"]

--- a/server/backend/tests/test_app.py
+++ b/server/backend/tests/test_app.py
@@ -408,6 +408,7 @@ class TestReviewLifecycleEndToEnd:
 
         store = _get_store()
         store.create_user("reviewer", hash_password("pass123"))
+        store.set_user_role("reviewer", "admin")  # /review/* requires admin
 
         # Log in.
         login_resp = client.post(

--- a/server/backend/tests/test_review.py
+++ b/server/backend/tests/test_review.py
@@ -28,8 +28,19 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
     app.dependency_overrides.pop(require_api_key, None)
 
 
-def _login(client: TestClient, username: str = "reviewer", password: str = "pass123") -> str:
-    """Seed a user, log in, return the JWT token."""
+def _login(
+    client: TestClient,
+    username: str = "reviewer",
+    password: str = "pass123",
+    *,
+    role: str = "admin",
+    enterprise_id: str | None = None,
+) -> str:
+    """Seed a user (admin by default for /review tests), log in, return JWT.
+
+    /review/* requires admin role (SEC-CRIT #32). Tests that want to
+    exercise the 403-on-non-admin path pass role="user".
+    """
     import contextlib
 
     from cq_server.app import _get_store
@@ -38,6 +49,14 @@ def _login(client: TestClient, username: str = "reviewer", password: str = "pass
     store = _get_store()
     with contextlib.suppress(Exception):
         store.create_user(username, hash_password(password))
+    if role != "user":
+        store.set_user_role(username, role)
+    if enterprise_id is not None:
+        with store._lock, store._conn:
+            store._conn.execute(
+                "UPDATE users SET enterprise_id = ? WHERE username = ?",
+                (enterprise_id, username),
+            )
     resp = client.post("/auth/login", json={"username": username, "password": password})
     return resp.json()["token"]
 
@@ -316,3 +335,107 @@ class TestReviewStatsDetail:
         unit_events = [e for e in events if e["unit_id"] == unit["id"]]
         assert len(unit_events) == 1
         assert unit_events[0]["type"] == "proposed"
+
+
+class TestReviewAdminGate:
+    """SEC-CRIT #32 — /review/* requires admin role."""
+
+    def test_non_admin_queue_403(self, client: TestClient) -> None:
+        token = _login(client, "regular-user", role="user")
+        resp = client.get("/review/queue", headers=_auth_header(token))
+        assert resp.status_code == 403
+
+    def test_non_admin_approve_403(self, client: TestClient) -> None:
+        admin_token = _login(client)
+        unit = _propose(client)
+        user_token = _login(client, "regular-user", role="user")
+        resp = client.post(f"/review/{unit['id']}/approve", headers=_auth_header(user_token))
+        assert resp.status_code == 403
+        # Admin can still approve.
+        resp = client.post(f"/review/{unit['id']}/approve", headers=_auth_header(admin_token))
+        assert resp.status_code == 200
+
+    def test_non_admin_delete_403(self, client: TestClient) -> None:
+        _login(client)  # seed admin so KU exists in default tenant
+        unit = _propose(client)
+        user_token = _login(client, "regular-user", role="user")
+        resp = client.delete(f"/review/{unit['id']}", headers=_auth_header(user_token))
+        assert resp.status_code == 403
+
+    def test_non_admin_stats_403(self, client: TestClient) -> None:
+        token = _login(client, "regular-user", role="user")
+        resp = client.get("/review/stats", headers=_auth_header(token))
+        assert resp.status_code == 403
+
+
+class TestReviewTenantScope:
+    """SEC-CRIT #32 — /review/* is scoped to the admin's Enterprise."""
+
+    def _set_ku_tenancy(self, unit_id: str, *, enterprise_id: str) -> None:
+        from cq_server.app import _get_store
+
+        store = _get_store()
+        with store._lock, store._conn:
+            store._conn.execute(
+                "UPDATE knowledge_units SET enterprise_id = ? WHERE id = ?",
+                (enterprise_id, unit_id),
+            )
+
+    def test_admin_a_cannot_see_admin_b_ku(self, client: TestClient) -> None:
+        token_a = _login(client, "admin-a", enterprise_id="acme")
+        token_b = _login(client, "admin-b", enterprise_id="globex")
+        # Both proposes land in default-enterprise; reassign the second one to globex.
+        _propose(client, domains=["acme-only"])
+        unit_b = _propose(client, domains=["globex-only"])
+        self._set_ku_tenancy(unit_b["id"], enterprise_id="globex")
+
+        # admin-a (acme) sees only acme's pending queue.
+        a_queue = client.get("/review/queue", headers=_auth_header(token_a)).json()
+        a_ids = {item["knowledge_unit"]["id"] for item in a_queue["items"]}
+        assert unit_b["id"] not in a_ids
+
+        # admin-b (globex) sees only globex's row.
+        b_queue = client.get("/review/queue", headers=_auth_header(token_b)).json()
+        b_ids = {item["knowledge_unit"]["id"] for item in b_queue["items"]}
+        assert b_ids == {unit_b["id"]}
+
+    def test_cross_tenant_get_returns_404(self, client: TestClient) -> None:
+        _login(client)  # seed default-tenant admin for the propose call
+        unit = _propose(client)
+        self._set_ku_tenancy(unit["id"], enterprise_id="globex")
+        token_a = _login(client, "admin-a", enterprise_id="acme")
+        resp = client.get(f"/review/{unit['id']}", headers=_auth_header(token_a))
+        assert resp.status_code == 404
+
+    def test_cross_tenant_approve_returns_404(self, client: TestClient) -> None:
+        _login(client)  # default-tenant admin to allow propose
+        unit = _propose(client)
+        self._set_ku_tenancy(unit["id"], enterprise_id="globex")
+        token_a = _login(client, "admin-a", enterprise_id="acme")
+        resp = client.post(f"/review/{unit['id']}/approve", headers=_auth_header(token_a))
+        assert resp.status_code == 404
+
+    def test_cross_tenant_delete_returns_404(self, client: TestClient) -> None:
+        _login(client)
+        unit = _propose(client)
+        self._set_ku_tenancy(unit["id"], enterprise_id="globex")
+        token_a = _login(client, "admin-a", enterprise_id="acme")
+        resp = client.delete(f"/review/{unit['id']}", headers=_auth_header(token_a))
+        assert resp.status_code == 404
+
+    def test_stats_scoped_to_admin_enterprise(self, client: TestClient) -> None:
+        _login(client)  # default-tenant admin
+        unit_default = _propose(client, domains=["scope-test"])
+        unit_globex = _propose(client, domains=["scope-test"])
+        self._set_ku_tenancy(unit_globex["id"], enterprise_id="globex")
+
+        token_a = _login(client, "admin-a", enterprise_id="acme")
+        # acme has zero KUs.
+        resp = client.get("/review/stats", headers=_auth_header(token_a))
+        assert resp.status_code == 200
+        assert sum(resp.json()["counts"].values()) == 0
+
+        token_b = _login(client, "admin-b", enterprise_id="globex")
+        resp = client.get("/review/stats", headers=_auth_header(token_b))
+        assert resp.status_code == 200
+        assert resp.json()["counts"]["pending"] == 1


### PR DESCRIPTION
Closes #32. /review/queue, /approve, /reject, DELETE, /stats, /units, /{id} now require admin role and are scoped to the caller's Enterprise. 11 store methods accept optional enterprise_id; SQL filters at row level. Cross-tenant per-unit ops return 404 (no fingerprinting). 355 tests passing (+9 new admin-gate + tenant-isolation tests).