### PR TITLE
[directory-client] sprint 3 — L2-side announce + 1h pull loop

### DIFF
--- a/server/backend/pyproject.toml
+++ b/server/backend/pyproject.toml
@@ -18,6 +18,12 @@ dependencies = [
     "alembic>=1.18.4,<2",
     "boto3>=1.34",
     "numpy>=1.26",
+    # 8th-Layer directory client (sprint 3) — Ed25519 signing of /announce
+    # envelopes and verification of peering records pulled from the
+    # directory. Same primitives as `OneZero1ai/8th-layer-directory`.
+    "cryptography>=42",
+    "rfc8785>=0.1.4",
+    "httpx",
 ]
 
 [project.scripts]

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -210,9 +210,17 @@ async def lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
 
     dsn_cache_task = asyncio.create_task(_signature_cache_loop())
 
+    # Sprint 3 — 8th-Layer Directory client (announce + 1h pull loop).
+    # Opt-in via CQ_DIRECTORY_ENABLED — defaults off until the public
+    # directory is deployed. The bootstrap function self-skips with a
+    # log line when disabled or under-configured.
+    from .directory_client import directory_bootstrap_and_loop
+
+    directory_task = asyncio.create_task(directory_bootstrap_and_loop(_store))
+
     yield
 
-    for task in (aigrp_task, dsn_cache_task):
+    for task in (aigrp_task, dsn_cache_task, directory_task):
         if task is not None:
             task.cancel()
             try:

