### PR TITLE
[sec] forwarder identity binding on /forward-* · partial CRIT #34

### DIFF
--- a/server/backend/src/cq_server/aigrp.py
+++ b/server/backend/src/cq_server/aigrp.py
@@ -94,6 +94,79 @@ def require_peer_key(request: Request) -> None:
         raise HTTPException(status_code=401, detail="invalid peer key")
 
 
+# SEC-CRIT #34 — forward-endpoint identity binding.
+#
+# The shared EnterprisePeerKey gates *transport* (only Enterprise L2s can call
+# each other). It does NOT bind a request to a specific *sender* L2 — every L2
+# in the Enterprise has the same key, so any L2 with the key can forge any
+# sibling's identity in the body.
+#
+# Until per-L2 Ed25519 keys land (sprint 4 — same primitive the directory and
+# reputation log need), the receiver explicitly enforces:
+#   1. The forwarder declares its identity in ``X-8L-Forwarder-L2-Id`` (header,
+#      not buried in body)
+#   2. The body's ``from_l2_id`` / ``requester_l2_id`` matches the header
+#   3. The header's Enterprise component equals the receiver's Enterprise —
+#      the peer-key gate is supposed to enforce this implicitly, but the body
+#      previously didn't have to honour it
+#
+# This raises the bar from "any body" to "any body matching declared header"
+# and closes cross-Enterprise impersonation outright. Sibling-L2 impersonation
+# inside an Enterprise is the residual gap closed by Ed25519.
+FORWARDER_HEADER = "x-8l-forwarder-l2-id"
+
+
+def require_forwarder_identity(
+    request: Request,
+    claimed_l2_id: str,
+    *,
+    same_enterprise_only: bool = True,
+) -> str:
+    """Validate the forwarder's declared identity on a /forward-* endpoint.
+
+    Args:
+        request: incoming FastAPI request (must contain the forwarder header).
+        claimed_l2_id: the L2 id claimed in the request body (e.g.
+            body.from_l2_id for consults, body.requester_l2_id for AIGRP).
+        same_enterprise_only: when True (intra-Enterprise forwards like
+            /consults/forward-*), the forwarder's Enterprise component must
+            match the receiver's Enterprise. When False (AIGRP cross-Enterprise
+            consent path), the header still must match the body but the
+            forwarder may belong to a peered foreign Enterprise — that
+            authorisation comes from cross_enterprise_consents downstream.
+
+    Returns:
+        The header-declared forwarder L2 id (post-validation).
+
+    Raises:
+        HTTPException 400 on missing/empty header.
+        HTTPException 403 on header/body mismatch or cross-Enterprise spoof.
+    """
+    declared = request.headers.get(FORWARDER_HEADER, "").strip()
+    if not declared:
+        raise HTTPException(
+            status_code=400,
+            detail=f"missing {FORWARDER_HEADER} header on cross-L2 forward",
+        )
+    if declared != claimed_l2_id:
+        raise HTTPException(
+            status_code=403,
+            detail=f"forwarder identity mismatch: header={declared!r} body={claimed_l2_id!r}",
+        )
+    declared_enterprise, sep, _ = declared.partition("/")
+    if not declared_enterprise or not sep:
+        raise HTTPException(
+            status_code=400,
+            detail=f"forwarder l2 id must be enterprise/group, got {declared!r}",
+        )
+    if same_enterprise_only and declared_enterprise != enterprise():
+        raise HTTPException(
+            status_code=403,
+            detail=f"cross-Enterprise forward rejected: forwarder={declared!r} receiver_enterprise={enterprise()!r}",
+        )
+    return declared
+
+
 def _bloom_hashes(domain: str) -> list[int]:
     """Return BLOOM_HASHES bit indices for a domain string."""
     digest = hashlib.sha256(domain.encode()).digest()

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -16,7 +16,7 @@ from cq.models import (
     Tier,
     create_knowledge_unit,
 )
