### PR TITLE
[license] NOTICE + MODIFICATIONS.md (Apache-2.0 §4(b))

### DIFF
--- a/MODIFICATIONS.md
+++ b/MODIFICATIONS.md
@@ -1,0 +1,83 @@
+# Modifications from upstream `mozilla-ai/cq`
+
+This file states the modifications made by OneZero1.ai to the upstream
+[`mozilla-ai/cq`](https://github.com/mozilla-ai/cq) codebase, in fulfillment
+of [Apache License, Version 2.0](LICENSE) §4(b).
+
+For project-level rationale and the upstream-vs-fork delta narrative, see
+[`FORK_DELTA.md`](FORK_DELTA.md). For per-PR detail, see this repository's
+[git log](https://github.com/OneZero1ai/8th-layer-agent/commits/main).
+
+## Fork base
+
+- Forked from `mozilla-ai/cq` on **2026-04-26**.
+- The exact upstream commit pinned at fork creation is recorded in
+  [`FORK_DELTA.md`](FORK_DELTA.md).
+
+## Apache-2.0 §4(b) compliance posture
+
+Apache-2.0 §4(b) requires that "any modified files" carry "prominent notices
+stating that You changed the files." This document is the prominent notice
+covering all modified files in this repository. We do not maintain per-file
+modification headers; this manifest is exhaustive and is updated whenever a
+file's status changes.
+
+## New files (entirely OneZero1.ai)
+
+These files do not exist in upstream `mozilla-ai/cq` and are wholly authored
+by OneZero1.ai:
+
+| File | Purpose |
+|---|---|
+| `server/backend/src/cq_server/aigrp.py` | AIGRP (Agent Intelligence Graph Routing Protocol) — intra-Enterprise peer-mesh routing |
+| `server/backend/src/cq_server/network.py` | DSN (Distributed Semantic Network) intent resolution + topology |
+| `server/backend/src/cq_server/consults.py` | L3 live consults — same-L2 + cross-L2 routing |
+| `server/backend/src/cq_server/directory_client.py` | Sprint 3 client for the public 8th-Layer Directory |
+| `server/backend/src/cq_server/quality.py` | Propose-quality guards (candidate to upstream) |
+| `server/backend/src/cq_server/embed.py` | Bedrock Titan v2 embeddings (8th-Layer-specific embedding setup) |
+| `server/backend/src/cq_server/tables.py` | Multi-tenant + AIGRP schema additions |
+| `server/backend/tests/test_aigrp_*.py` | AIGRP test suites |
+| `server/backend/tests/test_network_*.py` | DSN test suites |
+| `server/backend/tests/test_consults.py`, `test_cross_l2_routing.py`, `test_forward_query.py` | Consults + forward-query tests |
+| `server/backend/tests/test_directory_client.py` | Directory client tests |
+| `server/local-demo/**` | Local Docker mesh demo |
+| `FORK_DELTA.md`, `MODIFICATIONS.md`, `NOTICE` | This fork's documentation |
+
+## Modified files (additions on top of upstream)
+
+These files exist in upstream `mozilla-ai/cq` and have been modified by
+OneZero1.ai. The git diff against the fork-base commit is the authoritative
+record of changes.
+
+| File | Nature of modification |
+|---|---|
+| `server/backend/src/cq_server/app.py` | Multi-tenant scope params on `/query`, `/review/*`, `/stats`; AIGRP forward-query handler; directory-client lifespan task; security fixes (CRIT #32/#33/#34, HIGH #35/#37/#39) |
+| `server/backend/src/cq_server/store/__init__.py` | Tenant scoping on existing CRUD methods; new methods for AIGRP peers, consults, directory peerings, cross-L2 audit |
+| `server/backend/src/cq_server/auth.py` | Admin role; tenant scope resolution from user row |
+| `server/backend/src/cq_server/review.py` | Admin gate (`require_admin`) on every route; tenant scoping on aggregate methods |
+| `server/backend/src/cq_server/deps.py` | Tenant scope helpers |
+| `server/backend/tests/test_app.py`, `test_review.py`, `test_admin_delete.py` | Tests adapted for the multi-tenant surface |
+| `server/backend/pyproject.toml` | Added `cryptography`, `rfc8785`, `httpx` for the directory client |
+| `server/scripts/seed-users.py`, `server/local-demo/bin/seed-admin.sh` | Set `role='admin'` (post-CRIT #32) |
+| `plugins/cq/.claude-plugin/plugin.json` | Renamed plugin to `8l-cq`; OneZero1.ai authorship; updated description, repository, keywords |
+| `README.md` | Prepended 8th-Layer.ai fork-disclosure header (upstream cq README preserved verbatim below the separator) |
+
+## Files unchanged from upstream (the open standard)
+
+These are the open-protocol portions we explicitly preserve unchanged:
+
+- `LICENSE` (Apache-2.0, verbatim)
+- `schema/knowledge-unit.schema.json` (the open KU schema)
+- The MCP server name `cq` inside the renamed `8l-cq` plugin (kept for protocol compatibility — agent code calling `mcp__cq__*` continues to work)
+- DID/KERI identity model
+- Tier model semantics (Local / Remote / Global Commons)
+- SDK APIs (`sdk/`)
+- Cq's MCP tool surface (`propose`, `query`, `confirm`, `flag`, `reflect`, `status`, `health`)
+
+## Source-of-truth references
+
+- **Upstream**: https://github.com/mozilla-ai/cq
+- **Fork**: https://github.com/OneZero1ai/8th-layer-agent
+- **Project decisions**: https://github.com/OneZero1ai/crosstalk-enterprise/tree/main/docs/decisions
+- **Per-PR change history**: this repository's git log
+- **Trademark posture**: see [`NOTICE`](NOTICE) — Apache-2.0 §6 acknowledged; references to "cq" / "Mozilla.ai" are factual attribution only

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,37 @@
+8th-Layer.ai Agent (8l-cq plugin)
+Copyright (c) 2026 OneZero1.ai
+
+Licensed under the Apache License, Version 2.0 (the "License"); see the
+LICENSE file at the root of this repository for the full text. You may
+obtain a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+================================================================================
+
+This product is a fork of:
+
+    cq — https://github.com/mozilla-ai/cq
+    Copyright (c) Mozilla AI
+    Licensed under the Apache License, Version 2.0
+
+This fork was created on 2026-04-26. The exact upstream commit pinned at
+fork creation is recorded in FORK_DELTA.md. Modifications by OneZero1.ai
+relative to upstream cq are catalogued in MODIFICATIONS.md, in fulfillment
+of Apache License, Version 2.0 §4(b).
+
+This product retains the open standard portions of upstream cq unchanged
+(Knowledge Unit schema at schema/knowledge-unit.schema.json, REST contract,
+DID/KERI identity model, tier model, SDK APIs, MCP tool surface).
+
+The Apache License, Version 2.0 §6 explicitly does not grant trademark
+rights. Where this product references "cq", "Mozilla AI", or "Mozilla.ai",
+references are factual attribution only — they are not claims of
+endorsement, sponsorship, or affiliation. The Claude Code plugin shipped
+by this product is named "8l-cq" to distinguish it from upstream cq.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ The fork adopts upstream cq's open standard (Knowledge Unit schema, REST contrac
 | Design + decisions | `OneZero1ai/8th-layer` (private) | Architecture decisions, specs, marketing site, AWS deploy templates |
 | Plugin marketplace | [`OneZero1ai/8th-layer-marketplace`](https://github.com/OneZero1ai/8th-layer-marketplace) | Claude Code plugin catalog for the 8th-Layer enterprise connector |
 
-**See:** [`FORK_DELTA.md`](FORK_DELTA.md) for the complete upstream-vs-fork delta — what we add, what we keep unchanged, and our upstream-sync discipline.
+**See:**
+- [`FORK_DELTA.md`](FORK_DELTA.md) — upstream-vs-fork delta (what we add, what we keep unchanged, sync discipline)
+- [`MODIFICATIONS.md`](MODIFICATIONS.md) — Apache-2.0 §4(b) statement of changes; per-file modification catalog
+- [`NOTICE`](NOTICE) — license + attribution
 
 The remainder of this README is upstream cq's documentation, which we adopt as-is. The two are interoperable: a vanilla cq Remote can talk to an 8th-Layer L2, and an 8th-Layer agent can talk to a vanilla cq Remote. The 8th-Layer-specific endpoints (`/aigrp/*`, `/network/dsn/*`, `/consults/*`) are additive.
 


### PR DESCRIPTION
Adds NOTICE crediting upstream mozilla-ai/cq + MODIFICATIONS.md cataloging per-file changes, in fulfillment of Apache-2.0 §4(b). Documents trademark posture (cq → 8l-cq plugin rename, factual attribution only). No code changes. Closes the license-compliance gap surfaced by David's audit question.