--- a/server/backend/src/cq_server/directory_client.py
+++ b/server/backend/src/cq_server/directory_client.py
@@ -1,0 +1,496 @@
+"""8th-Layer Directory client — sprint 3.
+
+Cq-server's L2-side adapter for the public directory at
+``directory.8thlayer.onezero1.ai``. Per ``decisions/11`` and
+``specs/directory-v1.md``:
+
+- **Announce-on-startup**: when ``CQ_DIRECTORY_ENABLED=true``, the L2
+  signs an `/announce` envelope with the enterprise root key on
+  startup and POSTs it. 201 → first contact. 200 → record updated.
+- **Peering pull loop**: every ``CQ_DIRECTORY_PULL_INTERVAL_SEC``
+  (default 1 hour), GET ``/peerings/{enterprise_id}`` with a signed
+  empty-payload envelope as proof-of-identity, verify each returned
+  peering record's BOTH signatures (offer + accept) against the
+  ``/enterprises/{id}/key`` endpoint, and write-through to the local
+  ``aigrp_directory_peerings`` table.
+
+The directory is **never** in the data path. Once a peering is pulled
+and verified, /aigrp/forward-query and /consults/forward-* talk
+directly L2-to-L2 using the agreed peering key.
+
+Design choices:
+
+- We re-use ``rfc8785``'s JCS canonicalization so the bytes the
+  directory verifies are byte-identical to what we sign.
+- Ed25519 keypair source is filesystem-mount in v1
+  (``CQ_ENTERPRISE_ROOT_PRIVKEY_PATH``); HSM/KMS-backed signing is
+  v2.
+- Pull-loop failures are logged but never crash the server — the
+  directory is best-effort. Local routing falls back to whatever
+  peerings were pulled on the last success.
+- All work runs as asyncio background tasks attached to the FastAPI
+  lifespan. Cancellation is graceful.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import json
+import logging
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+import rfc8785
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+from .store import RemoteStore
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.INFO)
+if not log.handlers:
+    _h = logging.StreamHandler()
+    _h.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s %(message)s"))
+    log.addHandler(_h)
+
+# Public directory base URL. Override in tests via env.
+DEFAULT_DIRECTORY_URL = "https://directory.8thlayer.onezero1.ai"
+DEFAULT_PULL_INTERVAL_SEC = 3600
+ANNOUNCE_RETRY_BASE_SEC = 30
+ANNOUNCE_RETRY_MAX_SEC = 600
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def directory_enabled() -> bool:
+    return os.environ.get("CQ_DIRECTORY_ENABLED", "false").lower() == "true"
+
+
+def directory_url() -> str:
+    return os.environ.get("CQ_DIRECTORY_URL", DEFAULT_DIRECTORY_URL).rstrip("/")
+
+
+def pull_interval_sec() -> int:
+    try:
+        return int(os.environ.get("CQ_DIRECTORY_PULL_INTERVAL_SEC", str(DEFAULT_PULL_INTERVAL_SEC)))
+    except ValueError:
+        return DEFAULT_PULL_INTERVAL_SEC
+
+
+# ---------------------------------------------------------------------------
+# Crypto helpers (signing + envelope construction)
+# ---------------------------------------------------------------------------
+
+
+def _b64u(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+
+
+def _b64u_decode(s: str) -> bytes:
+    pad = (-len(s)) % 4
+    return base64.urlsafe_b64decode(s + ("=" * pad))
+
+
+def load_private_key(path: Path) -> Ed25519PrivateKey:
+    """Load an Ed25519 private key from a 32-byte raw file."""
+    raw = path.read_bytes()
+    if len(raw) != 32:
+        raise ValueError(f"Ed25519 private key must be 32 raw bytes, got {len(raw)}")
+    return Ed25519PrivateKey.from_private_bytes(raw)
+
+
+def public_key_b64u(privkey: Ed25519PrivateKey) -> str:
+    pub = privkey.public_key().public_bytes_raw()
+    return _b64u(pub)
+
+
+def fingerprint_sha256(pubkey_b64u: str) -> str:
+    """Match the directory's fingerprint format (`sha256:<hex>`)."""
+    raw = _b64u_decode(pubkey_b64u)
+    return f"sha256:{hashlib.sha256(raw).hexdigest()}"
+
+
+def canonicalize(payload: dict[str, Any]) -> bytes:
+    """RFC 8785 JCS canonical JSON bytes for ``payload``."""
+    return rfc8785.dumps(payload)
+
+
+def sign_envelope(privkey: Ed25519PrivateKey, payload: dict[str, Any]) -> dict[str, Any]:
+    """Build a signed envelope per directory-v1 spec.
+
+    Returns the dict the server expects on the wire:
+    ``{payload, payload_canonical, signature, signing_key_id}``.
+    """
+    canonical = canonicalize(payload)
+    signature = privkey.sign(canonical)
+    return {
+        "payload": payload,
+        "payload_canonical": canonical.decode(),
+        "signature": _b64u(signature),
+        "signing_key_id": public_key_b64u(privkey),
+    }
+
+
+def verify_envelope_signature(
+    pubkey_b64u: str,
+    payload_canonical: str,
+    signature_b64u: str,
+) -> bool:
+    """Constant-time Ed25519 verify of a signed-envelope payload.
+
+    Returns True on success, False on any cryptographic failure (we
+    never raise on verify; callers decide policy).
+    """
+    try:
+        pub = Ed25519PublicKey.from_public_bytes(_b64u_decode(pubkey_b64u))
+        pub.verify(_b64u_decode(signature_b64u), payload_canonical.encode())
+        return True
+    except (InvalidSignature, ValueError):
+        return False
+
+
+def now_iso() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Background tasks
+# ---------------------------------------------------------------------------
+
+
+async def _post_announce(
+    client: httpx.AsyncClient,
+    privkey: Ed25519PrivateKey,
+    enterprise_id: str,
+    display_name: str,
+    visibility: str,
+    contact_email: str,
+    l2_endpoints: list[dict[str, Any]],
+    discoverable_topics: list[str],
+) -> tuple[int, dict[str, Any] | None]:
+    """POST /announce. Returns (status_code, response_body | None on error)."""
+    payload = {
+        "enterprise_id": enterprise_id,
+        "display_name": display_name,
+        "visibility": visibility,
+        "root_pubkey": public_key_b64u(privkey),
+        "l2_endpoints": l2_endpoints,
+        "discoverable_topics": discoverable_topics,
+        "contact_email": contact_email,
+        "announce_ts": now_iso(),
+    }
+    envelope = sign_envelope(privkey, payload)
+    url = f"{directory_url()}/api/v1/directory/announce"
+    try:
+        r = await client.post(url, json=envelope, timeout=10.0)
+    except httpx.RequestError as e:
+        log.warning("directory: announce failed (network) err=%s", e)
+        return 0, None
+    if r.status_code in (200, 201):
+        log.info(
+            "directory: announce ok enterprise=%s status=%d (%s)",
+            enterprise_id,
+            r.status_code,
+            "first" if r.status_code == 201 else "update",
+        )
+        return r.status_code, r.json()
+    log.warning(
+        "directory: announce rejected enterprise=%s status=%d body=%s",
+        enterprise_id,
+        r.status_code,
+        r.text[:200],
+    )
+    return r.status_code, None
+
+
+async def _announce_with_retries(
+    privkey: Ed25519PrivateKey,
+    enterprise_id: str,
+    display_name: str,
+    visibility: str,
+    contact_email: str,
+    l2_endpoints: list[dict[str, Any]],
+    discoverable_topics: list[str],
+    max_attempts: int = 6,
+) -> bool:
+    """Announce with exponential backoff. Returns True on success."""
+    delay = ANNOUNCE_RETRY_BASE_SEC
+    async with httpx.AsyncClient() as client:
+        for attempt in range(1, max_attempts + 1):
+            status, _body = await _post_announce(
+                client,
+                privkey,
+                enterprise_id,
+                display_name,
+                visibility,
+                contact_email,
+                l2_endpoints,
+                discoverable_topics,
+            )
+            if status in (200, 201):
+                return True
+            # 4xx that isn't auth/timing → permanent; stop retrying.
+            if status in (400, 409, 422):
+                log.error(
+                    "directory: announce permanent failure status=%d; not retrying",
+                    status,
+                )
+                return False
+            log.info("directory: announce retry %d/%d in %ds", attempt, max_attempts, delay)
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, ANNOUNCE_RETRY_MAX_SEC)
+    return False
+
+
+async def _fetch_enterprise_pubkey(
+    client: httpx.AsyncClient, enterprise_id: str, _cache: dict[str, str]
+) -> str | None:
+    """Resolve an enterprise's root pubkey via /enterprises/{id}/key.
+
+    Cached per process for the life of the pull loop; cache flushed on
+    each pull cycle (a key rotation that landed mid-cycle is picked up
+    on the next cycle).
+    """
+    if enterprise_id in _cache:
+        return _cache[enterprise_id]
+    url = f"{directory_url()}/api/v1/directory/enterprises/{enterprise_id}/key"
+    try:
+        r = await client.get(url, timeout=10.0)
+    except httpx.RequestError as e:
+        log.warning("directory: pubkey fetch failed enterprise=%s err=%s", enterprise_id, e)
+        return None
+    if r.status_code != 200:
+        log.warning(
+            "directory: pubkey fetch unexpected status=%d enterprise=%s",
+            r.status_code,
+            enterprise_id,
+        )
+        return None
+    pubkey = r.json().get("root_pubkey", "")
+    if not pubkey:
+        return None
+    _cache[enterprise_id] = pubkey
+    return pubkey
+
+
+def _verify_peering_record(
+    record: dict[str, Any],
+    initiator_pubkey: str,
+    responder_pubkey: str,
+) -> bool:
+    """Verify both signatures (offer + accept) on a peering record."""
+    offer_ok = verify_envelope_signature(
+        initiator_pubkey,
+        record["offer_payload_canonical"],
+        record["offer_signature"],
+    )
+    accept_ok = verify_envelope_signature(
+        responder_pubkey,
+        record["accept_payload_canonical"],
+        record["accept_signature"],
+    )
+    return offer_ok and accept_ok
+
+
+async def _post_peerings_pull(
+    client: httpx.AsyncClient,
+    privkey: Ed25519PrivateKey,
+    enterprise_id: str,
+) -> list[dict[str, Any]] | None:
+    """Pull /peerings/{enterprise_id}. Server requires a signed identity proof.
+
+    Per directory-v1 spec, the proof is a signed envelope over a small
+    payload {enterprise_id, ts}. The server verifies the signature
+    against the enterprise's registered root key.
+    """
+    proof = {"enterprise_id": enterprise_id, "ts": now_iso()}
+    envelope = sign_envelope(privkey, proof)
+    url = f"{directory_url()}/api/v1/directory/peerings/{enterprise_id}"
+    try:
+        r = await client.request(
+            "GET",
+            url,
+            json=envelope,
+            timeout=15.0,
+        )
+    except httpx.RequestError as e:
+        log.warning("directory: peerings pull failed enterprise=%s err=%s", enterprise_id, e)
+        return None
+    if r.status_code != 200:
+        log.warning(
+            "directory: peerings pull unexpected status=%d enterprise=%s",
+            r.status_code,
+            enterprise_id,
+        )
+        return None
+    return r.json().get("peerings", [])
+
+
+async def _pull_and_persist_once(
+    privkey: Ed25519PrivateKey,
+    enterprise_id: str,
+    store: RemoteStore,
+) -> int:
+    """One pull cycle. Returns number of peerings persisted."""
+    pubkey_cache: dict[str, str] = {}
+    persisted = 0
+    async with httpx.AsyncClient() as client:
+        records = await _post_peerings_pull(client, privkey, enterprise_id)
+        if records is None:
+            return 0
+
+        for rec in records:
+            initiator_pubkey = await _fetch_enterprise_pubkey(
+                client, rec["from_enterprise"], pubkey_cache
+            )
+            responder_pubkey = await _fetch_enterprise_pubkey(
+                client, rec["to_enterprise"], pubkey_cache
+            )
+            if initiator_pubkey is None or responder_pubkey is None:
+                log.warning(
+                    "directory: missing pubkey from=%s to=%s offer=%s — skipping",
+                    rec["from_enterprise"],
+                    rec["to_enterprise"],
+                    rec.get("offer_id"),
+                )
+                continue
+            if not _verify_peering_record(rec, initiator_pubkey, responder_pubkey):
+                log.warning(
+                    "directory: peering signature INVALID offer=%s — skipping",
+                    rec.get("offer_id"),
+                )
+                continue
+
+            store.upsert_directory_peering(
+                offer_id=rec["offer_id"],
+                from_enterprise=rec["from_enterprise"],
+                to_enterprise=rec["to_enterprise"],
+                status=rec["status"],
+                content_policy=rec["content_policy"],
+                consult_logging_policy=rec["consult_logging_policy"],
+                topic_filters_json=json.dumps(rec.get("topic_filters") or []),
+                active_from=rec.get("active_from"),
+                expires_at=rec["expires_at"],
+                offer_payload_canonical=rec["offer_payload_canonical"],
+                offer_signature_b64u=rec["offer_signature"],
+                offer_signing_key_id=rec["offer_signing_key_id"],
+                accept_payload_canonical=rec["accept_payload_canonical"],
+                accept_signature_b64u=rec["accept_signature"],
+                accept_signing_key_id=rec["accept_signing_key_id"],
+                last_synced_at=now_iso(),
+            )
+            persisted += 1
+    return persisted
+
+
+async def _pull_loop(privkey: Ed25519PrivateKey, enterprise_id: str, store: RemoteStore) -> None:
+    """Long-running peering pull cron."""
+    interval = pull_interval_sec()
+    log.info("directory: pull loop started enterprise=%s interval=%ds", enterprise_id, interval)
+    while True:
+        try:
+            n = await _pull_and_persist_once(privkey, enterprise_id, store)
+            log.info("directory: pull cycle ok persisted=%d", n)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            log.exception("directory: pull cycle exploded err=%s", e)
+        try:
+            await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            raise
+
+
+# ---------------------------------------------------------------------------
+# Lifespan integration
+# ---------------------------------------------------------------------------
+
+
+def _load_endpoints_config() -> list[dict[str, Any]]:
+    """Build the l2_endpoints list from env. V1 advertises just this L2.
+
+    A multi-L2 enterprise running the announce flow from its admin
+    workstation will assemble the full roster and announce it from
+    there; for cq-server-driven announces we just declare ourselves.
+    """
+    self_url = os.environ.get("CQ_AIGRP_SELF_URL", "")
+    enterprise = os.environ.get("CQ_ENTERPRISE", "")
+    group = os.environ.get("CQ_GROUP", "")
+    if not (self_url and enterprise and group):
+        return []
+    return [
+        {
+            "l2_id": f"{enterprise}/{group}",
+            "endpoint_url": self_url,
+            "groups": [group],
+        }
+    ]
+
+
+async def directory_bootstrap_and_loop(store: RemoteStore) -> None:
+    """Top-level lifespan task: announce, then start the pull loop.
+
+    Skipped entirely when ``CQ_DIRECTORY_ENABLED`` is unset/false (the
+    rollout default — directory is opt-in per L2 until the public
+    instance is deployed).
+    """
+    if not directory_enabled():
+        log.info("directory: disabled (CQ_DIRECTORY_ENABLED!=true) — skipping bootstrap")
+        return
+
+    privkey_path = os.environ.get("CQ_ENTERPRISE_ROOT_PRIVKEY_PATH", "")
+    if not privkey_path:
+        log.error("directory: enabled but CQ_ENTERPRISE_ROOT_PRIVKEY_PATH unset — skipping")
+        return
+    enterprise_id = os.environ.get("CQ_ENTERPRISE", "")
+    if not enterprise_id:
+        log.error("directory: enabled but CQ_ENTERPRISE unset — skipping")
+        return
+    contact_email = os.environ.get("CQ_DIRECTORY_CONTACT_EMAIL", "")
+    if not contact_email:
+        log.error("directory: enabled but CQ_DIRECTORY_CONTACT_EMAIL unset — skipping")
+        return
+
+    try:
+        privkey = load_private_key(Path(privkey_path))
+    except (FileNotFoundError, ValueError) as e:
+        log.error("directory: cannot load privkey path=%s err=%s — skipping", privkey_path, e)
+        return
+
+    display_name = os.environ.get("CQ_DIRECTORY_DISPLAY_NAME", enterprise_id)
+    visibility = os.environ.get("CQ_DIRECTORY_VISIBILITY", "public")
+    topics_csv = os.environ.get("CQ_DIRECTORY_TOPICS", "")
+    discoverable_topics = [t.strip() for t in topics_csv.split(",") if t.strip()]
+    l2_endpoints = _load_endpoints_config()
+    if not l2_endpoints:
+        log.error(
+            "directory: cannot build l2_endpoints (CQ_AIGRP_SELF_URL/CQ_ENTERPRISE/CQ_GROUP) — skipping",
+        )
+        return
+
+    ok = await _announce_with_retries(
+        privkey,
+        enterprise_id,
+        display_name,
+        visibility,
+        contact_email,
+        l2_endpoints,
+        discoverable_topics,
+    )
+    if not ok:
+        log.error("directory: announce never succeeded after retries — pull loop not started")
+        return
+
+    # Pull loop runs forever until cancelled by lifespan teardown.
+    await _pull_loop(privkey, enterprise_id, store)