-from fastapi import APIRouter, Depends, FastAPI, HTTPException, Query
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Query, Request
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 from starlette.responses import FileResponse
@@ -685,6 +685,7 @@ def _decide_policy_for_ku(
 @api_router.post("/aigrp/forward-query")
 def aigrp_forward_query(
     body: AigrpForwardQueryRequest,
+    request: Request,
     _peer: None = Depends(aigrp.require_peer_key),
 ) -> AigrpForwardQueryResponse:
     """Cross-L2 forward-query — Phase 6 step 2.
@@ -700,9 +701,19 @@ def aigrp_forward_query(
     ``cross_enterprise_consents`` row — without that the call returns
     zero results silently rather than 401, so probes can't fingerprint
     consent state.
+
+    SEC-CRIT #34 — caller declares its identity in ``X-8L-Forwarder-L2-Id``;
+    receiver pins it to ``body.requester_l2_id`` and to its own Enterprise.
+    Closes cross-Enterprise impersonation; sibling-L2 spoof inside an
+    Enterprise is the residual gap (sprint 4 / Ed25519).
     """
     import uuid
 
+    # AIGRP forward-query supports cross-Enterprise via consent table — the
+    # foreign forwarder's Enterprise legitimately differs from the receiver's.
+    aigrp.require_forwarder_identity(
+        request, body.requester_l2_id, same_enterprise_only=False
+    )
     store = _get_store()
 
     responder_enterprise = aigrp.enterprise()

--- a/server/backend/src/cq_server/consults.py
+++ b/server/backend/src/cq_server/consults.py
@@ -26,7 +26,7 @@ from typing import Any
 from uuid import uuid4
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from . import aigrp as aigrp_mod
@@ -169,7 +169,10 @@ def _forward_request(target: dict[str, Any], payload: dict[str, Any]) -> None:
         with httpx.Client(timeout=L2_FORWARD_TIMEOUT) as client:
             r = client.post(
                 f"{base}/api/v1/consults/forward-request",
-                headers={"authorization": f"Bearer {peer_key}"},
+                headers={
+                    "authorization": f"Bearer {peer_key}",
+                    aigrp_mod.FORWARDER_HEADER: _self_l2_id(),
+                },
                 json=payload,
             )
         if r.status_code >= 400:
@@ -194,7 +197,10 @@ def _forward_message(target: dict[str, Any], payload: dict[str, Any]) -> None:
         with httpx.Client(timeout=L2_FORWARD_TIMEOUT) as client:
             r = client.post(
                 f"{base}/api/v1/consults/forward-message",
-                headers={"authorization": f"Bearer {peer_key}"},
+                headers={
+                    "authorization": f"Bearer {peer_key}",
+                    aigrp_mod.FORWARDER_HEADER: _self_l2_id(),
+                },
                 json=payload,
             )
         if r.status_code >= 400:
@@ -474,6 +480,7 @@ class ForwardRequestBody(BaseModel):
 @router.post("/forward-request", status_code=201)
 def forward_consult_request(
     body: ForwardRequestBody,
+    request: Request,
     store: RemoteStore = Depends(get_store),
     _peer: None = Depends(aigrp_mod.require_peer_key),
 ) -> dict[str, str]:
@@ -483,10 +490,15 @@ def forward_consult_request(
     side did its local mirror-write. We re-do the same writes here so
     BOTH L2s have the durable corporate-IP record per decisions/10.
 
+    SEC-CRIT #34 — receiver pins ``X-8L-Forwarder-L2-Id`` to ``body.from_l2_id``
+    and to its own Enterprise; closes cross-Enterprise impersonation outright
+    and surfaces the residual sibling-L2 gap (sprint 4 / Ed25519).
+
     Idempotent on thread_id collision: if the thread already exists
     (re-delivery, retry), we skip the create and just append the message
     if it's new. Same for message_id.
     """
+    aigrp_mod.require_forwarder_identity(request, body.from_l2_id)
     if store.get_consult(body.thread_id) is None:
         store.create_consult(
             thread_id=body.thread_id,
@@ -535,6 +547,7 @@ class ForwardMessageBody(BaseModel):
 @router.post("/forward-message", status_code=201)
 def forward_consult_message(
     body: ForwardMessageBody,
+    request: Request,
     store: RemoteStore = Depends(get_store),
     _peer: None = Depends(aigrp_mod.require_peer_key),
 ) -> dict[str, str]:
@@ -544,7 +557,10 @@ def forward_consult_message(
     create it from the embedded thread metadata before appending. This
     prevents a single dropped forward from permanently breaking the
     audit trail on this side.
+
+    SEC-CRIT #34 — same forwarder-identity binding as /forward-request.
     """
+    aigrp_mod.require_forwarder_identity(request, body.from_l2_id)
     existing = store.get_consult(body.thread_id)
     if existing is None:
         if not (

--- a/server/backend/src/cq_server/network.py
+++ b/server/backend/src/cq_server/network.py
@@ -978,7 +978,12 @@ async def _call_forward_query(
     # responder's key in this internal-fleet topology). For cross-Enterprise
     # the responder has its own key, which is why we resolve by target.
     peer_key = _peer_key_for(target["enterprise"])
-    headers = {"authorization": f"Bearer {peer_key}"} if peer_key else {}
+    headers: dict[str, str] = {}
+    if peer_key:
+        headers["authorization"] = f"Bearer {peer_key}"
+    # SEC-CRIT #34 — declare the forwarder identity so the receiver can pin
+    # the body's requester_l2_id to the same value.
+    headers[aigrp.FORWARDER_HEADER] = f"{requester['enterprise']}/{requester['group']}"
     t0 = time.monotonic()
     try:
         r = await client.post(

--- a/server/backend/tests/test_cross_l2_routing.py
+++ b/server/backend/tests/test_cross_l2_routing.py
@@ -269,7 +269,10 @@ def test_forward_request_mirrors_thread_and_message(client: TestClient) -> None:
     }
     r = client.post(
         "/api/v1/consults/forward-request",
-        headers={"Authorization": f"Bearer {ACME_PEER_KEY}"},
+        headers={
+            "Authorization": f"Bearer {ACME_PEER_KEY}",
+            "x-8l-forwarder-l2-id": "acme/solutions",
+        },
         json=payload,
     )
     assert r.status_code == 201, r.text
@@ -292,7 +295,7 @@ def test_forward_request_idempotent_on_redelivery(client: TestClient) -> None:
         "content": "first",
         "created_at": "2026-05-01T17:00:00+00:00",
     }
-    h = {"Authorization": f"Bearer {ACME_PEER_KEY}"}
+    h = {"Authorization": f"Bearer {ACME_PEER_KEY}", "x-8l-forwarder-l2-id": "acme/solutions"}
     r1 = client.post("/api/v1/consults/forward-request", headers=h, json=payload)
     r2 = client.post("/api/v1/consults/forward-request", headers=h, json=payload)
     assert r1.status_code == 201
@@ -302,13 +305,16 @@ def test_forward_request_idempotent_on_redelivery(client: TestClient) -> None:
 def test_forward_request_rejects_wrong_peer_key(client: TestClient) -> None:
     r = client.post(
         "/api/v1/consults/forward-request",
-        headers={"Authorization": "Bearer wrong-key"},
+        headers={
+            "Authorization": "Bearer wrong-key",
+            "x-8l-forwarder-l2-id": "acme/solutions",
+        },
         json={
             "thread_id": "x",
             "message_id": "x",
-            "from_l2_id": "a",
+            "from_l2_id": "acme/solutions",
             "from_persona": "x",
-            "to_l2_id": "b",
+            "to_l2_id": "acme/engineering",
             "to_persona": "x",
             "content": "x",
             "created_at": "x",
@@ -323,9 +329,9 @@ def test_forward_request_rejects_anonymous(client: TestClient) -> None:
         json={
             "thread_id": "x",
             "message_id": "x",
-            "from_l2_id": "a",
+            "from_l2_id": "acme/solutions",
             "from_persona": "x",
-            "to_l2_id": "b",
+            "to_l2_id": "acme/engineering",
             "to_persona": "x",
             "content": "x",
             "created_at": "x",
@@ -340,7 +346,7 @@ def test_forward_request_rejects_anonymous(client: TestClient) -> None:
 
 
 def test_forward_message_appends_to_existing_thread(client: TestClient) -> None:
-    h = {"Authorization": f"Bearer {ACME_PEER_KEY}"}
+    h = {"Authorization": f"Bearer {ACME_PEER_KEY}", "x-8l-forwarder-l2-id": "acme/solutions"}
     # First, mirror the thread via /forward-request
     client.post("/api/v1/consults/forward-request", headers=h, json={
         "thread_id": "th_msg_a",
@@ -352,8 +358,10 @@ def test_forward_message_appends_to_existing_thread(client: TestClient) -> None:
         "content": "open",
         "created_at": "2026-05-01T18:00:00+00:00",
     })
-    # Append a reply via /forward-message
-    r = client.post("/api/v1/consults/forward-message", headers=h, json={
+    # Append a reply via /forward-message — note the reply is from
+    # acme/engineering (forwarder identity must match body.from_l2_id).
+    h_reply = {"Authorization": f"Bearer {ACME_PEER_KEY}", "x-8l-forwarder-l2-id": "acme/engineering"}
+    r = client.post("/api/v1/consults/forward-message", headers=h_reply, json={
         "thread_id": "th_msg_a",
         "message_id": "msg_msg_a_2",
         "from_l2_id": "acme/engineering",
@@ -373,7 +381,7 @@ def test_forward_message_appends_to_existing_thread(client: TestClient) -> None:
 
 def test_forward_message_lazily_creates_missing_thread(client: TestClient) -> None:
     """If /forward-request was lost, /forward-message backfills the thread row."""
-    h = {"Authorization": f"Bearer {ACME_PEER_KEY}"}
+    h = {"Authorization": f"Bearer {ACME_PEER_KEY}", "x-8l-forwarder-l2-id": "acme/solutions"}
     r = client.post("/api/v1/consults/forward-message", headers=h, json={
         "thread_id": "th_lazy_a",
         "message_id": "msg_lazy_a",
@@ -396,7 +404,7 @@ def test_forward_message_lazily_creates_missing_thread(client: TestClient) -> No
 
 
 def test_forward_message_missing_thread_no_metadata_400(client: TestClient) -> None:
-    h = {"Authorization": f"Bearer {ACME_PEER_KEY}"}
+    h = {"Authorization": f"Bearer {ACME_PEER_KEY}", "x-8l-forwarder-l2-id": "acme/solutions"}
     r = client.post("/api/v1/consults/forward-message", headers=h, json={
         "thread_id": "th_missing",
         "message_id": "msg_x",
@@ -405,6 +413,96 @@ def test_forward_message_missing_thread_no_metadata_400(client: TestClient) -> N
         "content": "no thread no metadata",
         "created_at": "2026-05-01T20:00:00+00:00",
     })
+    assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# SEC-CRIT #34 — forwarder identity binding on /forward-* endpoints
+# ---------------------------------------------------------------------------
+
+
+_VALID_FWD_PAYLOAD = {
+    "thread_id": "th_sec",
+    "message_id": "msg_sec",
+    "from_l2_id": "acme/solutions",
+    "from_persona": "carla",
+    "to_l2_id": "acme/engineering",
+    "to_persona": "alice",
+    "content": "hello",
+    "created_at": "2026-05-01T21:00:00+00:00",
+}
+
+
+def test_forward_request_missing_forwarder_header_400(client: TestClient) -> None:
+    r = client.post(
+        "/api/v1/consults/forward-request",
+        headers={"Authorization": f"Bearer {ACME_PEER_KEY}"},
+        json=dict(_VALID_FWD_PAYLOAD),
+    )
+    assert r.status_code == 400
+    assert "x-8l-forwarder-l2-id" in r.json()["detail"].lower()
+
+
+def test_forward_request_header_body_mismatch_403(client: TestClient) -> None:
+    """Compromised L2 forges body identity but forgets to match the header."""
+    r = client.post(
+        "/api/v1/consults/forward-request",
+        headers={
+            "Authorization": f"Bearer {ACME_PEER_KEY}",
+            "x-8l-forwarder-l2-id": "acme/finance",  # claims to be finance
+        },
+        json={**_VALID_FWD_PAYLOAD, "from_l2_id": "acme/solutions"},  # body says solutions
+    )
+    assert r.status_code == 403
+    assert "mismatch" in r.json()["detail"].lower()
+
+
+def test_forward_request_cross_enterprise_forwarder_rejected(client: TestClient) -> None:
+    """A forwarder claiming to belong to a foreign Enterprise is rejected.
+
+    consults.forward-* is intra-Enterprise only (decision 10's mutual
+    logging within an Enterprise); cross-Enterprise consults flow through
+    /aigrp/forward-query with consent.
+    """
+    r = client.post(
+        "/api/v1/consults/forward-request",
+        headers={
+            "Authorization": f"Bearer {ACME_PEER_KEY}",
+            "x-8l-forwarder-l2-id": "rival/eng",
+        },
+        json={**_VALID_FWD_PAYLOAD, "from_l2_id": "rival/eng"},
+    )
+    assert r.status_code == 403
+    assert "cross-enterprise" in r.json()["detail"].lower()
+
+
+def test_forward_request_malformed_forwarder_header_400(client: TestClient) -> None:
+    """Forwarder header without enterprise/group separator is invalid."""
+    r = client.post(
+        "/api/v1/consults/forward-request",
+        headers={
+            "Authorization": f"Bearer {ACME_PEER_KEY}",
+            "x-8l-forwarder-l2-id": "no-slash-here",
+        },
+        json={**_VALID_FWD_PAYLOAD, "from_l2_id": "no-slash-here"},
+    )
+    assert r.status_code == 400
+    assert "enterprise/group" in r.json()["detail"].lower()
+
+
+def test_forward_message_missing_forwarder_header_400(client: TestClient) -> None:
+    r = client.post(
+        "/api/v1/consults/forward-message",
+        headers={"Authorization": f"Bearer {ACME_PEER_KEY}"},
+        json={
+            "thread_id": "x",
+            "message_id": "y",
+            "from_l2_id": "acme/solutions",
+            "from_persona": "carla",
+            "content": "x",
+            "created_at": "x",
+        },
+    )
     assert r.status_code == 400
 
 

--- a/server/backend/tests/test_forward_query.py
+++ b/server/backend/tests/test_forward_query.py
@@ -109,16 +109,28 @@ def _post_forward_query(
     *,
     requester_enterprise: str,
     requester_group: str,
-    requester_l2_id: str = "acme-engineering-l2",
+    requester_l2_id: str | None = None,
     requester_persona: str = "persona-cloudfront-asker",
     query_axis: int = 0,
     max_results: int = 5,
     peer_key: str = PEER_KEY,
+    forwarder_l2_id: str | None = None,
 ) -> Any:
-    """Issue a forward-query call with a unit-vector embedding."""
+    """Issue a forward-query call with a unit-vector embedding.
+
+    SEC-CRIT #34: ``X-8L-Forwarder-L2-Id`` is required and must match
+    ``requester_l2_id``; defaults derived from requester scope.
+    """
+    if requester_l2_id is None:
+        requester_l2_id = f"{requester_enterprise}/{requester_group}"
+    if forwarder_l2_id is None:
+        forwarder_l2_id = requester_l2_id
     return client.post(
         "/api/v1/aigrp/forward-query",
-        headers={"authorization": f"Bearer {peer_key}"},
+        headers={
+            "authorization": f"Bearer {peer_key}",
+            "x-8l-forwarder-l2-id": forwarder_l2_id,
+        },
         json={
             "query_vec": _unit_vec(axis=query_axis),
             "query_text": "cloudfront cache",
@@ -428,10 +440,13 @@ class TestRouteMounts:
         _seed_ku(enterprise_id="acme", group_id="solutions")
         resp = aigrp_client.post(
             "/aigrp/forward-query",
-            headers={"authorization": f"Bearer {PEER_KEY}"},
+            headers={
+                "authorization": f"Bearer {PEER_KEY}",
+                "x-8l-forwarder-l2-id": "acme/engineering",
+            },
             json={
                 "query_vec": _unit_vec(),
-                "requester_l2_id": "acme-engineering-l2",
+                "requester_l2_id": "acme/engineering",
                 "requester_enterprise": "acme",
                 "requester_group": "engineering",
                 "max_results": 5,


### PR DESCRIPTION
Refs #34. Closes cross-Enterprise impersonation; sibling-L2 spoof inside an Enterprise is the residual gap (Ed25519 per-L2 keys, sprint 4 — same primitive directory + reputation log need). 360 tests passing (+5 new identity-binding tests).