### PR TITLE
[sec] admin-seed scripts set role=admin (CRIT #32 follow-up)

### DIFF
--- a/server/local-demo/bin/seed-admin.sh
+++ b/server/local-demo/bin/seed-admin.sh
@@ -16,6 +16,9 @@ fi
 
 ADMIN_PW=$(openssl rand -base64 32 | tr -d '/+=' | head -c 32)
 
+# SEC-CRIT #32 (PR #42) — /review/* requires role='admin'. The script's
+# whole purpose is to seed an admin, so we set the role explicitly on
+# both insert and update paths.
 docker exec -e ADMIN_PW="$ADMIN_PW" "$CONTAINER" /app/.venv/bin/python -c "
 import os, sqlite3, datetime
 from cq_server.auth import hash_password
@@ -24,13 +27,13 @@ con = sqlite3.connect('/data/cq.db')
 con.execute('CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT NOT NULL UNIQUE, password_hash TEXT NOT NULL, created_at TEXT NOT NULL)')
 now = datetime.datetime.now(datetime.UTC).isoformat()
 try:
-    con.execute('INSERT INTO users (username, password_hash, created_at) VALUES (?, ?, ?)', ('admin', hash_password(pw), now))
+    con.execute('INSERT INTO users (username, password_hash, created_at, role) VALUES (?, ?, ?, ?)', ('admin', hash_password(pw), now, 'admin'))
     con.commit()
-    print('admin created')
+    print('admin created (role=admin)')
 except sqlite3.IntegrityError:
-    con.execute('UPDATE users SET password_hash = ? WHERE username = ?', (hash_password(pw), 'admin'))
+    con.execute('UPDATE users SET password_hash = ?, role = ? WHERE username = ?', (hash_password(pw), 'admin', 'admin'))
     con.commit()
-    print('admin password reset')
+    print('admin password + role reset')
 con.close()
 "
 

--- a/server/scripts/seed-users.py
+++ b/server/scripts/seed-users.py
@@ -9,10 +9,16 @@ import bcrypt
 
 
 def main() -> None:
-    """Seed a user into the cq remote database."""
+    """Seed a user into the cq remote database.
+
+    SEC-CRIT #32 (PR #42) added an admin gate on /review/* — users
+    seeded without ``--role admin`` will get 403 on the review surface.
+    Pass ``--role admin`` for any user expected to triage the queue.
+    """
     parser = argparse.ArgumentParser(description="Seed a cq remote user.")
     parser.add_argument("--username", required=True)
     parser.add_argument("--password", required=True)
+    parser.add_argument("--role", default="user", choices=["user", "admin"])
     parser.add_argument("--db", default="/data/cq.db")
     args = parser.parse_args()
 
@@ -25,18 +31,19 @@ def main() -> None:
     conn = sqlite3.connect(str(db_path))
     try:
         conn.execute(
-            "INSERT INTO users (username, password_hash, created_at) VALUES (?, ?, datetime('now'))",
-            (args.username, password_hash),
+            "INSERT INTO users (username, password_hash, created_at, role) "
+            "VALUES (?, ?, datetime('now'), ?)",
+            (args.username, password_hash, args.role),
         )
         conn.commit()
-        print(f"User '{args.username}' created.")
+        print(f"User '{args.username}' created with role='{args.role}'.")
     except sqlite3.IntegrityError:
         conn.execute(
-            "UPDATE users SET password_hash = ? WHERE username = ?",
-            (password_hash, args.username),
+            "UPDATE users SET password_hash = ?, role = ? WHERE username = ?",
+            (password_hash, args.role, args.username),
         )
         conn.commit()
-        print(f"User '{args.username}' already exists — password updated.")
+        print(f"User '{args.username}' already exists — password + role='{args.role}' updated.")
     finally:
         conn.close()
 


### PR DESCRIPTION
Surfaced during Docker E2E validation of PR #42. Both admin-seed scripts (local-demo bin/seed-admin.sh and prod scripts/seed-users.py) pre-date the /review/* admin gate, so freshly-seeded admins were getting 403. Both now set role='admin'; re-running the script promotes pre-existing users. 360 tests passing.