--- a/server/backend/src/cq_server/store/__init__.py
+++ b/server/backend/src/cq_server/store/__init__.py
@@ -21,6 +21,7 @@ from ..tables import (
     DEFAULT_ENTERPRISE_ID,
     DEFAULT_GROUP_ID,
     ensure_aigrp_peers_table,
+    ensure_directory_peerings_schema,
     ensure_api_keys_table,
     ensure_consults_schema,
     ensure_embedding_columns,
@@ -106,6 +107,8 @@ class RemoteStore:
         # Sprint 2 (issue #20) — L3 consult tables. Same idempotent
         # shape; safe to call on every startup.
         ensure_consults_schema(self._conn)
+        # Sprint 3 — directory peering mirror. Idempotent.
+        ensure_directory_peerings_schema(self._conn)
         # Phase 6 step 1 — additive tenancy columns. Idempotent; safe to
         # run on every startup. Backfills legacy rows so the columns can
         # be queried without NULL handling once enforcement lands.
@@ -997,6 +1000,102 @@ class RemoteStore:
                 )
         except sqlite3.Error:
             _logger.exception("Failed to update last_used_at for api key %s", key_id)
+
+    # -- Directory peerings (sprint 3) -----------------------------------
+
+    def upsert_directory_peering(
+        self,
+        *,
+        offer_id: str,
+        from_enterprise: str,
+        to_enterprise: str,
+        status: str,
+        content_policy: str,
+        consult_logging_policy: str,
+        topic_filters_json: str,
+        active_from: str | None,
+        expires_at: str,
+        offer_payload_canonical: str,
+        offer_signature_b64u: str,
+        offer_signing_key_id: str,
+        accept_payload_canonical: str,
+        accept_signature_b64u: str,
+        accept_signing_key_id: str,
+        last_synced_at: str,
+    ) -> None:
+        """Mirror one verified peering record from the directory pull loop.
+
+        Both signatures (offer + accept) are persisted alongside the
+        canonical payloads so any later code can re-verify offline
+        without going back to the directory.
+        """
+        self._check_open()
+        with self._lock, self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO aigrp_directory_peerings (
+                    offer_id, from_enterprise, to_enterprise, status,
+                    content_policy, consult_logging_policy, topic_filters_json,
+                    active_from, expires_at,
+                    offer_payload_canonical, offer_signature_b64u, offer_signing_key_id,
+                    accept_payload_canonical, accept_signature_b64u, accept_signing_key_id,
+                    last_synced_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(offer_id) DO UPDATE SET
+                    status = excluded.status,
+                    content_policy = excluded.content_policy,
+                    consult_logging_policy = excluded.consult_logging_policy,
+                    topic_filters_json = excluded.topic_filters_json,
+                    active_from = excluded.active_from,
+                    expires_at = excluded.expires_at,
+                    offer_payload_canonical = excluded.offer_payload_canonical,
+                    offer_signature_b64u = excluded.offer_signature_b64u,
+                    offer_signing_key_id = excluded.offer_signing_key_id,
+                    accept_payload_canonical = excluded.accept_payload_canonical,
+                    accept_signature_b64u = excluded.accept_signature_b64u,
+                    accept_signing_key_id = excluded.accept_signing_key_id,
+                    last_synced_at = excluded.last_synced_at
+                """,
+                (
+                    offer_id, from_enterprise, to_enterprise, status,
+                    content_policy, consult_logging_policy, topic_filters_json,
+                    active_from, expires_at,
+                    offer_payload_canonical, offer_signature_b64u, offer_signing_key_id,
+                    accept_payload_canonical, accept_signature_b64u, accept_signing_key_id,
+                    last_synced_at,
+                ),
+            )
+
+    def list_directory_peerings(
+        self,
+        *,
+        enterprise_id: str | None = None,
+        status: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return mirrored directory peering rows.
+
+        ``enterprise_id`` matches either side of the peering (from or to);
+        callers that need one-sided filtering can post-filter.
+        """
+        self._check_open()
+        sql = "SELECT * FROM aigrp_directory_peerings"
+        clauses: list[str] = []
+        params: list[Any] = []
+        if enterprise_id is not None:
+            clauses.append("(from_enterprise = ? OR to_enterprise = ?)")
+            params.extend([enterprise_id, enterprise_id])
+        if status is not None:
+            clauses.append("status = ?")
+            params.append(status)
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
+        sql += " ORDER BY active_from DESC NULLS LAST, last_synced_at DESC"
+        with self._lock:
+            rows = self._conn.execute(sql, params).fetchall()
+            cols = [c[0] for c in self._conn.execute(
+                "SELECT * FROM aigrp_directory_peerings LIMIT 0"
+            ).description]
+        return [dict(zip(cols, row, strict=True)) for row in rows]
 
     # -- AIGRP peer mesh -------------------------------------------------
 

--- a/server/backend/src/cq_server/tables.py
+++ b/server/backend/src/cq_server/tables.py
@@ -221,6 +221,42 @@ def ensure_users_table(conn: sqlite3.Connection) -> None:
     conn.executescript(USERS_TABLE_SQL)
 
 
+DIRECTORY_PEERINGS_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS aigrp_directory_peerings (
+    offer_id                  TEXT PRIMARY KEY,
+    from_enterprise           TEXT NOT NULL,
+    to_enterprise             TEXT NOT NULL,
+    status                    TEXT NOT NULL,
+    content_policy            TEXT NOT NULL,
+    consult_logging_policy    TEXT NOT NULL,
+    topic_filters_json        TEXT NOT NULL DEFAULT '[]',
+    active_from               TEXT,
+    expires_at                TEXT NOT NULL,
+    offer_payload_canonical   TEXT NOT NULL,
+    offer_signature_b64u      TEXT NOT NULL,
+    offer_signing_key_id      TEXT NOT NULL,
+    accept_payload_canonical  TEXT NOT NULL,
+    accept_signature_b64u     TEXT NOT NULL,
+    accept_signing_key_id     TEXT NOT NULL,
+    last_synced_at            TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_directory_peerings_from
+    ON aigrp_directory_peerings(from_enterprise, status);
+CREATE INDEX IF NOT EXISTS idx_directory_peerings_to
+    ON aigrp_directory_peerings(to_enterprise, status);
+"""
+
+
+def ensure_directory_peerings_schema(conn: sqlite3.Connection) -> None:
+    """Create aigrp_directory_peerings table.
+
+    Sprint 3 — local mirror of peering records pulled from the public
+    8th-Layer Directory. Each row carries BOTH signed envelopes (offer
+    + accept) so any local consumer can re-verify offline. Idempotent.
+    """
+    conn.executescript(DIRECTORY_PEERINGS_TABLE_SQL)
+
+
 def ensure_consults_schema(conn: sqlite3.Connection) -> None:
     """Create the L3 consult tables if they do not exist.
 

--- a/server/backend/tests/test_directory_client.py
+++ b/server/backend/tests/test_directory_client.py
@@ -1,0 +1,517 @@
+"""Tests for the L2-side 8th-Layer Directory client (sprint 3).
+
+Covers:
+  - crypto helpers (sign / verify / JCS roundtrip)
+  - feature-flag default-off behaviour
+  - announce flow (201 first, 200 update; 4xx permanent failure)
+  - peerings pull + signature verification + persistence
+  - bad-sig records are NOT persisted
+  - store schema for aigrp_directory_peerings exists and accepts upsert
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import rfc8785
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from fastapi.testclient import TestClient
+
+from cq_server import directory_client as dc
+from cq_server.app import _get_store, app
+
+
+@pytest.fixture()
+def keypair() -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.generate()
+
+
+@pytest.fixture()
+def keypair_b() -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.generate()
+
+
+@pytest.fixture()
+def privkey_path(tmp_path: Path, keypair: Ed25519PrivateKey) -> Path:
+    p = tmp_path / "ed25519.key"
+    p.write_bytes(keypair.private_bytes_raw())
+    return p
+
+
+@pytest.fixture()
+def app_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    """A FastAPI TestClient solely so the store schema is initialised.
+
+    We don't exercise HTTP endpoints in this file — we just need the
+    aigrp_directory_peerings table to exist for the persistence tests.
+    """
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "cli.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    monkeypatch.setenv("CQ_DIRECTORY_ENABLED", "false")  # keep loop dormant
+    with TestClient(app) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# Crypto helpers
+# ---------------------------------------------------------------------------
+
+
+class TestCryptoHelpers:
+    def test_sign_and_verify_roundtrip(self, keypair: Ed25519PrivateKey) -> None:
+        payload = {"hello": "world", "n": 7}
+        envelope = dc.sign_envelope(keypair, payload)
+
+        assert envelope["payload"] == payload
+        assert envelope["signing_key_id"] == dc.public_key_b64u(keypair)
+
+        # Canonical bytes must round-trip via rfc8785.
+        assert envelope["payload_canonical"].encode() == rfc8785.dumps(payload)
+
+        ok = dc.verify_envelope_signature(
+            envelope["signing_key_id"],
+            envelope["payload_canonical"],
+            envelope["signature"],
+        )
+        assert ok is True
+
+    def test_verify_rejects_tampered_payload(self, keypair: Ed25519PrivateKey) -> None:
+        envelope = dc.sign_envelope(keypair, {"a": 1})
+        # Flip a byte in the canonical payload — sig over the original
+        # payload should no longer verify.
+        tampered = envelope["payload_canonical"].replace('"a":1', '"a":2')
+        ok = dc.verify_envelope_signature(
+            envelope["signing_key_id"], tampered, envelope["signature"]
+        )
+        assert ok is False
+
+    def test_verify_rejects_wrong_key(
+        self, keypair: Ed25519PrivateKey, keypair_b: Ed25519PrivateKey
+    ) -> None:
+        envelope = dc.sign_envelope(keypair, {"a": 1})
+        ok = dc.verify_envelope_signature(
+            dc.public_key_b64u(keypair_b),
+            envelope["payload_canonical"],
+            envelope["signature"],
+        )
+        assert ok is False
+
+    def test_load_private_key_roundtrip(
+        self, tmp_path: Path, keypair: Ed25519PrivateKey
+    ) -> None:
+        p = tmp_path / "k.key"
+        p.write_bytes(keypair.private_bytes_raw())
+        loaded = dc.load_private_key(p)
+        assert dc.public_key_b64u(loaded) == dc.public_key_b64u(keypair)
+
+    def test_load_private_key_rejects_wrong_size(self, tmp_path: Path) -> None:
+        p = tmp_path / "bad.key"
+        p.write_bytes(b"x" * 31)
+        with pytest.raises(ValueError, match="32 raw bytes"):
+            dc.load_private_key(p)
+
+
+# ---------------------------------------------------------------------------
+# Feature flag
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureFlag:
+    @pytest.mark.asyncio
+    async def test_disabled_skips_bootstrap(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("CQ_DIRECTORY_ENABLED", "false")
+        called: list[str] = []
+        monkeypatch.setattr(
+            dc, "_announce_with_retries", lambda *a, **kw: called.append("announce")
+        )
+        # Should return immediately without any side effects.
+        from cq_server.store import RemoteStore
+
+        store = RemoteStore(db_path=tmp_path / "x.db")
+        await dc.directory_bootstrap_and_loop(store)
+        assert called == []
+        store.close()
+
+    @pytest.mark.asyncio
+    async def test_enabled_but_unconfigured_skips(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # Enabled but no privkey path → graceful skip, not crash.
+        monkeypatch.setenv("CQ_DIRECTORY_ENABLED", "true")
+        monkeypatch.delenv("CQ_ENTERPRISE_ROOT_PRIVKEY_PATH", raising=False)
+        from cq_server.store import RemoteStore
+
+        store = RemoteStore(db_path=tmp_path / "y.db")
+        await dc.directory_bootstrap_and_loop(store)  # should not raise
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# Announce flow (mocked httpx)
+# ---------------------------------------------------------------------------
+
+
+class TestAnnounce:
+    @pytest.mark.asyncio
+    async def test_announce_201_first_time(
+        self, monkeypatch: pytest.MonkeyPatch, keypair: Ed25519PrivateKey
+    ) -> None:
+        captured: dict[str, Any] = {}
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured["url"] = str(request.url)
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(
+                201,
+                json={
+                    "enterprise_id": "acme",
+                    "directory_record_id": "rec_test",
+                    "registered_at": "2026-05-01T20:00:00Z",
+                    "verifying_key_fingerprint": "sha256:deadbeef",
+                },
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            status, body = await dc._post_announce(
+                client,
+                keypair,
+                enterprise_id="acme",
+                display_name="Acme Industries",
+                visibility="public",
+                contact_email="admin@acme.example",
+                l2_endpoints=[
+                    {
+                        "l2_id": "acme/engineering",
+                        "endpoint_url": "https://eng.acme.example",
+                        "groups": ["engineering"],
+                    }
+                ],
+                discoverable_topics=["cloudfront"],
+            )
+        assert status == 201
+        assert body is not None
+        assert body["enterprise_id"] == "acme"
+        # Body sent to directory must be the full signed envelope shape.
+        env = captured["body"]
+        assert env["payload"]["enterprise_id"] == "acme"
+        assert env["signing_key_id"] == dc.public_key_b64u(keypair)
+        # Signature must verify against the canonical bytes.
+        assert dc.verify_envelope_signature(
+            env["signing_key_id"], env["payload_canonical"], env["signature"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_announce_200_on_update(self, keypair: Ed25519PrivateKey) -> None:
+        async def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "enterprise_id": "acme",
+                    "directory_record_id": "rec_existing",
+                    "registered_at": "2026-04-01T00:00:00Z",
+                    "verifying_key_fingerprint": "sha256:deadbeef",
+                },
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            status, body = await dc._post_announce(
+                client,
+                keypair,
+                enterprise_id="acme",
+                display_name="Acme",
+                visibility="public",
+                contact_email="a@b.c",
+                l2_endpoints=[
+                    {"l2_id": "acme/eng", "endpoint_url": "https://x", "groups": ["eng"]}
+                ],
+                discoverable_topics=[],
+            )
+        assert status == 200
+        assert body is not None
+
+    @pytest.mark.asyncio
+    async def test_announce_4xx_permanent_no_retry(
+        self, monkeypatch: pytest.MonkeyPatch, keypair: Ed25519PrivateKey
+    ) -> None:
+        # _announce_with_retries should give up on 400/409/422 (permanent
+        # rejection — retrying won't help).
+        attempts = 0
+
+        async def handler(_request: httpx.Request) -> httpx.Response:
+            nonlocal attempts
+            attempts += 1
+            return httpx.Response(409, json={"detail": "id taken with different key"})
+
+        # Stub httpx.AsyncClient.post to use mock transport.
+        original_async_client = httpx.AsyncClient
+
+        def patched_async_client(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+            kwargs["transport"] = httpx.MockTransport(handler)
+            return original_async_client(*args, **kwargs)
+
+        monkeypatch.setattr(dc.httpx, "AsyncClient", patched_async_client)
+
+        ok = await dc._announce_with_retries(
+            keypair,
+            enterprise_id="acme",
+            display_name="Acme",
+            visibility="public",
+            contact_email="a@b.c",
+            l2_endpoints=[{"l2_id": "x/y", "endpoint_url": "https://x", "groups": ["y"]}],
+            discoverable_topics=[],
+            max_attempts=3,
+        )
+        assert ok is False
+        assert attempts == 1, "permanent 4xx must not retry"
+
+
+# ---------------------------------------------------------------------------
+# Pull + verify + persist
+# ---------------------------------------------------------------------------
+
+
+def _make_peering_record(
+    initiator: Ed25519PrivateKey,
+    responder: Ed25519PrivateKey,
+    *,
+    offer_id: str = "off_test",
+    from_enterprise: str = "acme",
+    to_enterprise: str = "rival",
+) -> dict[str, Any]:
+    """Build a fully-signed bilateral peering record. Real signatures."""
+    offer_payload = {
+        "offer_id": offer_id,
+        "from_enterprise": from_enterprise,
+        "to_enterprise": to_enterprise,
+        "content_policy": "summary_only",
+        "consult_logging_policy": "mutual_log_required",
+        "topic_filters": ["cloudfront"],
+        "expires_at": "2026-12-31T23:59:59Z",
+        "offer_ts": "2026-05-01T20:30:00Z",
+    }
+    offer_envelope = dc.sign_envelope(initiator, offer_payload)
+    accept_payload = {
+        "offer_id": offer_id,
+        "accepted_offer_payload_canonical": offer_envelope["payload_canonical"],
+        "accept_ts": "2026-05-01T20:45:00Z",
+    }
+    accept_envelope = dc.sign_envelope(responder, accept_payload)
+
+    return {
+        "offer_id": offer_id,
+        "status": "active",
+        "from_enterprise": from_enterprise,
+        "to_enterprise": to_enterprise,
+        "content_policy": "summary_only",
+        "consult_logging_policy": "mutual_log_required",
+        "topic_filters": ["cloudfront"],
+        "active_from": accept_payload["accept_ts"],
+        "expires_at": offer_payload["expires_at"],
+        "offer_payload_canonical": offer_envelope["payload_canonical"],
+        "offer_signature": offer_envelope["signature"],
+        "offer_signing_key_id": offer_envelope["signing_key_id"],
+        "accept_payload_canonical": accept_envelope["payload_canonical"],
+        "accept_signature": accept_envelope["signature"],
+        "accept_signing_key_id": accept_envelope["signing_key_id"],
+    }
+
+
+class TestPullAndPersist:
+    @pytest.mark.asyncio
+    async def test_pull_persists_verified_records(
+        self,
+        app_client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+        keypair: Ed25519PrivateKey,
+        keypair_b: Ed25519PrivateKey,
+    ) -> None:
+        store = _get_store()
+        record = _make_peering_record(keypair, keypair_b)
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/peerings/acme"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "enterprise_id": "acme",
+                        "as_of": "2026-05-01T21:00:00Z",
+                        "peerings": [record],
+                    },
+                )
+            if path.endswith("/enterprises/acme/key"):
+                return httpx.Response(
+                    200, json={"root_pubkey": dc.public_key_b64u(keypair)}
+                )
+            if path.endswith("/enterprises/rival/key"):
+                return httpx.Response(
+                    200, json={"root_pubkey": dc.public_key_b64u(keypair_b)}
+                )
+            return httpx.Response(404)
+
+        original_async_client = httpx.AsyncClient
+
+        def patched(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+            kwargs["transport"] = httpx.MockTransport(handler)
+            return original_async_client(*args, **kwargs)
+
+        monkeypatch.setattr(dc.httpx, "AsyncClient", patched)
+
+        n = await dc._pull_and_persist_once(keypair, "acme", store)
+        assert n == 1
+
+        rows = store.list_directory_peerings(enterprise_id="acme")
+        assert len(rows) == 1
+        assert rows[0]["offer_id"] == "off_test"
+        assert rows[0]["from_enterprise"] == "acme"
+        assert rows[0]["to_enterprise"] == "rival"
+        assert rows[0]["status"] == "active"
+        assert json.loads(rows[0]["topic_filters_json"]) == ["cloudfront"]
+
+    @pytest.mark.asyncio
+    async def test_pull_drops_record_with_bad_signature(
+        self,
+        app_client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+        keypair: Ed25519PrivateKey,
+        keypair_b: Ed25519PrivateKey,
+    ) -> None:
+        store = _get_store()
+        record = _make_peering_record(keypair, keypair_b, offer_id="off_bad")
+        # Tamper: replace the offer signature with a junk value.
+        record["offer_signature"] = "AA" * 32
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/peerings/acme"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "enterprise_id": "acme",
+                        "as_of": "2026-05-01T21:00:00Z",
+                        "peerings": [record],
+                    },
+                )
+            if path.endswith("/enterprises/acme/key"):
+                return httpx.Response(
+                    200, json={"root_pubkey": dc.public_key_b64u(keypair)}
+                )
+            if path.endswith("/enterprises/rival/key"):
+                return httpx.Response(
+                    200, json={"root_pubkey": dc.public_key_b64u(keypair_b)}
+                )
+            return httpx.Response(404)
+
+        original_async_client = httpx.AsyncClient
+
+        def patched(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+            kwargs["transport"] = httpx.MockTransport(handler)
+            return original_async_client(*args, **kwargs)
+
+        monkeypatch.setattr(dc.httpx, "AsyncClient", patched)
+
+        n = await dc._pull_and_persist_once(keypair, "acme", store)
+        assert n == 0  # bad sig rejected
+        rows = store.list_directory_peerings(enterprise_id="acme")
+        assert all(r["offer_id"] != "off_bad" for r in rows)
+
+    @pytest.mark.asyncio
+    async def test_pull_drops_record_when_pubkey_unavailable(
+        self,
+        app_client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+        keypair: Ed25519PrivateKey,
+        keypair_b: Ed25519PrivateKey,
+    ) -> None:
+        store = _get_store()
+        record = _make_peering_record(keypair, keypair_b, offer_id="off_nokey")
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if path.endswith("/peerings/acme"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "enterprise_id": "acme",
+                        "as_of": "2026-05-01T21:00:00Z",
+                        "peerings": [record],
+                    },
+                )
+            if "/enterprises/" in path and path.endswith("/key"):
+                return httpx.Response(404)  # neither side resolvable
+            return httpx.Response(404)
+
+        original_async_client = httpx.AsyncClient
+
+        def patched(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+            kwargs["transport"] = httpx.MockTransport(handler)
+            return original_async_client(*args, **kwargs)
+
+        monkeypatch.setattr(dc.httpx, "AsyncClient", patched)
+
+        n = await dc._pull_and_persist_once(keypair, "acme", store)
+        assert n == 0
+
+
+# ---------------------------------------------------------------------------
+# Store schema
+# ---------------------------------------------------------------------------
+
+
+class TestSchema:
+    def test_directory_peerings_table_exists_and_upserts(
+        self, app_client: TestClient
+    ) -> None:
+        store = _get_store()
+        store.upsert_directory_peering(
+            offer_id="off_schema",
+            from_enterprise="a",
+            to_enterprise="b",
+            status="active",
+            content_policy="summary_only",
+            consult_logging_policy="mutual_log_required",
+            topic_filters_json="[]",
+            active_from="2026-05-01T00:00:00Z",
+            expires_at="2026-12-31T00:00:00Z",
+            offer_payload_canonical='{"x":1}',
+            offer_signature_b64u="AA",
+            offer_signing_key_id="K",
+            accept_payload_canonical='{"y":2}',
+            accept_signature_b64u="BB",
+            accept_signing_key_id="J",
+            last_synced_at="2026-05-01T21:00:00Z",
+        )
+        rows = store.list_directory_peerings()
+        assert len(rows) == 1
+        assert rows[0]["offer_id"] == "off_schema"
+
+        # Re-upsert with new status — same row, updated.
+        store.upsert_directory_peering(
+            offer_id="off_schema",
+            from_enterprise="a",
+            to_enterprise="b",
+            status="expired",
+            content_policy="summary_only",
+            consult_logging_policy="mutual_log_required",
+            topic_filters_json="[]",
+            active_from="2026-05-01T00:00:00Z",
+            expires_at="2026-12-31T00:00:00Z",
+            offer_payload_canonical='{"x":1}',
+            offer_signature_b64u="AA",
+            offer_signing_key_id="K",
+            accept_payload_canonical='{"y":2}',
+            accept_signature_b64u="BB",
+            accept_signing_key_id="J",
+            last_synced_at="2026-05-02T00:00:00Z",
+        )
+        rows = store.list_directory_peerings()
+        assert len(rows) == 1
+        assert rows[0]["status"] == "expired"


### PR DESCRIPTION
Wires cq-server to OneZero1ai/8th-layer-directory. Announce-on-startup + 1h peerings pull + Ed25519 signature verification + write-through to new aigrp_directory_peerings table. Feature-flagged (CQ_DIRECTORY_ENABLED, default false) — safe to merge before the public directory is deployed; existing fleet stays no-op until flipped per-cluster. 380 tests passing (+14 new). Refs decision 11, spec directory-v1.