### PR TITLE
[sec] Ed25519 per-L2 forward signing · closes #44, full CRIT #34 close

### DIFF
--- a/server/backend/src/cq_server/aigrp.py
+++ b/server/backend/src/cq_server/aigrp.py
@@ -10,11 +10,23 @@ This module owns:
 - Peer-key auth dependency (Bearer EnterprisePeerKey)
 - Signature computation (centroid of approved KU embeddings + Bloom of domains)
 - Peer-table persistence helpers (against the shared SQLite store)
+- Forwarder-identity validation (header binding + sprint-4 Ed25519 sig)
 
 The /aigrp/* HTTP endpoints live in app.py and call into this module.
 
 Cross-Enterprise mesh is intentionally out of scope here; that's the AI-BGP
 protocol (separate spec, future work).
+
+Environment variables consumed here (sprint 4 — see also ``forward_sign``):
+    CQ_AIGRP_PEER_KEY            shared EnterprisePeerKey for /aigrp/* auth.
+    CQ_AIGRP_IS_FIRST_DEPLOY     ``true`` on the genesis L2 of an Enterprise.
+    CQ_AIGRP_SEED_PEER_URL       seed peer the joiner contacts on startup.
+    CQ_AIGRP_SELF_URL            externally reachable URL of this L2.
+    CQ_ENTERPRISE / CQ_GROUP     this L2's identity components.
+    CQ_AIGRP_L2_PRIVKEY_PATH     forward-signing private key on disk
+                                 (default /data/aigrp_l2_key.bin).
+    CQ_REQUIRE_SIGNED_FORWARDS   ``true`` flips strict mode on receivers
+                                 (legacy unsigned forwards are rejected).
 """
 
 from __future__ import annotations
@@ -121,8 +133,14 @@ def require_forwarder_identity(
     claimed_l2_id: str,
     *,
     same_enterprise_only: bool = True,
+    body_for_sig: dict | None = None,
+    store: object | None = None,
 ) -> str:
     """Validate the forwarder's declared identity on a /forward-* endpoint.
+
+    Layers the CRIT #34 partial fix (header/body binding) with the
+    sprint-4 Ed25519 forward signature (#44 — closes the residual
+    sibling-L2 spoof).
 
     Args:
         request: incoming FastAPI request (must contain the forwarder header).
@@ -134,13 +152,23 @@ def require_forwarder_identity(
             consent path), the header still must match the body but the
             forwarder may belong to a peered foreign Enterprise — that
             authorisation comes from cross_enterprise_consents downstream.
+        body_for_sig: parsed request body (canonicalisable dict). When
+            provided alongside ``store``, the receiver verifies the
+            ``X-8L-Forwarder-Sig`` header against the peer's recorded
+            Ed25519 public key. ``None`` skips signature verification —
+            used by legacy callers that haven't been migrated yet.
+        store: ``RemoteStore`` instance for pubkey lookup. Pass alongside
+            ``body_for_sig``. Typed as ``object`` to avoid an import
+            cycle with ``cq_server.store``.
 
     Returns:
         The header-declared forwarder L2 id (post-validation).
 
     Raises:
         HTTPException 400 on missing/empty header.
-        HTTPException 403 on header/body mismatch or cross-Enterprise spoof.
+        HTTPException 403 on header/body mismatch, cross-Enterprise spoof,
+            missing-sig in strict mode, or invalid signature when the
+            peer's pubkey is on file.
     """
     declared = request.headers.get(FORWARDER_HEADER, "").strip()
     if not declared:
@@ -164,6 +192,60 @@ def require_forwarder_identity(
             status_code=403,
             detail=f"cross-Enterprise forward rejected: forwarder={declared!r} receiver_enterprise={enterprise()!r}",
         )
+
+    # Sprint 4 — Ed25519 forward signature (#44).
+    #
+    # When the caller supplies the parsed body and the store, look up
+    # the peer's pubkey. Three cases:
+    #
+    #   1. Pubkey on file + valid sig          → verified signed forward.
+    #   2. Pubkey on file + missing/invalid sig → 403 (sibling-L2 spoof
+    #      attempt or stale peer key — operator must rotate).
+    #   3. No pubkey on file (legacy peer)     → log WARNING and accept
+    #      via header-only auth, UNLESS CQ_REQUIRE_SIGNED_FORWARDS=true
+    #      (strict mode), in which case 403.
+    #
+    # TODO: post-rollout (after one full bootstrap cycle has populated
+    # every peer's pubkey), flip default of CQ_REQUIRE_SIGNED_FORWARDS
+    # to true and deprecate the legacy code path.
+    if body_for_sig is not None and store is not None:
+        from . import forward_sign
+
+        peer_pubkey = None
+        try:
+            peer_pubkey = store.get_aigrp_peer_pubkey(declared)  # type: ignore[attr-defined]
+        except Exception:  # noqa: BLE001
+            # Defensive: a borked store call shouldn't 500 a forward path.
+            logger.exception("forward-sign: pubkey lookup failed for peer=%s", declared)
+        sig_header = request.headers.get(forward_sign.SIGNATURE_HEADER, "").strip()
+        if peer_pubkey:
+            if not sig_header:
+                raise HTTPException(
+                    status_code=403,
+                    detail=f"missing {forward_sign.SIGNATURE_HEADER} header from signed peer {declared!r}",
+                )
+            if not forward_sign.verify_forward_signature(
+                peer_pubkey, body_for_sig, declared, sig_header
+            ):
+                raise HTTPException(
+                    status_code=403,
+                    detail=f"forward signature verification failed for peer={declared!r}",
+                )
+            logger.info("aigrp: verified signed forward from peer=%s", declared)
+        else:
+            if forward_sign.require_signed_forwards():
+                raise HTTPException(
+                    status_code=403,
+                    detail=(
+                        f"strict mode (CQ_REQUIRE_SIGNED_FORWARDS=true) and no pubkey "
+                        f"on file for peer={declared!r}; require re-hello"
+                    ),
+                )
+            logger.warning(
+                "aigrp: legacy unsigned forward from peer=%s (no pubkey on file; "
+                "will become 403 once CQ_REQUIRE_SIGNED_FORWARDS=true)",
+                declared,
+            )
     return declared
 
 

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -89,13 +89,23 @@ async def _aigrp_bootstrap_and_poll(store: RemoteStore) -> None:
     def _try_bootstrap() -> bool:
         """Hit the seed's /aigrp/hello and absorb its peer table.
         Returns True on success. Idempotent on the seed side.
+
+        Sprint 4 (#44) — every hello (initial + every poll cycle re-hello)
+        carries this L2's Ed25519 forward-signing public key so the
+        receiver can populate its ``aigrp_peers.public_key_ed25519`` row.
+        Re-sending on every cycle is intentional self-healing: if the
+        first hello was lost or the receiver was rebuilt, the next cycle
+        recovers without operator intervention.
         """
+        from . import forward_sign
+
         try:
             hello_payload = json.dumps({
                 "l2_id": aigrp.self_l2_id(),
                 "enterprise": aigrp.enterprise(),
                 "group": aigrp.group(),
                 "endpoint_url": aigrp.self_url(),
+                "public_key_ed25519": forward_sign.self_public_key_b64u(),
             }).encode()
             req = urllib.request.Request(
                 f"{aigrp.seed_peer_url()}/api/v1/aigrp/hello",
@@ -122,6 +132,7 @@ async def _aigrp_bootstrap_and_poll(store: RemoteStore) -> None:
                     domain_count=p.get("domain_count", 0),
                     embedding_model=p.get("embedding_model"),
                     signature_received=False,
+                    public_key_ed25519=p.get("public_key_ed25519"),
                 )
             log.info("aigrp bootstrap: seed=%s peers=%d", aigrp.seed_peer_url(), len(body.get("peers", [])))
             return True
@@ -138,6 +149,37 @@ async def _aigrp_bootstrap_and_poll(store: RemoteStore) -> None:
     #    pending; gives self-healing if the seed was down at start.
     import base64
 
+    def _rehello_peer(peer_endpoint: str) -> None:
+        """Re-send hello to a known peer so they pick up our pubkey.
+
+        Sprint 4 (#44) — re-hello on every poll cycle, idempotent on the
+        receiver. This is the recovery path for a peer that joined
+        before this L2 generated its key, or whose row was rebuilt.
+        """
+        from . import forward_sign
+
+        payload = json.dumps({
+            "l2_id": aigrp.self_l2_id(),
+            "enterprise": aigrp.enterprise(),
+            "group": aigrp.group(),
+            "endpoint_url": aigrp.self_url(),
+            "public_key_ed25519": forward_sign.self_public_key_b64u(),
+        }).encode()
+        try:
+            req = urllib.request.Request(
+                f"{peer_endpoint.rstrip('/')}/api/v1/aigrp/hello",
+                method="POST",
+                data=payload,
+                headers={
+                    "content-type": "application/json",
+                    "authorization": f"Bearer {os.environ.get('CQ_AIGRP_PEER_KEY', '')}",
+                },
+            )
+            with urllib.request.urlopen(req, timeout=5):
+                pass
+        except Exception:  # noqa: BLE001 — best-effort
+            pass
+
     while True:
         try:
             await asyncio.sleep(poll_interval)
@@ -149,6 +191,8 @@ async def _aigrp_bootstrap_and_poll(store: RemoteStore) -> None:
                     continue
                 if not p["endpoint_url"]:
                     continue
+                # Sprint 4 — push our pubkey to this peer (cheap, idempotent).
+                _rehello_peer(p["endpoint_url"])
                 try:
                     req = urllib.request.Request(
                         f"{p['endpoint_url'].rstrip('/')}/api/v1/aigrp/signature",
@@ -367,12 +411,22 @@ class AigrpHelloRequest(BaseModel):
     a developer laptop or a customer-edge node without inbound exposure).
     Stub peers are recorded in the table but skipped by the periodic
     poll loop (since there's no address to poll).
+
+    Sprint 4 (#44) — joiners include their forward-signing Ed25519
+    public key (base64url-encoded). Optional for backward compat with
+    pre-sprint-4 peers; receivers store NULL when absent and fall back
+    to legacy unsigned forward auth for that peer.
     """
 
     l2_id: str = Field(min_length=1, description="canonical Enterprise/Group identity")
     enterprise: str = Field(min_length=1)
     group: str = Field(min_length=1)
     endpoint_url: str = Field(default="", description="how peers should reach me; empty = stub L2 (consumer-only)")
+    public_key_ed25519: str | None = Field(
+        default=None,
+        description="forward-signing Ed25519 public key, unpadded base64url; "
+        "None on pre-sprint-4 peers",
+    )
 
 
 class AigrpAnnounceRequest(BaseModel):
@@ -383,6 +437,10 @@ class AigrpAnnounceRequest(BaseModel):
     group: str = Field(min_length=1)
     endpoint_url: str = Field(default="", description="empty = stub L2 (consumer-only)")
     announced_by: str = Field(default="", description="l2_id of the peer doing the flooding")
+    public_key_ed25519: str | None = Field(
+        default=None,
+        description="forwarded pubkey of the joiner (sprint 4); None for legacy peers",
+    )
 
 
 class AigrpPeer(BaseModel):
@@ -398,6 +456,7 @@ class AigrpPeer(BaseModel):
     first_seen_at: str
     last_seen_at: str
     last_signature_at: str | None = None
+    public_key_ed25519: str | None = None
 
 
 class AigrpPeersResponse(BaseModel):
@@ -477,6 +536,7 @@ async def aigrp_hello(
         domain_count=0,
         embedding_model=None,
         signature_received=False,
+        public_key_ed25519=body.public_key_ed25519,
     )
 
     # Compose the response — current peer table from this L2's POV.
@@ -497,6 +557,7 @@ async def aigrp_hello(
                 "group": body.group,
                 "endpoint_url": body.endpoint_url,
                 "announced_by": aigrp.self_l2_id(),
+                "public_key_ed25519": body.public_key_ed25519,
             }).encode()
             for p in peers:
                 if p["l2_id"] == body.l2_id or p["l2_id"] == aigrp.self_l2_id():
@@ -527,6 +588,8 @@ async def aigrp_hello(
     # we exist as a peer; otherwise it learns about every OTHER peer the
     # seed knows but never records the seed itself. Real EIGRP neighbor
     # adjacency advertisements include the speaker too.
+    from . import forward_sign
+
     self_entry = {
         "l2_id": aigrp.self_l2_id(),
         "enterprise": aigrp.enterprise(),
@@ -538,6 +601,7 @@ async def aigrp_hello(
         "first_seen_at": aigrp.now_iso(),
         "last_seen_at": aigrp.now_iso(),
         "last_signature_at": None,
+        "public_key_ed25519": forward_sign.self_public_key_b64u(),
     }
     peers_plus_self = peers + [self_entry]
 
@@ -573,6 +637,7 @@ def aigrp_announce(
         domain_count=0,
         embedding_model=None,
         signature_received=False,
+        public_key_ed25519=body.public_key_ed25519,
     )
     return {"recorded": body.l2_id, "by": aigrp.self_l2_id()}
 
@@ -719,10 +784,16 @@ def aigrp_forward_query(
 
     # AIGRP forward-query supports cross-Enterprise via consent table — the
     # foreign forwarder's Enterprise legitimately differs from the receiver's.
-    aigrp.require_forwarder_identity(
-        request, body.requester_l2_id, same_enterprise_only=False
-    )
+    # Sprint 4 (#44) — when the peer has a pubkey on file, also verifies
+    # the Ed25519 signature over JCS(body) || requester_l2_id.
     store = _get_store()
+    aigrp.require_forwarder_identity(
+        request,
+        body.requester_l2_id,
+        same_enterprise_only=False,
+        body_for_sig=body.model_dump(mode="json"),
+        store=store,
+    )
 
     responder_enterprise = aigrp.enterprise()
     responder_group = aigrp.group()

--- a/server/backend/src/cq_server/consults.py
+++ b/server/backend/src/cq_server/consults.py
@@ -155,6 +155,27 @@ def _self_l2_id() -> str:
     return f"{aigrp_mod.enterprise()}/{aigrp_mod.group()}"
 
 
+def _build_forward_headers(peer_key: str, payload: dict[str, Any]) -> dict[str, str]:
+    """Compose authorization + forwarder-identity + (sprint 4) signature
+    headers for outbound /consults/forward-* calls.
+
+    The signature header is omitted when no L2 keypair is available on
+    disk — receivers fall back to legacy unsigned mode (until they flip
+    ``CQ_REQUIRE_SIGNED_FORWARDS=true``).
+    """
+    from . import forward_sign
+
+    forwarder_id = _self_l2_id()
+    headers = {
+        "authorization": f"Bearer {peer_key}",
+        aigrp_mod.FORWARDER_HEADER: forwarder_id,
+    }
+    sig = forward_sign.sign_forward_request(payload, forwarder_id)
+    if sig:
+        headers[forward_sign.SIGNATURE_HEADER] = sig
+    return headers
+
+
 def _forward_request(target: dict[str, Any], payload: dict[str, Any]) -> None:
     """POST /consults/forward-request to a peer L2 with the peer-key bearer.
 
@@ -162,19 +183,20 @@ def _forward_request(target: dict[str, Any], payload: dict[str, Any]) -> None:
     write. Callers see 502 if the peer is unreachable so they know the
     remote side won't see the message until they reach the recipient L2
     directly. Subsequent replies retry independently.
+
+    Sprint 4 (#44) — when this L2 has an Ed25519 keypair on disk, the
+    request body is signed and the sig travels in ``X-8L-Forwarder-Sig``.
     """
     base = target["endpoint_url"].rstrip("/")
     peer_key = os.environ.get("CQ_AIGRP_PEER_KEY", "")
     if not peer_key:
         raise HTTPException(503, detail="cross-L2 routing requires CQ_AIGRP_PEER_KEY")
+    headers = _build_forward_headers(peer_key, payload)
     try:
         with httpx.Client(timeout=L2_FORWARD_TIMEOUT) as client:
             r = client.post(
                 f"{base}/api/v1/consults/forward-request",
-                headers={
-                    "authorization": f"Bearer {peer_key}",
-                    aigrp_mod.FORWARDER_HEADER: _self_l2_id(),
-                },
+                headers=headers,
                 json=payload,
             )
         if r.status_code >= 400:
@@ -190,19 +212,20 @@ def _forward_request(target: dict[str, Any], payload: dict[str, Any]) -> None:
 
 
 def _forward_message(target: dict[str, Any], payload: dict[str, Any]) -> None:
-    """POST /consults/forward-message — symmetric to _forward_request."""
+    """POST /consults/forward-message — symmetric to _forward_request.
+
+    Sprint 4 (#44) — same Ed25519 signature treatment as forward-request.
+    """
     base = target["endpoint_url"].rstrip("/")
     peer_key = os.environ.get("CQ_AIGRP_PEER_KEY", "")
     if not peer_key:
         raise HTTPException(503, detail="cross-L2 routing requires CQ_AIGRP_PEER_KEY")
+    headers = _build_forward_headers(peer_key, payload)
     try:
         with httpx.Client(timeout=L2_FORWARD_TIMEOUT) as client:
             r = client.post(
                 f"{base}/api/v1/consults/forward-message",
-                headers={
-                    "authorization": f"Bearer {peer_key}",
-                    aigrp_mod.FORWARDER_HEADER: _self_l2_id(),
-                },
+                headers=headers,
                 json=payload,
             )
         if r.status_code >= 400:
@@ -499,8 +522,16 @@ def forward_consult_request(
     Idempotent on thread_id collision: if the thread already exists
     (re-delivery, retry), we skip the create and just append the message
     if it's new. Same for message_id.
+
+    Sprint 4 (#44) — pubkey-on-file peers must also present a valid
+    ``X-8L-Forwarder-Sig`` over JCS(body) || from_l2_id.
     """
-    aigrp_mod.require_forwarder_identity(request, body.from_l2_id)
+    aigrp_mod.require_forwarder_identity(
+        request,
+        body.from_l2_id,
+        body_for_sig=body.model_dump(mode="json"),
+        store=store,
+    )
     if store.get_consult(body.thread_id) is None:
         store.create_consult(
             thread_id=body.thread_id,
@@ -561,8 +592,15 @@ def forward_consult_message(
     audit trail on this side.
 
     SEC-CRIT #34 — same forwarder-identity binding as /forward-request.
+    Sprint 4 (#44) — also requires Ed25519 forward signature for peers
+    with a recorded pubkey.
     """
-    aigrp_mod.require_forwarder_identity(request, body.from_l2_id)
+    aigrp_mod.require_forwarder_identity(
+        request,
+        body.from_l2_id,
+        body_for_sig=body.model_dump(mode="json"),
+        store=store,
+    )
     existing = store.get_consult(body.thread_id)
     if existing is None:
         if not (

--- a/server/backend/src/cq_server/crypto.py
+++ b/server/backend/src/cq_server/crypto.py
@@ -1,0 +1,140 @@
+"""Shared Ed25519 + RFC 8785 primitives.
+
+Sprint 4 extracted these helpers from ``directory_client.py`` so they can be
+reused by the per-L2 forward-signing path (`forward_sign.py`) without a
+circular import. Two callers, one canonical implementation:
+
+- ``directory_client.py``  — enterprise-ROOT keypair, signs /announce + peerings pull
+- ``forward_sign.py``      — per-L2 keypair, signs forward-* request bodies
+
+The two key scopes are intentionally separate. The directory key is the
+enterprise's identity to the public 8th-Layer directory; the per-L2 key
+is the L2's identity to its sibling L2s on the AIGRP mesh. They never
+cross paths; key rotation on one does not affect the other.
+
+All bytes that get signed are produced by ``canonicalize`` (RFC 8785 JCS)
+so verifiers see byte-identical input regardless of dict ordering or
+JSON whitespace.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import rfc8785
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+
+# ---------------------------------------------------------------------------
+# base64url helpers (no padding) — directory + forward-sign both use this
+# ---------------------------------------------------------------------------
+
+
+def b64u(b: bytes) -> str:
+    """Encode bytes as unpadded base64url."""
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+
+
+def b64u_decode(s: str) -> bytes:
+    """Decode unpadded base64url back to bytes."""
+    pad = (-len(s)) % 4
+    return base64.urlsafe_b64decode(s + ("=" * pad))
+
+
+# ---------------------------------------------------------------------------
+# Ed25519 key load / public-key extraction
+# ---------------------------------------------------------------------------
+
+
+def load_private_key(path: Path) -> Ed25519PrivateKey:
+    """Load an Ed25519 private key from a 32-byte raw file."""
+    raw = path.read_bytes()
+    if len(raw) != 32:
+        raise ValueError(f"Ed25519 private key must be 32 raw bytes, got {len(raw)}")
+    return Ed25519PrivateKey.from_private_bytes(raw)
+
+
+def public_key_b64u(privkey: Ed25519PrivateKey) -> str:
+    """Return the unpadded base64url-encoded raw public key."""
+    pub = privkey.public_key().public_bytes_raw()
+    return b64u(pub)
+
+
+def fingerprint_sha256(pubkey_b64u: str) -> str:
+    """Match the directory's fingerprint format (`sha256:<hex>`)."""
+    raw = b64u_decode(pubkey_b64u)
+    return f"sha256:{hashlib.sha256(raw).hexdigest()}"
+
+
+# ---------------------------------------------------------------------------
+# Canonical-JSON sign / verify (RFC 8785 envelope shape)
+# ---------------------------------------------------------------------------
+
+
+def canonicalize(payload: dict[str, Any]) -> bytes:
+    """RFC 8785 JCS canonical JSON bytes for ``payload``."""
+    return rfc8785.dumps(payload)
+
+
+def sign_envelope(privkey: Ed25519PrivateKey, payload: dict[str, Any]) -> dict[str, Any]:
+    """Build a signed envelope per directory-v1 spec.
+
+    Returns the dict the directory expects on the wire:
+    ``{payload, payload_canonical, signature, signing_key_id}``.
+    """
+    canonical = canonicalize(payload)
+    signature = privkey.sign(canonical)
+    return {
+        "payload": payload,
+        "payload_canonical": canonical.decode(),
+        "signature": b64u(signature),
+        "signing_key_id": public_key_b64u(privkey),
+    }
+
+
+def verify_envelope_signature(
+    pubkey_b64u: str,
+    payload_canonical: str,
+    signature_b64u: str,
+) -> bool:
+    """Constant-time Ed25519 verify of a signed-envelope payload.
+
+    Returns True on success, False on any cryptographic failure (we
+    never raise on verify; callers decide policy).
+    """
+    try:
+        pub = Ed25519PublicKey.from_public_bytes(b64u_decode(pubkey_b64u))
+        pub.verify(b64u_decode(signature_b64u), payload_canonical.encode())
+        return True
+    except (InvalidSignature, ValueError):
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Raw (non-envelope) sign / verify — forward-* uses this path because
+# the wire body is a normal JSON request, not a signed envelope. The
+# bytes signed are JCS(body) || forwarder_l2_id_bytes (concatenation;
+# see forward_sign.signing_input_for docstring).
+# ---------------------------------------------------------------------------
+
+
+def sign_raw(privkey: Ed25519PrivateKey, message: bytes) -> str:
+    """Sign arbitrary bytes; return the unpadded-base64url signature."""
+    return b64u(privkey.sign(message))
+
+
+def verify_raw(pubkey_b64u_str: str, message: bytes, signature_b64u: str) -> bool:
+    """Verify a raw-bytes signature. False on any failure."""
+    try:
+        pub = Ed25519PublicKey.from_public_bytes(b64u_decode(pubkey_b64u_str))
+        pub.verify(b64u_decode(signature_b64u), message)
+        return True
+    except (InvalidSignature, ValueError):
+        return False

--- a/server/backend/src/cq_server/forward_sign.py
+++ b/server/backend/src/cq_server/forward_sign.py
@@ -1,0 +1,250 @@
+"""Per-L2 Ed25519 keypair management + forward-* request signing.
+
+Sprint 4 — closes residual sibling-L2 spoof gap left by CRIT #34
+(issue #44). The peer-key-only auth in CRIT #34's partial fix proved
+the *forwarder header matches the body's from_l2_id*, but every L2 in
+an Enterprise shares the same EnterprisePeerKey, so any L2 with the
+key could still set ``X-8L-Forwarder-L2-Id`` to a sibling's id and the
+receiver had no way to tell. This module makes that lie cryptographic
+rather than declarative.
+
+The shape:
+
+- Each L2 owns a 32-byte Ed25519 private key on disk at
+  ``CQ_AIGRP_L2_PRIVKEY_PATH`` (default ``/data/aigrp_l2_key.bin``,
+  mode 0600). Generated lazily on first startup.
+- The L2 includes its base64url-encoded public key in every
+  ``/aigrp/hello`` (initial bootstrap + every poll cycle thereafter,
+  for self-healing if a re-hello is missed). The receiver upserts it
+  onto the ``aigrp_peers.public_key_ed25519`` column.
+- Outbound /forward-* calls sign a deterministic message — the
+  RFC 8785 JCS canonical bytes of the *request body* concatenated with
+  the forwarder L2's id (UTF-8 bytes). Signature goes in
+  ``X-8L-Forwarder-Sig`` (unpadded base64url). See
+  ``signing_input_for`` for the exact byte layout.
+- Inbound /forward-* receivers look up the peer's pubkey, verify the
+  signature against the same bytes, and 403 on mismatch. If the peer
+  has no pubkey on file (legacy peer that hasn't re-helloed since the
+  rollout), the receiver falls back to the CRIT-#34-partial behaviour
+  and logs a WARNING. ``CQ_REQUIRE_SIGNED_FORWARDS=true`` flips strict
+  mode and rejects unsigned forwards even for legacy peers.
+
+V1 is filesystem-mounted keys; KMS/HSM-backed signing is V2 (#48-class
+follow-up). The directory client uses a *separate* enterprise-root
+keypair — different scope, different trust anchor, intentionally
+isolated. Don't conflate the two.
+
+Environment variables
+    CQ_AIGRP_L2_PRIVKEY_PATH    where to read/write the 32-byte private key.
+                                Default: /data/aigrp_l2_key.bin
+    CQ_REQUIRE_SIGNED_FORWARDS  ``true`` → strict; legacy unsigned forwards 403.
+                                Default: false (rollout window).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+from pathlib import Path
+from typing import Any
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from .crypto import (
+    b64u,
+    canonicalize,
+    public_key_b64u,
+    sign_raw,
+    verify_raw,
+)
+
+log = logging.getLogger(__name__)
+
+DEFAULT_PRIVKEY_PATH = "/data/aigrp_l2_key.bin"
+SIGNATURE_HEADER = "x-8l-forwarder-sig"
+
+
+def privkey_path() -> Path:
+    return Path(os.environ.get("CQ_AIGRP_L2_PRIVKEY_PATH", DEFAULT_PRIVKEY_PATH))
+
+
+def require_signed_forwards() -> bool:
+    """When True, receivers reject legacy unsigned forwards with 403.
+
+    During the rollout window this is False so peers that haven't yet
+    re-helloed under the new schema (no pubkey in receiver's table)
+    still work. Once a full bootstrap cycle has elapsed and every peer
+    has a non-NULL pubkey, operators flip this to True cluster-wide.
+    """
+    return os.environ.get("CQ_REQUIRE_SIGNED_FORWARDS", "false").lower() == "true"
+
+
+# ---------------------------------------------------------------------------
+# Keypair load / generate
+# ---------------------------------------------------------------------------
+
+
+def _generate_and_persist(path: Path) -> Ed25519PrivateKey:
+    """Create a fresh Ed25519 keypair and write the 32 raw private bytes
+    with mode 0600. Parent directory is created if missing.
+    """
+    raw = secrets.token_bytes(32)
+    privkey = Ed25519PrivateKey.from_private_bytes(raw)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Open with O_CREAT|O_WRONLY|O_EXCL would race; we accept a short
+    # window where another process could read the directory entry. The
+    # subsequent chmod tightens to 0600 immediately.
+    path.write_bytes(raw)
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        # Best-effort on filesystems that don't support unix mode bits
+        # (e.g. FAT-formatted bind mount). Log but don't fail startup.
+        log.warning("forward-sign: chmod 0600 failed on %s", path)
+    return privkey
+
+
+def load_or_create_l2_privkey() -> Ed25519PrivateKey | None:
+    """Return this L2's Ed25519 private key, generating it if absent.
+
+    Returns ``None`` (signing disabled) on any unrecoverable load
+    failure — receiving peers will then see unsigned forwards and fall
+    through to the legacy-peer code path. We never crash startup over a
+    bad key file; corrupt key + strict-mode receivers is a deployment
+    bug we want surfaced as 403s in logs, not as a crashing L2.
+    """
+    path = privkey_path()
+    try:
+        if path.exists():
+            raw = path.read_bytes()
+            if len(raw) != 32:
+                log.error(
+                    "forward-sign: existing key at %s has wrong length=%d (want 32) — "
+                    "signing disabled; rotate the file to recover",
+                    path,
+                    len(raw),
+                )
+                return None
+            return Ed25519PrivateKey.from_private_bytes(raw)
+        log.info("forward-sign: no key at %s; generating fresh Ed25519 keypair", path)
+        return _generate_and_persist(path)
+    except OSError as e:
+        log.error(
+            "forward-sign: cannot load/create key at %s err=%s — signing disabled",
+            path,
+            e,
+        )
+        return None
+
+
+# Process-level cache — lazy load on first call. Tests can monkeypatch
+# the env var and call ``reload_l2_privkey()`` to get a fresh handle.
+_cached_privkey: Ed25519PrivateKey | None = None
+_cached_loaded: bool = False
+
+
+def get_l2_privkey() -> Ed25519PrivateKey | None:
+    """Return the cached private key (loading on first call). ``None``
+    when load failed; callers must treat that as 'sign disabled, fall
+    back to header-only identity declaration'.
+    """
+    global _cached_privkey, _cached_loaded  # noqa: PLW0603
+    if not _cached_loaded:
+        _cached_privkey = load_or_create_l2_privkey()
+        _cached_loaded = True
+    return _cached_privkey
+
+
+def reload_l2_privkey() -> Ed25519PrivateKey | None:
+    """Force a re-read from disk. Test hook + ops hook for hot rotate."""
+    global _cached_privkey, _cached_loaded  # noqa: PLW0603
+    _cached_loaded = False
+    _cached_privkey = None
+    return get_l2_privkey()
+
+
+def self_public_key_b64u() -> str | None:
+    """Base64url public key for inclusion in /aigrp/hello payloads.
+
+    Returns ``None`` when signing is disabled — receivers then store
+    NULL in ``aigrp_peers.public_key_ed25519`` for this peer, which
+    correctly downgrades them to the legacy-unsigned code path.
+    """
+    pk = get_l2_privkey()
+    if pk is None:
+        return None
+    return public_key_b64u(pk)
+
+
+# ---------------------------------------------------------------------------
+# Sign / verify a forward-* request
+# ---------------------------------------------------------------------------
+
+
+def signing_input_for(body: dict[str, Any], forwarder_l2_id: str) -> bytes:
+    """Build the deterministic byte string we sign / verify.
+
+    Layout:
+
+        canonical_body_bytes || forwarder_l2_id_utf8
+
+    where ``canonical_body_bytes`` is the RFC 8785 JCS canonicalisation
+    of ``body`` and the concatenation is plain bytewise (no separator).
+    Including ``forwarder_l2_id`` in the signed input prevents a
+    sibling L2 with a leaked body+sig pair from replaying it under its
+    own header; the bytes wouldn't match. The body alone isn't enough
+    because the AIGRP forward-query body contains the requester id but
+    /consults/forward-* bodies use ``from_l2_id`` — both are pinned via
+    ``require_forwarder_identity`` already, but binding the header to
+    the signature gives the receiver a single canonical thing to verify.
+    """
+    return canonicalize(body) + forwarder_l2_id.encode("utf-8")
+
+
+def sign_forward_request(
+    body: dict[str, Any], forwarder_l2_id: str
+) -> str | None:
+    """Sign a forward-* request body. Returns the b64url signature or
+    ``None`` when signing is disabled (no key on disk).
+
+    Caller adds the result as ``X-8L-Forwarder-Sig`` header. When
+    ``None``, caller omits the header — receivers with the legacy code
+    path accept that; receivers in strict mode reject it.
+    """
+    pk = get_l2_privkey()
+    if pk is None:
+        return None
+    return sign_raw(pk, signing_input_for(body, forwarder_l2_id))
+
+
+def verify_forward_signature(
+    pubkey_b64u_str: str,
+    body: dict[str, Any],
+    forwarder_l2_id: str,
+    signature_b64u: str,
+) -> bool:
+    """Verify a forward-* signature. False on any cryptographic failure."""
+    return verify_raw(
+        pubkey_b64u_str,
+        signing_input_for(body, forwarder_l2_id),
+        signature_b64u,
+    )
+
+
+# Convenience: expose the b64u helper on this module so callers can
+# encode peer pubkeys for the wire without reaching into ``crypto``.
+__all__ = [
+    "DEFAULT_PRIVKEY_PATH",
+    "SIGNATURE_HEADER",
+    "b64u",
+    "get_l2_privkey",
+    "load_or_create_l2_privkey",
+    "privkey_path",
+    "reload_l2_privkey",
+    "require_signed_forwards",
+    "self_public_key_b64u",
+    "sign_forward_request",
+    "signing_input_for",
+    "verify_forward_signature",
+]

--- a/server/backend/src/cq_server/network.py
+++ b/server/backend/src/cq_server/network.py
@@ -986,22 +986,31 @@ async def _call_forward_query(
     if peer_key:
         headers["authorization"] = f"Bearer {peer_key}"
     # SEC-CRIT #34 — declare the forwarder identity so the receiver can pin
-    # the body's requester_l2_id to the same value.
-    headers[aigrp.FORWARDER_HEADER] = f"{requester['enterprise']}/{requester['group']}"
+    # the body's requester_l2_id to the same value. Sprint 4 (#44) — also
+    # Ed25519-sign the request body when this L2 has a key on disk.
+    from . import aigrp as _aigrp_mod
+    from . import forward_sign
+
+    forwarder_l2_id = f"{requester['enterprise']}/{requester['group']}"
+    headers[_aigrp_mod.FORWARDER_HEADER] = forwarder_l2_id
+    body = {
+        "query_vec": query_vec,
+        "query_text": query_text,
+        "requester_l2_id": forwarder_l2_id,
+        "requester_enterprise": requester["enterprise"],
+        "requester_group": requester["group"],
+        "requester_persona": requester_persona,
+        "max_results": 5,
+    }
+    sig = forward_sign.sign_forward_request(body, forwarder_l2_id)
+    if sig:
+        headers[forward_sign.SIGNATURE_HEADER] = sig
     t0 = time.monotonic()
     try:
         r = await client.post(
             f"{base}/api/v1/aigrp/forward-query",
             headers=headers,
-            json={
-                "query_vec": query_vec,
-                "query_text": query_text,
-                "requester_l2_id": f"{requester['enterprise']}/{requester['group']}",
-                "requester_enterprise": requester["enterprise"],
-                "requester_group": requester["group"],
-                "requester_persona": requester_persona,
-                "max_results": 5,
-            },
+            json=body,
         )
         latency = int((time.monotonic() - t0) * 1000)
         if r.status_code == 200:

--- a/server/backend/src/cq_server/store/__init__.py
+++ b/server/backend/src/cq_server/store/__init__.py
@@ -1112,6 +1112,7 @@ class RemoteStore:
         domain_count: int,
         embedding_model: str | None,
         signature_received: bool,
+        public_key_ed25519: str | None = None,
     ) -> None:
         """Insert or update an AIGRP peer record.
 
@@ -1120,6 +1121,13 @@ class RemoteStore:
         means the caller is just announcing the peer's existence (e.g.
         from /aigrp/hello before the peer's signature is fetched); we
         leave the signature columns alone if the row already exists.
+
+        ``public_key_ed25519`` (sprint 4) is the peer's forward-signing
+        public key, base64url-encoded. ``None`` leaves any existing
+        value alone (so a /signature poll that doesn't carry pubkey
+        doesn't wipe what /aigrp/hello recorded). To explicitly clear
+        a pubkey, pass an empty string and the caller path will go
+        through the dedicated ``set_aigrp_peer_pubkey`` helper.
         """
         self._check_open()
         now = datetime.now(UTC).isoformat()
@@ -1133,13 +1141,15 @@ class RemoteStore:
                     INSERT INTO aigrp_peers (
                         l2_id, enterprise, "group", endpoint_url,
                         embedding_centroid, domain_bloom, ku_count, domain_count,
-                        embedding_model, first_seen_at, last_seen_at, last_signature_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        embedding_model, first_seen_at, last_seen_at, last_signature_at,
+                        public_key_ed25519
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         l2_id, enterprise, group, endpoint_url,
                         embedding_centroid, domain_bloom, ku_count, domain_count,
                         embedding_model, now, now, now if signature_received else None,
+                        public_key_ed25519,
                     ),
                 )
             elif signature_received:
@@ -1159,6 +1169,11 @@ class RemoteStore:
                         now, now, l2_id,
                     ),
                 )
+                if public_key_ed25519 is not None:
+                    self._conn.execute(
+                        "UPDATE aigrp_peers SET public_key_ed25519 = ? WHERE l2_id = ?",
+                        (public_key_ed25519, l2_id),
+                    )
             else:
                 # touch last_seen but keep cached signature
                 self._conn.execute(
@@ -1170,6 +1185,28 @@ class RemoteStore:
                     """,
                     (enterprise, group, endpoint_url, now, l2_id),
                 )
+                if public_key_ed25519 is not None:
+                    self._conn.execute(
+                        "UPDATE aigrp_peers SET public_key_ed25519 = ? WHERE l2_id = ?",
+                        (public_key_ed25519, l2_id),
+                    )
+
+    def get_aigrp_peer_pubkey(self, l2_id: str) -> str | None:
+        """Return the base64url-encoded Ed25519 public key for ``l2_id``,
+        or ``None`` if the peer is unknown / has no pubkey on file.
+
+        Used by the receiver-side forward-signature verifier in
+        ``aigrp.require_forwarder_identity`` (sprint 4).
+        """
+        self._check_open()
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT public_key_ed25519 FROM aigrp_peers WHERE l2_id = ?",
+                (l2_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return row[0]
 
     def list_aigrp_peers(self, enterprise: str) -> list[dict[str, Any]]:
         """Return every known peer in the given Enterprise.
@@ -1184,7 +1221,8 @@ class RemoteStore:
                 SELECT l2_id, enterprise, "group", endpoint_url,
                        embedding_centroid, domain_bloom,
                        ku_count, domain_count, embedding_model,
-                       first_seen_at, last_seen_at, last_signature_at
+                       first_seen_at, last_seen_at, last_signature_at,
+                       public_key_ed25519
                 FROM aigrp_peers
                 WHERE enterprise = ?
                 ORDER BY last_seen_at DESC
@@ -1205,6 +1243,7 @@ class RemoteStore:
                 "first_seen_at": r[9],
                 "last_seen_at": r[10],
                 "last_signature_at": r[11],
+                "public_key_ed25519": r[12],
             }
             for r in rows
         ]

--- a/server/backend/src/cq_server/tables.py
+++ b/server/backend/src/cq_server/tables.py
@@ -88,10 +88,18 @@ CREATE TABLE IF NOT EXISTS aigrp_peers (
     embedding_model TEXT,
     first_seen_at TEXT NOT NULL,
     last_seen_at TEXT NOT NULL,
-    last_signature_at TEXT
+    last_signature_at TEXT,
+    public_key_ed25519 TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_aigrp_peers_enterprise ON aigrp_peers(enterprise);
 """
+
+# Sprint 4 — peers gain ``public_key_ed25519`` for cryptographic forward-id
+# binding (issue #44). Idempotent ALTER TABLE is run alongside CREATE so
+# pre-sprint-4 deployments pick up the column on first restart.
+_AIGRP_PEERS_COLUMN_STATEMENTS = (
+    "ALTER TABLE aigrp_peers ADD COLUMN public_key_ed25519 TEXT",
+)
 
 CONSULTS_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS consults (
@@ -210,10 +218,18 @@ def ensure_aigrp_peers_table(conn: sqlite3.Connection) -> None:
 
     Holds this L2's view of every other L2 it knows about in the same
     Enterprise, including their last-published signature (centroid +
-    Bloom). Built up via /aigrp/hello flooding at deploy time and
-    refreshed by the periodic peer-poll task.
+    Bloom) and (sprint 4) their forward-signing Ed25519 public key.
+    Built up via /aigrp/hello flooding at deploy time and refreshed by
+    the periodic peer-poll task.
     """
     conn.executescript(AIGRP_PEERS_TABLE_SQL)
+    cursor = conn.execute("PRAGMA table_info(aigrp_peers)")
+    existing = {row[1] for row in cursor.fetchall()}
+    for statement in _AIGRP_PEERS_COLUMN_STATEMENTS:
+        col = statement.split("COLUMN ")[1].split()[0]
+        if col not in existing:
+            conn.execute(statement)
+    conn.commit()
 
 
 def ensure_users_table(conn: sqlite3.Connection) -> None:

--- a/server/backend/tests/test_ed25519_forward_signing.py
+++ b/server/backend/tests/test_ed25519_forward_signing.py
@@ -1,0 +1,490 @@
+"""Sprint 4 — Ed25519 per-L2 forward-signing tests (#44 / full CRIT #34 close).
+
+The unit under test:
+
+- Per-L2 keypair bootstrap (load existing / generate fresh / corrupt
+  recovery / disabled-on-error) in ``forward_sign``.
+- /aigrp/hello carries pubkey, receiver records it.
+- /aigrp/peers response includes the recorded pubkey.
+- Sender-side signature header on /aigrp/forward-query (network) and
+  /consults/forward-* (consults).
+- Receiver-side verification:
+   - peer with pubkey + valid sig → accepted (info-log).
+   - peer with pubkey + missing sig → 403.
+   - peer with pubkey + invalid sig → 403.
+   - peer with pubkey + tampered body → 403.
+   - peer with pubkey + sig from wrong key → 403.
+   - peer without pubkey → legacy mode accepts (warning) by default.
+   - peer without pubkey + CQ_REQUIRE_SIGNED_FORWARDS=true → 403.
+- Pubkey survives a re-hello with the same key (idempotent).
+"""
+
+from __future__ import annotations
+
+import logging
+import struct
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from fastapi.testclient import TestClient
+
+from cq_server import aigrp as aigrp_mod
+from cq_server import consults, forward_sign, network
+from cq_server.app import _get_store, app
+from cq_server.crypto import b64u, public_key_b64u
+
+PEER_KEY = "test-peer-key-ed25519-fwd-sign!!"
+PEER_L2 = "acme/engineering"
+SELF_ENTERPRISE = "acme"
+SELF_GROUP = "solutions"
+SELF_L2 = f"{SELF_ENTERPRISE}/{SELF_GROUP}"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def aigrp_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    """TestClient with this L2 as ``acme/solutions`` + per-L2 key on disk."""
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "ed25519.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    monkeypatch.setenv("CQ_AIGRP_PEER_KEY", PEER_KEY)
+    monkeypatch.setenv("CQ_ENTERPRISE", SELF_ENTERPRISE)
+    monkeypatch.setenv("CQ_GROUP", SELF_GROUP)
+    monkeypatch.setenv("CQ_AIGRP_L2_PRIVKEY_PATH", str(tmp_path / "self_l2.key"))
+    monkeypatch.setenv("CQ_EMBED_ENABLED", "false")
+    monkeypatch.delenv("CQ_REQUIRE_SIGNED_FORWARDS", raising=False)
+    forward_sign.reload_l2_privkey()
+    network._signature_cache.clear()
+    network._signature_cache_filled_at = 0.0
+    with TestClient(app) as c:
+        yield c
+    forward_sign.reload_l2_privkey()
+
+
+@pytest.fixture()
+def peer_keypair() -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.generate()
+
+
+@pytest.fixture()
+def other_keypair() -> Ed25519PrivateKey:
+    return Ed25519PrivateKey.generate()
+
+
+# ---------------------------------------------------------------------------
+# 1. Per-L2 keypair bootstrap
+# ---------------------------------------------------------------------------
+
+
+class TestKeypairBootstrap:
+    def test_generates_new_key_when_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        path = tmp_path / "fresh.key"
+        monkeypatch.setenv("CQ_AIGRP_L2_PRIVKEY_PATH", str(path))
+        forward_sign.reload_l2_privkey()
+        pk = forward_sign.get_l2_privkey()
+        assert pk is not None
+        assert path.exists()
+        assert len(path.read_bytes()) == 32
+
+    def test_loads_existing_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        path = tmp_path / "existing.key"
+        seeded = Ed25519PrivateKey.generate()
+        path.write_bytes(seeded.private_bytes_raw())
+        monkeypatch.setenv("CQ_AIGRP_L2_PRIVKEY_PATH", str(path))
+        forward_sign.reload_l2_privkey()
+        pk = forward_sign.get_l2_privkey()
+        assert pk is not None
+        assert public_key_b64u(pk) == public_key_b64u(seeded)
+
+    def test_corrupt_key_disables_signing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        path = tmp_path / "corrupt.key"
+        path.write_bytes(b"too-short")
+        monkeypatch.setenv("CQ_AIGRP_L2_PRIVKEY_PATH", str(path))
+        forward_sign.reload_l2_privkey()
+        assert forward_sign.get_l2_privkey() is None
+        assert forward_sign.self_public_key_b64u() is None
+        # And signing returns None instead of crashing.
+        assert forward_sign.sign_forward_request({"x": 1}, "acme/eng") is None
+
+
+# ---------------------------------------------------------------------------
+# 2. /aigrp/hello propagates pubkey
+# ---------------------------------------------------------------------------
+
+
+class TestHelloPubkeyExchange:
+    def test_hello_records_pubkey(
+        self, aigrp_client: TestClient, peer_keypair: Ed25519PrivateKey
+    ) -> None:
+        peer_pub = public_key_b64u(peer_keypair)
+        r = aigrp_client.post(
+            "/api/v1/aigrp/hello",
+            headers={"authorization": f"Bearer {PEER_KEY}"},
+            json={
+                "l2_id": PEER_L2,
+                "enterprise": "acme",
+                "group": "engineering",
+                "endpoint_url": "http://peer.test",
+                "public_key_ed25519": peer_pub,
+            },
+        )
+        assert r.status_code == 201
+        store = _get_store()
+        assert store.get_aigrp_peer_pubkey(PEER_L2) == peer_pub
+
+    def test_peers_endpoint_exposes_pubkey(
+        self, aigrp_client: TestClient, peer_keypair: Ed25519PrivateKey
+    ) -> None:
+        peer_pub = public_key_b64u(peer_keypair)
+        # The /aigrp/hello response is what new joiners use to learn the
+        # mesh topology — it must include our own pubkey in the self_entry
+        # so the joiner can later verify forwards FROM us.
+        hello = aigrp_client.post(
+            "/api/v1/aigrp/hello",
+            headers={"authorization": f"Bearer {PEER_KEY}"},
+            json={
+                "l2_id": PEER_L2,
+                "enterprise": "acme",
+                "group": "engineering",
+                "endpoint_url": "http://peer.test",
+                "public_key_ed25519": peer_pub,
+            },
+        )
+        hello_peers = {p["l2_id"]: p for p in hello.json()["peers"]}
+        assert hello_peers[SELF_L2]["public_key_ed25519"] == forward_sign.self_public_key_b64u()
+        # /aigrp/peers reflects the recorded peer rows — joiner is in there.
+        r = aigrp_client.get(
+            "/api/v1/aigrp/peers", headers={"authorization": f"Bearer {PEER_KEY}"}
+        )
+        assert r.status_code == 200
+        peers = {p["l2_id"]: p for p in r.json()["peers"]}
+        assert peers[PEER_L2]["public_key_ed25519"] == peer_pub
+
+    def test_rehello_same_key_is_idempotent(
+        self, aigrp_client: TestClient, peer_keypair: Ed25519PrivateKey
+    ) -> None:
+        peer_pub = public_key_b64u(peer_keypair)
+        body = {
+            "l2_id": PEER_L2,
+            "enterprise": "acme",
+            "group": "engineering",
+            "endpoint_url": "http://peer.test",
+            "public_key_ed25519": peer_pub,
+        }
+        for _ in range(3):
+            r = aigrp_client.post(
+                "/api/v1/aigrp/hello",
+                headers={"authorization": f"Bearer {PEER_KEY}"},
+                json=body,
+            )
+            assert r.status_code == 201
+        store = _get_store()
+        assert store.get_aigrp_peer_pubkey(PEER_L2) == peer_pub
+
+    def test_legacy_hello_without_pubkey_yields_null(
+        self, aigrp_client: TestClient
+    ) -> None:
+        r = aigrp_client.post(
+            "/api/v1/aigrp/hello",
+            headers={"authorization": f"Bearer {PEER_KEY}"},
+            json={
+                "l2_id": PEER_L2,
+                "enterprise": "acme",
+                "group": "engineering",
+                "endpoint_url": "http://peer.test",
+            },
+        )
+        assert r.status_code == 201
+        store = _get_store()
+        assert store.get_aigrp_peer_pubkey(PEER_L2) is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Sender-side signature header
+# ---------------------------------------------------------------------------
+
+
+def _pack_vec(vec: list[float]) -> bytes:
+    return struct.pack(f"<{len(vec)}f", *vec)
+
+
+class TestSenderSideSignatures:
+    def test_forward_query_sender_signs_body(
+        self, aigrp_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``network._call_forward_query`` adds X-8L-Forwarder-Sig that
+        verifies against this L2's pubkey + JCS(body) || forwarder id."""
+        captured: dict[str, Any] = {}
+
+        class StubResp:
+            status_code = 200
+
+            def json(self) -> dict[str, Any]:
+                return {"results": [], "policy_applied": "denied", "result_count": 0}
+
+        class StubClient:
+            async def post(self, url: str, *, headers: dict[str, str], json: dict[str, Any]) -> StubResp:
+                captured["url"] = url
+                captured["headers"] = headers
+                captured["json"] = json
+                return StubResp()
+
+        import asyncio
+
+        async def _run() -> None:
+            await network._call_forward_query(
+                StubClient(),  # type: ignore[arg-type]
+                target={
+                    "endpoint": "http://peer.test",
+                    "enterprise": "rival",
+                    "slug": "rival",
+                },
+                requester={"enterprise": "acme", "group": "solutions"},
+                requester_persona="alice",
+                query_vec=[1.0, 0.0, 0.0],
+                query_text="cf cache",
+            )
+
+        asyncio.run(_run())
+        sig_header = captured["headers"].get(forward_sign.SIGNATURE_HEADER)
+        assert sig_header, "sender omitted the signature header"
+        # Verify it against this L2's own pubkey.
+        self_pub = forward_sign.self_public_key_b64u()
+        assert self_pub
+        assert forward_sign.verify_forward_signature(
+            self_pub, captured["json"], "acme/solutions", sig_header
+        )
+
+    def test_consult_forward_request_signed(
+        self, aigrp_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: list[dict[str, Any]] = []
+
+        class StubResp:
+            status_code = 201
+            text = "{}"
+
+        class StubClient:
+            def __init__(self, **kw: Any) -> None:
+                pass
+
+            def __enter__(self) -> "StubClient":
+                return self
+
+            def __exit__(self, *a: Any) -> None:
+                return None
+
+            def post(
+                self, url: str, *, headers: dict[str, str], json: dict[str, Any]
+            ) -> StubResp:
+                captured.append({"headers": headers, "json": json})
+                return StubResp()
+
+        monkeypatch.setattr(consults.httpx, "Client", StubClient)
+
+        target = {
+            "l2_id": PEER_L2,
+            "endpoint_url": "http://peer.test",
+        }
+        payload = {
+            "thread_id": "t1",
+            "message_id": "m1",
+            "from_l2_id": SELF_L2,
+            "from_persona": "alice",
+            "to_l2_id": PEER_L2,
+            "to_persona": "bob",
+            "subject": "hello",
+            "content": "ping",
+            "created_at": "2026-05-01T00:00:00+00:00",
+        }
+        consults._forward_request(target, payload)
+
+        assert len(captured) == 1
+        sig = captured[0]["headers"].get(forward_sign.SIGNATURE_HEADER)
+        assert sig
+        assert captured[0]["headers"][aigrp_mod.FORWARDER_HEADER] == SELF_L2
+        self_pub = forward_sign.self_public_key_b64u()
+        assert self_pub
+        assert forward_sign.verify_forward_signature(self_pub, payload, SELF_L2, sig)
+
+
+# ---------------------------------------------------------------------------
+# 4. Receiver-side verification
+# ---------------------------------------------------------------------------
+
+
+def _seed_peer(store: Any, pubkey_b64u: str | None) -> None:
+    store.upsert_aigrp_peer(
+        l2_id=PEER_L2,
+        enterprise="acme",
+        group="engineering",
+        endpoint_url="http://peer.test",
+        embedding_centroid=None,
+        domain_bloom=None,
+        ku_count=0,
+        domain_count=0,
+        embedding_model=None,
+        signature_received=False,
+        public_key_ed25519=pubkey_b64u,
+    )
+
+
+def _forward_query_body(axis: int = 0) -> dict[str, Any]:
+    vec = [0.0] * 8
+    vec[axis] = 1.0
+    return {
+        "query_vec": vec,
+        "query_text": "cdn cache",
+        "requester_l2_id": PEER_L2,
+        "requester_enterprise": "acme",
+        "requester_group": "engineering",
+        "requester_persona": "alice",
+        "max_results": 5,
+    }
+
+
+class TestReceiverVerification:
+    def test_valid_signature_accepted(
+        self, aigrp_client: TestClient, peer_keypair: Ed25519PrivateKey
+    ) -> None:
+        store = _get_store()
+        _seed_peer(store, public_key_b64u(peer_keypair))
+        body = _forward_query_body()
+        sig = b64u(peer_keypair.sign(forward_sign.signing_input_for(body, PEER_L2)))
+        r = aigrp_client.post(
+            "/api/v1/aigrp/forward-query",
+            headers={
+                "authorization": f"Bearer {PEER_KEY}",
+                aigrp_mod.FORWARDER_HEADER: PEER_L2,
+                forward_sign.SIGNATURE_HEADER: sig,
+            },
+            json=body,
+        )
+        assert r.status_code == 200, r.text
+
+    def test_missing_signature_when_pubkey_on_file_403(
+        self, aigrp_client: TestClient, peer_keypair: Ed25519PrivateKey
+    ) -> None:
+        store = _get_store()
+        _seed_peer(store, public_key_b64u(peer_keypair))
+        body = _forward_query_body()
+        r = aigrp_client.post(
+            "/api/v1/aigrp/forward-query",
+            headers={
+                "authorization": f"Bearer {PEER_KEY}",
+                aigrp_mod.FORWARDER_HEADER: PEER_L2,
+            },
+            json=body,
+        )
+        assert r.status_code == 403
+        assert "missing" in r.json()["detail"].lower()
+
+    def test_tampered_body_rejected(
+        self, aigrp_client: TestClient, peer_keypair: Ed25519PrivateKey
+    ) -> None:
+        store = _get_store()
+        _seed_peer(store, public_key_b64u(peer_keypair))
+        body = _forward_query_body()
+        # Sign one body, send a different one.
+        sig = b64u(peer_keypair.sign(forward_sign.signing_input_for(body, PEER_L2)))
+        tampered = dict(body)
+        tampered["query_text"] = "DIFFERENT QUERY"
+        r = aigrp_client.post(
+            "/api/v1/aigrp/forward-query",
+            headers={
+                "authorization": f"Bearer {PEER_KEY}",
+                aigrp_mod.FORWARDER_HEADER: PEER_L2,
+                forward_sign.SIGNATURE_HEADER: sig,
+            },
+            json=tampered,
+        )
+        assert r.status_code == 403
+        assert "verification failed" in r.json()["detail"]
+
+    def test_signature_from_wrong_key_rejected(
+        self,
+        aigrp_client: TestClient,
+        peer_keypair: Ed25519PrivateKey,
+        other_keypair: Ed25519PrivateKey,
+    ) -> None:
+        store = _get_store()
+        _seed_peer(store, public_key_b64u(peer_keypair))
+        body = _forward_query_body()
+        # Signed with a *different* key than the one we recorded.
+        sig = b64u(other_keypair.sign(forward_sign.signing_input_for(body, PEER_L2)))
+        r = aigrp_client.post(
+            "/api/v1/aigrp/forward-query",
+            headers={
+                "authorization": f"Bearer {PEER_KEY}",
+                aigrp_mod.FORWARDER_HEADER: PEER_L2,
+                forward_sign.SIGNATURE_HEADER: sig,
+            },
+            json=body,
+        )
+        assert r.status_code == 403
+
+    def test_legacy_no_pubkey_accepted_with_warning(
+        self, aigrp_client: TestClient, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        store = _get_store()
+        _seed_peer(store, None)  # legacy peer
+        body = _forward_query_body()
+        with caplog.at_level(logging.WARNING, logger=aigrp_mod.logger.name):
+            r = aigrp_client.post(
+                "/api/v1/aigrp/forward-query",
+                headers={
+                    "authorization": f"Bearer {PEER_KEY}",
+                    aigrp_mod.FORWARDER_HEADER: PEER_L2,
+                },
+                json=body,
+            )
+        assert r.status_code == 200
+        assert any("legacy unsigned forward" in m for m in caplog.messages)
+
+    def test_strict_mode_rejects_legacy(
+        self, aigrp_client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store = _get_store()
+        _seed_peer(store, None)  # legacy peer
+        monkeypatch.setenv("CQ_REQUIRE_SIGNED_FORWARDS", "true")
+        body = _forward_query_body()
+        r = aigrp_client.post(
+            "/api/v1/aigrp/forward-query",
+            headers={
+                "authorization": f"Bearer {PEER_KEY}",
+                aigrp_mod.FORWARDER_HEADER: PEER_L2,
+            },
+            json=body,
+        )
+        assert r.status_code == 403
+        assert "strict mode" in r.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# 5. Sign/verify primitive
+# ---------------------------------------------------------------------------
+
+
+class TestSigningInput:
+    def test_signing_input_is_canonical_plus_l2_id(self) -> None:
+        body_a = {"a": 1, "b": 2}
+        body_b = {"b": 2, "a": 1}  # different dict order, same JCS
+        m1 = forward_sign.signing_input_for(body_a, "acme/eng")
+        m2 = forward_sign.signing_input_for(body_b, "acme/eng")
+        assert m1 == m2
+        # Different forwarder id -> different bytes.
+        m3 = forward_sign.signing_input_for(body_a, "acme/sol")
+        assert m1 != m3

--- a/server/backend/uv.lock
+++ b/server/backend/uv.lock
@@ -155,6 +155,76 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "cfgv"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -206,10 +276,13 @@ dependencies = [
     { name = "bcrypt" },
     { name = "boto3" },
     { name = "cq-sdk" },
+    { name = "cryptography" },
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "numpy" },
     { name = "pydantic" },
     { name = "pyjwt" },
+    { name = "rfc8785" },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -238,10 +311,13 @@ requires-dist = [
     { name = "bcrypt", specifier = ">=4.0" },
     { name = "boto3", specifier = ">=1.34" },
     { name = "cq-sdk", specifier = "~=0.9.1" },
+    { name = "cryptography", specifier = ">=42" },
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyjwt", specifier = ">=2.0" },
+    { name = "rfc8785", specifier = ">=0.1.4" },
     { name = "sqlalchemy", specifier = ">=2.0.49,<2.1" },
     { name = "uvicorn", extras = ["standard"] },
 ]
@@ -262,6 +338,65 @@ tests = [
     { name = "httpx" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+]
+
+[[package]]
+name = "cryptography"
+version = "47.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/b2/7ffa7fe8207a8c42147ffe70c3e360b228160c1d85dc3faff16aaa3244c0/cryptography-47.0.0.tar.gz", hash = "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb", size = 830863, upload-time = "2026-04-24T19:54:57.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/98/40dfe932134bdcae4f6ab5927c87488754bf9eb79297d7e0070b78dd58e9/cryptography-47.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0", size = 7912214, upload-time = "2026-04-24T19:53:03.864Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c6/2733531243fba725f58611b918056b277692f1033373dcc8bd01af1c05d4/cryptography-47.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973", size = 4644617, upload-time = "2026-04-24T19:53:06.909Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e3/b27be1a670a9b87f855d211cf0e1174a5d721216b7616bd52d8581d912ed/cryptography-47.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5c15764f261394b22aef6b00252f5195f46f2ca300bec57149474e2538b31f8", size = 4668186, upload-time = "2026-04-24T19:53:09.053Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b9/8443cfe5d17d482d348cee7048acf502bb89a51b6382f06240fd290d4ca3/cryptography-47.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9c59ab0e0fa3a180a5a9c59f3a5abe3ef90d474bc56d7fadfbe80359491b615b", size = 4651244, upload-time = "2026-04-24T19:53:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/5e/13ed0cdd0eb88ba159d6dd5ebfece8cb901dbcf1ae5ac4072e28b55d3153/cryptography-47.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:34b4358b925a5ea3e14384ca781a2c0ef7ac219b57bb9eacc4457078e2b19f92", size = 5252906, upload-time = "2026-04-24T19:53:13.532Z" },
+    { url = "https://files.pythonhosted.org/packages/64/16/ed058e1df0f33d440217cd120d41d5dda9dd215a80b8187f68483185af82/cryptography-47.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7", size = 4701842, upload-time = "2026-04-24T19:53:15.618Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3d30986b30fdbd9e969abbdf8ba00ed0618615144341faeb57f395a084fe/cryptography-47.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:1e47422b5557bb82d3fff997e8d92cff4e28b9789576984f08c248d2b3535d93", size = 4289313, upload-time = "2026-04-24T19:53:17.755Z" },
+    { url = "https://files.pythonhosted.org/packages/df/fd/32db38e3ad0cb331f0691cb4c7a8a6f176f679124dee746b3af6633db4d9/cryptography-47.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:6f29f36582e6151d9686235e586dd35bb67491f024767d10b842e520dc6a07ac", size = 4650964, upload-time = "2026-04-24T19:53:20.062Z" },
+    { url = "https://files.pythonhosted.org/packages/86/53/5395d944dfd48cb1f67917f533c609c34347185ef15eb4308024c876f274/cryptography-47.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a9b761f012a943b7de0e828843c5688d0de94a0578d44d6c85a1bae32f87791f", size = 5207817, upload-time = "2026-04-24T19:53:22.498Z" },
+    { url = "https://files.pythonhosted.org/packages/34/4f/e5711b28e1901f7d480a2b1b688b645aa4c77c73f10731ed17e7f7db3f0d/cryptography-47.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8", size = 4701544, upload-time = "2026-04-24T19:53:24.356Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/c8ddc25de3010fc8da447648f5a092c40e7a8fadf01dd6d255d9c0b9373d/cryptography-47.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef6b3634087f18d2155b1e8ce264e5345a753da2c5fa9815e7d41315c90f8318", size = 4783536, upload-time = "2026-04-24T19:53:26.665Z" },
+    { url = "https://files.pythonhosted.org/packages/66/b6/d4a68f4ea999c6d89e8498579cba1c5fcba4276284de7773b17e4fa69293/cryptography-47.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11dbb9f50a0f1bb9757b3d8c27c1101780efb8f0bdecfb12439c22a74d64c001", size = 4926106, upload-time = "2026-04-24T19:53:28.686Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ed/5f524db1fade9c013aa618e1c99c6ed05e8ffc9ceee6cda22fed22dda3f4/cryptography-47.0.0-cp311-abi3-win32.whl", hash = "sha256:7fda2f02c9015db3f42bb8a22324a454516ed10a8c29ca6ece6cdbb5efe2a203", size = 3258581, upload-time = "2026-04-24T19:53:31.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dc/1b901990b174786569029f67542b3edf72ac068b6c3c8683c17e6a2f5363/cryptography-47.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:f5c3296dab66202f1b18a91fa266be93d6aa0c2806ea3d67762c69f60adc71aa", size = 3775309, upload-time = "2026-04-24T19:53:33.054Z" },
+    { url = "https://files.pythonhosted.org/packages/14/88/7aa18ad9c11bc87689affa5ce4368d884b517502d75739d475fc6f4a03c7/cryptography-47.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:be12cb6a204f77ed968bcefe68086eb061695b540a3dd05edac507a3111b25f0", size = 7904299, upload-time = "2026-04-24T19:53:35.003Z" },
+    { url = "https://files.pythonhosted.org/packages/07/55/c18f75724544872f234678fdedc871391722cb34a2aee19faa9f63100bb2/cryptography-47.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2ebd84adf0728c039a3be2700289378e1c164afc6748df1a5ed456767bef9ba7", size = 4631180, upload-time = "2026-04-24T19:53:37.517Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/65/31a5cc0eaca99cec5bafffe155d407115d96136bb161e8b49e0ef73f09a7/cryptography-47.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f68d6fbc7fbbcfb0939fea72c3b96a9f9a6edfc0e1b1d29778a2066030418b1", size = 4653529, upload-time = "2026-04-24T19:53:39.775Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/bc/641c0519a495f3bfd0421b48d7cd325c4336578523ccd76ea322b6c29c7a/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:6651d32eff255423503aa276739da98c30f26c40cbeffcc6048e0d54ef704c0c", size = 4638570, upload-time = "2026-04-24T19:53:42.129Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f2/300327b0a47f6dc94dd8b71b57052aefe178bb51745073d73d80604f11ab/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3fb8fa48075fad7193f2e5496135c6a76ac4b2aa5a38433df0a539296b377829", size = 5238019, upload-time = "2026-04-24T19:53:44.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5a/5b5cf994391d4bf9d9c7efd4c66aabe4d95227256627f8fea6cff7dfadbd/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11438c7518132d95f354fa01a4aa2f806d172a061a7bed18cf18cbdacdb204d7", size = 4686832, upload-time = "2026-04-24T19:53:47.015Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2c/ae950e28fd6475c852fc21a44db3e6b5bcc1261d1e370f2b6e42fa800fef/cryptography-47.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8c1a736bbb3288005796c3f7ccb9453360d7fed483b13b9f468aea5171432923", size = 4269301, upload-time = "2026-04-24T19:53:48.97Z" },
+    { url = "https://files.pythonhosted.org/packages/67/fb/6a39782e150ffe5cc1b0018cb6ddc48bf7ca62b498d7539ffc8a758e977d/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:f1557695e5c2b86e204f6ce9470497848634100787935ab7adc5397c54abd7ab", size = 4638110, upload-time = "2026-04-24T19:53:51.011Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d7/0b3c71090a76e5c203164a47688b697635ece006dcd2499ab3a4dbd3f0bd/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:f9a034b642b960767fb343766ae5ba6ad653f2e890ddd82955aef288ffea8736", size = 5194988, upload-time = "2026-04-24T19:53:52.962Z" },
+    { url = "https://files.pythonhosted.org/packages/63/33/63a961498a9df51721ab578c5a2622661411fc520e00bd83b0cc64eb20c4/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b1c76fca783aa7698eb21eb14f9c4aa09452248ee54a627d125025a43f83e7a7", size = 4686563, upload-time = "2026-04-24T19:53:55.274Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/5ee5b145248f92250de86145d1c1d6edebbd57a7fe7caa4dedb5d4cf06a1/cryptography-47.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4f7722c97826770bab8ae92959a2e7b20a5e9e9bf4deae68fd86c3ca457bab52", size = 4770094, upload-time = "2026-04-24T19:53:57.753Z" },
+    { url = "https://files.pythonhosted.org/packages/92/43/21d220b2da5d517773894dacdcdb5c682c28d3fffce65548cb06e87d5501/cryptography-47.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:09f6d7bf6724f8db8b32f11eccf23efc8e759924bc5603800335cf8859a3ddbd", size = 4913811, upload-time = "2026-04-24T19:54:00.236Z" },
+    { url = "https://files.pythonhosted.org/packages/31/98/dc4ad376ac5f1a1a7d4a83f7b0c6f2bcad36b5d2d8f30aeb482d3a7d9582/cryptography-47.0.0-cp314-cp314t-win32.whl", hash = "sha256:6eebcaf0df1d21ce1f90605c9b432dd2c4f4ab665ac29a40d5e3fc68f51b5e63", size = 3237158, upload-time = "2026-04-24T19:54:02.606Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/da/97f62d18306b5133468bc3f8cc73a3111e8cdc8cf8d3e69474d6e5fd2d1b/cryptography-47.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:51c9313e90bd1690ec5a75ed047c27c0b8e6c570029712943d6116ef9a90620b", size = 3758706, upload-time = "2026-04-24T19:54:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/34/a4fae8ae7c3bc227460c9ae43f56abf1b911da0ec29e0ebac53bb0a4b6b7/cryptography-47.0.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:14432c8a9bcb37009784f9594a62fae211a2ae9543e96c92b2a8e4c3cd5cd0c4", size = 7904072, upload-time = "2026-04-24T19:54:06.411Z" },
+    { url = "https://files.pythonhosted.org/packages/01/64/d7b1e54fdb69f22d24a64bb3e88dc718b31c7fb10ef0b9691a3cf7eeea6e/cryptography-47.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27", size = 4635767, upload-time = "2026-04-24T19:54:08.519Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/7b/cca826391fb2a94efdcdfe4631eb69306ee1cff0b22f664a412c90713877/cryptography-47.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b45761c6ec22b7c726d6a829558777e32d0f1c8be7c3f3480f9c912d5ee8a10", size = 4654350, upload-time = "2026-04-24T19:54:10.795Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/65/4b57bcc823f42a991627c51c2f68c9fd6eb1393c1756aac876cba2accae2/cryptography-47.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:edd4da498015da5b9f26d38d3bfc2e90257bfa9cbed1f6767c282a0025ae649b", size = 4643394, upload-time = "2026-04-24T19:54:13.275Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/2c5fbeea70adbbca2bbae865e1d605d6a4a7f8dbd9d33eaf69645087f06c/cryptography-47.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9af828c0d5a65c70ec729cd7495a4bf1a67ecb66417b8f02ff125ab8a6326a74", size = 5225777, upload-time = "2026-04-24T19:54:15.18Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/b8/ac57107ef32749d2b244e36069bb688792a363aaaa3acc9e3cf84c130315/cryptography-47.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:256d07c78a04d6b276f5df935a9923275f53bd1522f214447fdf365494e2d515", size = 4688771, upload-time = "2026-04-24T19:54:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fc/9f1de22ff8be99d991f240a46863c52d475404c408886c5a38d2b5c3bb26/cryptography-47.0.0-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:5d0e362ff51041b0c0d219cc7d6924d7b8996f57ce5712bdcef71eb3c65a59cc", size = 4270753, upload-time = "2026-04-24T19:54:19.963Z" },
+    { url = "https://files.pythonhosted.org/packages/00/68/d70c852797aa68e8e48d12e5a87170c43f67bb4a59403627259dd57d15de/cryptography-47.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:1581aef4219f7ca2849d0250edaa3866212fb74bf5667284f46aa92f9e65c1ca", size = 4642911, upload-time = "2026-04-24T19:54:21.818Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/51/661cbee74f594c5d97ff82d34f10d5551c085ca4668645f4606ebd22bd5d/cryptography-47.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a49a3eb5341b9503fa3000a9a0db033161db90d47285291f53c2a9d2cd1b7f76", size = 5181411, upload-time = "2026-04-24T19:54:24.376Z" },
+    { url = "https://files.pythonhosted.org/packages/94/87/f2b6c374a82cf076cfa1416992ac8e8ec94d79facc37aec87c1a5cb72352/cryptography-47.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2207a498b03275d0051589e326b79d4cf59985c99031b05bb292ac52631c37fe", size = 4688262, upload-time = "2026-04-24T19:54:26.946Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e2/8b7462f4acf21ec509616f0245018bb197194ab0b65c2ea21a0bdd53c0eb/cryptography-47.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7a02675e2fabd0c0fc04c868b8781863cbf1967691543c22f5470500ff840b31", size = 4775506, upload-time = "2026-04-24T19:54:28.926Z" },
+    { url = "https://files.pythonhosted.org/packages/70/75/158e494e4c08dc05e039da5bb48553826bd26c23930cf8d3cd5f21fa8921/cryptography-47.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80887c5cbd1774683cb126f0ab4184567f080071d5acf62205acb354b4b753b7", size = 4912060, upload-time = "2026-04-24T19:54:30.869Z" },
+    { url = "https://files.pythonhosted.org/packages/06/bd/0a9d3edbf5eadbac926d7b9b3cd0c4be584eeeae4a003d24d9eda4affbbd/cryptography-47.0.0-cp38-abi3-win32.whl", hash = "sha256:ed67ea4e0cfb5faa5bc7ecb6e2b8838f3807a03758eec239d6c21c8769355310", size = 3248487, upload-time = "2026-04-24T19:54:33.494Z" },
+    { url = "https://files.pythonhosted.org/packages/60/80/5681af756d0da3a599b7bdb586fac5a1540f1bcefd2717a20e611ddade45/cryptography-47.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:835d2d7f47cdc53b3224e90810fb1d36ca94ea29cc1801fb4c1bc43876735769", size = 3755737, upload-time = "2026-04-24T19:54:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a0/928c9ce0d120a40a81aa99e3ba383e87337b9ac9ef9f6db02e4d7822424d/cryptography-47.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:7f1207974a904e005f762869996cf620e9bf79ecb4622f148550bb48e0eb35a7", size = 3909893, upload-time = "2026-04-24T19:54:38.334Z" },
+    { url = "https://files.pythonhosted.org/packages/81/75/d691e284750df5d9569f2b1ce4a00a71e1d79566da83b2b3e5549c84917f/cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:1a405c08857258c11016777e11c02bacbe7ef596faf259305d282272a3a05cbe", size = 4587867, upload-time = "2026-04-24T19:54:40.619Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d6/1b90f1a4e453009730b4545286f0b39bb348d805c11181fc31544e4f9a65/cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:20fdbe3e38fb67c385d233c89371fa27f9909f6ebca1cecc20c13518dae65475", size = 4627192, upload-time = "2026-04-24T19:54:42.849Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/53/cb358a80e9e359529f496870dd08c102aa8a4b5b9f9064f00f0d6ed5b527/cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:f7db373287273d8af1414cf95dc4118b13ffdc62be521997b0f2b270771fef50", size = 4587486, upload-time = "2026-04-24T19:54:44.908Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/57/aaa3d53876467a226f9a7a82fd14dd48058ad2de1948493442dfa16e2ffd/cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:9fe6b7c64926c765f9dff301f9c1b867febcda5768868ca084e18589113732ab", size = 4626327, upload-time = "2026-04-24T19:54:47.813Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/9c/51f28c3550276bcf35660703ba0ab829a90b88be8cd98a71ef23c2413913/cryptography-47.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:cffbba3392df0fa8629bb7f43454ee2925059ee158e23c54620b9063912b86c8", size = 3698916, upload-time = "2026-04-24T19:54:49.782Z" },
 ]
 
 [[package]]
@@ -682,6 +817,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -927,6 +1071,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "rfc8785"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/2f/fa1d2e740c490191b572d33dbca5daa180cb423c24396b856f5886371d8b/rfc8785-0.1.4.tar.gz", hash = "sha256:e545841329fe0eee4f6a3b44e7034343100c12b4ec566dc06ca9735681deb4da", size = 14321, upload-time = "2024-09-27T16:33:31.206Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/78/119878110660b2ad709888c8a1614fce7e2fab39080ab960656dc8605bf6/rfc8785-0.1.4-py3-none-any.whl", hash = "sha256:520d690b448ecf0703691c76e1a34a24ddcd4fc5bc41d589cb7c58ec651bcd48", size = 9240, upload-time = "2024-09-27T16:33:29.683Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Closes #44 — sibling-L2 forward-spoof inside an Enterprise. CRIT #34's partial fix bound `X-8L-Forwarder-L2-Id` to the body's `from_l2_id`/`requester_l2_id`, but every L2 in an Enterprise shares the same `EnterprisePeerKey` — sibling spoof was the residual gap. This sprint makes it cryptographic.
- Per-L2 Ed25519 keypair on disk (filesystem v1 at `CQ_AIGRP_L2_PRIVKEY_PATH`, default `/data/aigrp_l2_key.bin`, mode `0600`); KMS/HSM-backed v2 follow-up.
- Public key carried on every `/aigrp/hello` (initial + every poll re-hello so a peer who joined before its sibling generated a key recovers itself).
- Senders sign `JCS(canonical_body) || forwarder_l2_id_utf8` and ship sig in `X-8L-Forwarder-Sig`. Receivers look up the peer's pubkey from `aigrp_peers.public_key_ed25519` and verify; missing/bad sig from a known peer → 403; unknown-pubkey peer → WARNING + accept (legacy rollout window). `CQ_REQUIRE_SIGNED_FORWARDS=true` flips strict mode.
- Crypto primitives extracted into `cq_server/crypto.py`; directory_client keeps its own copies for sprint-3 stability (consolidation is a follow-up).

## What changed
- **Schema**: `aigrp_peers.public_key_ed25519 TEXT` via idempotent `ALTER TABLE`.
- **`cq_server/crypto.py`** (new, 140 LOC): shared `b64u`, `canonicalize`, `sign_envelope`/`verify_envelope_signature`, `sign_raw`/`verify_raw`, `load_private_key`, `public_key_b64u`, `fingerprint_sha256`.
- **`cq_server/forward_sign.py`** (new, 250 LOC): per-L2 keypair load/generate/cache, `sign_forward_request`, `verify_forward_signature`, `signing_input_for` (defines the `JCS(body) || l2_id` byte layout), `require_signed_forwards()` strict-mode flag.
- **`aigrp.require_forwarder_identity`**: extended with optional `body_for_sig` + `store` kwargs; verifies sig when peer pubkey known, falls back to legacy header-binding otherwise (with WARNING).
- **Sender paths**: `consults._forward_request`/`_forward_message` and `network._call_forward_query` add the sig header when this L2 has a key.
- **`/aigrp/hello`**: request schema gains optional `public_key_ed25519`; receiver upserts; response self_entry now carries this L2's pubkey so joiners can verify forwards FROM us.
- **`_aigrp_bootstrap_and_poll`**: re-hellos every peer on every poll cycle (idempotent on receiver) so a missed first hello is self-healing.
- **Tests**: 16 new in `test_ed25519_forward_signing.py`.

## Test plan
- [x] `pytest tests/test_ed25519_forward_signing.py` — 16/16 passing
- [x] `pytest tests/` (full suite) — 396/396 passing
- [x] Local-demo E2E: rebuilt `cq-server:sec-trio`, brought up `--profile acme`, AIGRP converged in ~30s, both peers showed non-NULL `public_key_ed25519`, cross-L2 consult `/forward-request` returned 201, spoof attempt (unsigned forward from peer with known pubkey) returned 403 `"missing x-8l-forwarder-sig header from signed peer"`.

## E2E excerpts
```
=== /aigrp/peers (acme-engineering view) ===
{"l2_id":"acme/solutions", ..., "public_key_ed25519":"vx-PPDgpY_oB_LYIFmFQt4h4_8JRwQAYYmzHNFs-AtQ"}

=== /aigrp/peers (acme-solutions view) ===
{"l2_id":"acme/engineering", ..., "public_key_ed25519":"3V6qq7iWxNrXXwj_H6TzewHI8bSj-iBNbT0afdjq84o"}

=== Cross-L2 consult forward (signed) ===
INFO: 172.21.0.2:48978 - "POST /api/v1/consults/forward-request HTTP/1.1" 201 Created

=== Spoof attempt rejected ===
HTTP=403 {"detail":"missing x-8l-forwarder-sig header from signed peer 'acme/engineering'"}
```

## Open question
The legacy path (no pubkey on file → WARNING + accept) is the rollout window. Once every peer has re-helloed, operators flip `CQ_REQUIRE_SIGNED_FORWARDS=true` cluster-wide. What's the operator signal to consider rollout complete? A reaper that scans `aigrp_peers` and asserts no NULL pubkey would do it — worth a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)