### PR TITLE
[x-enterprise] sprint 4 Track A phase 1 — sender-side cross-Enterprise consult forward

### DIFF
--- a/server/backend/src/cq_server/consults.py
+++ b/server/backend/src/cq_server/consults.py
@@ -19,6 +19,7 @@ service token; out of scope here.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 from datetime import UTC, datetime
@@ -30,6 +31,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from . import aigrp as aigrp_mod
+from . import forward_sign
 from .auth import get_current_user
 from .deps import get_store
 from .store import RemoteStore
@@ -240,6 +242,127 @@ def _forward_message(target: dict[str, Any], payload: dict[str, Any]) -> None:
         ) from e
 
 
+def _resolve_x_enterprise_target(
+    store: RemoteStore, to_l2_id: str, self_enterprise: str
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    """Resolve a cross-Enterprise consult target via the directory peering mirror.
+
+    Returns ``(peering_row, target_endpoint_row)`` when an active peering
+    exists between this enterprise and the target's enterprise, AND the
+    target l2_id appears in the peering's ``to_l2_endpoints_json`` roster
+    (the directory's snapshot of the other side's L2s at peering time).
+    Returns None when no peering exists or the target L2 isn't in the
+    peering's roster.
+
+    The bearer + per-L2 sig auth on the wire is derived from the
+    returned peering record (caller composes via ``forward_sign``).
+    """
+    try:
+        target_enterprise, _ = to_l2_id.split("/", 1)
+    except ValueError:
+        return None
+    if target_enterprise == self_enterprise:
+        # Caller should have routed this as same-Enterprise — defensive guard.
+        return None
+    peering = store.find_active_directory_peering(
+        from_enterprise=self_enterprise,
+        to_enterprise=target_enterprise,
+    )
+    if peering is None:
+        return None
+    try:
+        endpoints = json.loads(peering.get("to_l2_endpoints_json") or "[]")
+    except (json.JSONDecodeError, TypeError):
+        endpoints = []
+    for ep in endpoints:
+        if isinstance(ep, dict) and ep.get("l2_id") == to_l2_id:
+            return peering, ep
+    return None
+
+
+X_ENTERPRISE_FORWARD_PATH = "/api/v1/consults/x-enterprise-forward-request"
+
+
+def _x_enterprise_forward_request(
+    peering: dict[str, Any],
+    target_endpoint: dict[str, Any],
+    payload: dict[str, Any],
+) -> None:
+    """POST a cross-Enterprise consult forward to the peer L2.
+
+    Auth on the wire is **two-layer**:
+
+    1. ``Authorization: Bearer <peering-bearer>`` — derived locally
+       from the peering's offer + accept signatures (HKDF-SHA256). The
+       receiver, also a party to this peering, derives the same bearer
+       and matches. This proves "the sender knows about an active
+       peering between us and them."
+
+    2. ``X-8L-Forwarder-Sig`` (when this L2 has an Ed25519 keypair on
+       disk per sprint-4 PR #53) — Ed25519 signature over the canonical
+       request body + forwarder l2_id. The receiver looks up the
+       forwarder's pubkey from its peering record's roster and verifies.
+       This proves "this specific L2 within the sender's enterprise
+       sent this forward."
+
+    Plus the ``X-8L-Forwarder-L2-Id`` and ``X-8L-Peering-Offer-Id``
+    headers so the receiver can look up the relevant peering + pubkey
+    deterministically.
+
+    Best-effort like the same-Enterprise forward path. Failure does NOT
+    roll back the local mirror write.
+    """
+    base = target_endpoint["endpoint_url"].rstrip("/")
+    bearer = forward_sign.derive_peering_bearer(
+        peering["offer_signature_b64u"],
+        peering["accept_signature_b64u"],
+    )
+    forwarder_id = _self_l2_id()
+    headers: dict[str, str] = {
+        "authorization": f"Bearer {bearer}",
+        aigrp_mod.FORWARDER_HEADER: forwarder_id,
+        "x-8l-peering-offer-id": peering["offer_id"],
+    }
+    sig = forward_sign.sign_forward_request(payload, forwarder_id)
+    if sig:
+        headers[forward_sign.SIGNATURE_HEADER] = sig
+    try:
+        with httpx.Client(timeout=L2_FORWARD_TIMEOUT) as client:
+            r = client.post(
+                f"{base}{X_ENTERPRISE_FORWARD_PATH}",
+                headers=headers,
+                json=payload,
+            )
+        if r.status_code >= 400:
+            raise HTTPException(
+                status_code=502,
+                detail=(
+                    f"peer {target_endpoint['l2_id']} returned {r.status_code} "
+                    f"on x-enterprise-forward-request: {r.text[:200]}"
+                ),
+            )
+    except httpx.RequestError as e:
+        raise HTTPException(
+            status_code=502,
+            detail=f"peer {target_endpoint['l2_id']} unreachable: {e}",
+        ) from e
+
+
+def _redact_for_policy(content: str, policy: str) -> str:
+    """Apply ``consult_logging_policy`` to a message body for local storage.
+
+    Per directory-v1 spec + decisions/10:
+    - mutual_log_required → store full content
+    - summary_only_log    → redact body, keep thread metadata only
+    - no_log_consults     → caller skips the message-row write entirely;
+                            this helper still returns a redacted string
+                            for any path that does insist on writing.
+    """
+    if policy == "mutual_log_required":
+        return content
+    return f"<redacted: {policy}>"
+
+
 def _to_thread_out(row: dict[str, Any]) -> ConsultThreadOut:
     return ConsultThreadOut(
         thread_id=row["thread_id"],
@@ -275,42 +398,68 @@ def request_consult(
     a single round-trip is sufficient for the asker.
     """
     self_l2_id, self_persona = _self_identity(store, username)
+    self_enterprise = aigrp_mod.enterprise()
 
     thread_id = f"th_{uuid4().hex[:16]}"
     msg_id = f"msg_{uuid4().hex[:16]}"
     now = _now_iso()
 
-    # Resolve cross-L2 target if the recipient lives on a different L2.
-    is_same_l2 = body.to_l2_id == self_l2_id
+    # Three routing modes:
+    #   1. same-L2 (this process)               — no forward
+    #   2. cross-L2 same-Enterprise              — forward via AIGRP peer table + EnterprisePeerKey
+    #   3. cross-Enterprise                      — forward via directory peering mirror + per-pair bearer
     target_peer: dict[str, Any] | None = None
+    x_enterprise: tuple[dict[str, Any], dict[str, Any]] | None = None
+    target_logging_policy = "mutual_log_required"  # default for same-L2 / same-Enterprise
+
+    is_same_l2 = body.to_l2_id == self_l2_id
 
     if not is_same_l2:
-        target_peer = _resolve_peer(store, body.to_l2_id)
-        if target_peer is None:
+        # Distinguish same-Enterprise (uses AIGRP peer table) from
+        # cross-Enterprise (uses directory peering mirror).
+        try:
+            target_enterprise, _ = body.to_l2_id.split("/", 1)
+        except ValueError:
             raise HTTPException(
-                status_code=404,
-                detail=(
-                    f"target L2 {body.to_l2_id!r} is not in this L2's AIGRP peer "
-                    "table — either it's not in the same Enterprise or AIGRP "
-                    "hasn't converged yet. Cross-Enterprise consults will use "
-                    "AI-BGP (issue #19), not yet shipped."
-                ),
+                status_code=400,
+                detail=f"to_l2_id {body.to_l2_id!r} must be enterprise/group form",
+            ) from None
+
+        if target_enterprise == self_enterprise:
+            # Same-Enterprise — must be in AIGRP peer table.
+            target_peer = _resolve_peer(store, body.to_l2_id)
+            if target_peer is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=(
+                        f"target L2 {body.to_l2_id!r} is not in this L2's AIGRP "
+                        "peer table — AIGRP hasn't converged yet or the L2 is "
+                        "not part of this Enterprise."
+                    ),
+                )
+        else:
+            # Cross-Enterprise — must have an active directory peering.
+            x_enterprise = _resolve_x_enterprise_target(
+                store, body.to_l2_id, self_enterprise
             )
-        # Cross-Enterprise reach is gated on AI-BGP. Today it's just a
-        # peer-table lookup — same-Enterprise only by virtue of how the
-        # peer table is populated. Belt-and-braces guard:
-        if target_peer["enterprise"] != aigrp_mod.enterprise():
-            raise HTTPException(
-                status_code=501,
-                detail=(
-                    "cross-Enterprise consult routing is on the roadmap "
-                    "(issue #19 AI-BGP); same-Enterprise cross-Group works today."
-                ),
-            )
+            if x_enterprise is None:
+                raise HTTPException(
+                    status_code=403,
+                    detail=(
+                        f"no active peering covers {body.to_l2_id!r}. Either "
+                        "no peering exists with enterprise "
+                        f"{target_enterprise!r}, or the target L2 is not in the "
+                        "peering's roster."
+                    ),
+                )
+            peering_row, _ep = x_enterprise
+            target_logging_policy = peering_row["consult_logging_policy"]
 
     # Mirror-write the thread + opening message LOCALLY first. This is
     # the asker's audit point: even if the forward fails, the asker's
     # L2 has a durable record of "I tried to consult X on Y at T".
+    # Logging-policy applies to the asker side too — for symmetry — so
+    # both ends honor the same policy on what gets persisted.
     store.create_consult(
         thread_id=thread_id,
         from_l2_id=self_l2_id,
@@ -320,29 +469,36 @@ def request_consult(
         subject=body.subject,
         created_at=now,
     )
-    store.append_consult_message(
-        message_id=msg_id,
-        thread_id=thread_id,
-        from_l2_id=self_l2_id,
-        from_persona=self_persona,
-        content=body.content,
-        created_at=now,
-    )
+    if target_logging_policy != "no_log_consults":
+        store.append_consult_message(
+            message_id=msg_id,
+            thread_id=thread_id,
+            from_l2_id=self_l2_id,
+            from_persona=self_persona,
+            content=_redact_for_policy(body.content, target_logging_policy),
+            created_at=now,
+        )
 
-    # Forward to the recipient L2 if cross-L2. Both sides log = the
-    # routing-through-L2 corporate-IP audit point per decisions/10.
+    forward_payload = {
+        "thread_id": thread_id,
+        "message_id": msg_id,
+        "from_l2_id": self_l2_id,
+        "from_persona": self_persona,
+        "to_l2_id": body.to_l2_id,
+        "to_persona": body.to_persona,
+        "subject": body.subject,
+        "content": body.content,
+        "created_at": now,
+    }
+
+    # Forward via the appropriate path. Both sides log per the
+    # logging policy = the routing-through-L2 corporate-IP audit point
+    # per decisions/10.
     if target_peer is not None:
-        _forward_request(target_peer, {
-            "thread_id": thread_id,
-            "message_id": msg_id,
-            "from_l2_id": self_l2_id,
-            "from_persona": self_persona,
-            "to_l2_id": body.to_l2_id,
-            "to_persona": body.to_persona,
-            "subject": body.subject,
-            "content": body.content,
-            "created_at": now,
-        })
+        _forward_request(target_peer, forward_payload)
+    elif x_enterprise is not None:
+        peering_row, target_endpoint = x_enterprise
+        _x_enterprise_forward_request(peering_row, target_endpoint, forward_payload)
 
     row = store.get_consult(thread_id)
     assert row is not None  # just inserted

--- a/server/backend/src/cq_server/directory_client.py
+++ b/server/backend/src/cq_server/directory_client.py
@@ -346,6 +346,11 @@ async def _pull_and_persist_once(
                 accept_signature_b64u=rec["accept_signature"],
                 accept_signing_key_id=rec["accept_signing_key_id"],
                 last_synced_at=now_iso(),
+                # Sprint-4 Track A — persist the directory's roster snapshot
+                # of the OTHER enterprise's L2s so cross-Enterprise consult
+                # forwards can resolve the target endpoint locally without
+                # per-request directory round-trips.
+                to_l2_endpoints_json=json.dumps(rec.get("to_l2_endpoints") or []),
             )
             persisted += 1
     return persisted

--- a/server/backend/src/cq_server/forward_sign.py
+++ b/server/backend/src/cq_server/forward_sign.py
@@ -49,10 +49,13 @@ import secrets
 from pathlib import Path
 from typing import Any
 
+from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 
 from .crypto import (
     b64u,
+    b64u_decode,
     canonicalize,
     public_key_b64u,
     sign_raw,
@@ -232,12 +235,57 @@ def verify_forward_signature(
     )
 
 
+# ---------------------------------------------------------------------------
+# Cross-Enterprise peering bearer derivation (sprint 4 Track A phase 1)
+# ---------------------------------------------------------------------------
+
+
+X_ENTERPRISE_BEARER_INFO = b"8l-x-enterprise-bearer-v1"
+X_ENTERPRISE_BEARER_HEADER = "x-8l-peering-bearer"
+
+
+def derive_peering_bearer(offer_signature_b64u: str, accept_signature_b64u: str) -> str:
+    """Derive a 32-byte symmetric bearer from a peering's bilateral sigs.
+
+    Both sides of an active peering can compute this independently with
+    no out-of-band exchange — the input material is the publicly-served
+    offer + accept signatures (both are on the peering record returned
+    by ``GET /peerings/{enterprise_id}``). HKDF-SHA256 with a versioned
+    info string gives us cheap rotation by changing the info-string
+    version when the wire format evolves.
+
+    The bearer is **NOT a secret** in the cryptographic sense. Anyone
+    who can read the public peering record can compute it. It serves
+    as a *peering identifier* — a sender presenting it asserts "I am
+    a party to a peering between us." Identity (which specific L2
+    forwarded) is provided by the per-L2 Ed25519 sig (sprint-4 forward
+    signing); auth (the peering itself is real) is provided by the
+    bilateral signatures the receiver re-verifies locally against
+    published enterprise root keys.
+
+    Compromise of one peering's bearer does not reveal others (per-pair
+    derivation; HKDF input differs). Bearer rotates whenever a peering
+    is renewed (new offer/accept sigs => new bearer).
+    """
+    ikm = b64u_decode(offer_signature_b64u) + b64u_decode(accept_signature_b64u)
+    derived = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=None,
+        info=X_ENTERPRISE_BEARER_INFO,
+    ).derive(ikm)
+    return b64u(derived)
+
+
 # Convenience: expose the b64u helper on this module so callers can
 # encode peer pubkeys for the wire without reaching into ``crypto``.
 __all__ = [
     "DEFAULT_PRIVKEY_PATH",
     "SIGNATURE_HEADER",
+    "X_ENTERPRISE_BEARER_HEADER",
+    "X_ENTERPRISE_BEARER_INFO",
     "b64u",
+    "derive_peering_bearer",
     "get_l2_privkey",
     "load_or_create_l2_privkey",
     "privkey_path",

--- a/server/backend/src/cq_server/store/__init__.py
+++ b/server/backend/src/cq_server/store/__init__.py
@@ -1022,12 +1022,17 @@ class RemoteStore:
         accept_signature_b64u: str,
         accept_signing_key_id: str,
         last_synced_at: str,
+        to_l2_endpoints_json: str = "[]",
     ) -> None:
         """Mirror one verified peering record from the directory pull loop.
 
         Both signatures (offer + accept) are persisted alongside the
         canonical payloads so any later code can re-verify offline
-        without going back to the directory.
+        without going back to the directory. ``to_l2_endpoints_json`` is
+        the directory's roster snapshot of the *other* enterprise's L2s
+        at peering time — used by the cross-Enterprise consult forward
+        path to resolve the target endpoint without per-request
+        directory round-trips (sprint 4 Track A).
         """
         self._check_open()
         with self._lock, self._conn:
@@ -1039,8 +1044,8 @@ class RemoteStore:
                     active_from, expires_at,
                     offer_payload_canonical, offer_signature_b64u, offer_signing_key_id,
                     accept_payload_canonical, accept_signature_b64u, accept_signing_key_id,
-                    last_synced_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    last_synced_at, to_l2_endpoints_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(offer_id) DO UPDATE SET
                     status = excluded.status,
                     content_policy = excluded.content_policy,
@@ -1054,7 +1059,8 @@ class RemoteStore:
                     accept_payload_canonical = excluded.accept_payload_canonical,
                     accept_signature_b64u = excluded.accept_signature_b64u,
                     accept_signing_key_id = excluded.accept_signing_key_id,
-                    last_synced_at = excluded.last_synced_at
+                    last_synced_at = excluded.last_synced_at,
+                    to_l2_endpoints_json = excluded.to_l2_endpoints_json
                 """,
                 (
                     offer_id, from_enterprise, to_enterprise, status,
@@ -1062,9 +1068,47 @@ class RemoteStore:
                     active_from, expires_at,
                     offer_payload_canonical, offer_signature_b64u, offer_signing_key_id,
                     accept_payload_canonical, accept_signature_b64u, accept_signing_key_id,
-                    last_synced_at,
+                    last_synced_at, to_l2_endpoints_json,
                 ),
             )
+
+    def find_active_directory_peering(
+        self,
+        *,
+        from_enterprise: str,
+        to_enterprise: str,
+        now_iso: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Find an active, unexpired peering between two specific enterprises.
+
+        Peerings are bidirectional — a peering from A → B is the same as
+        one from B → A. Returns the row when ``status = 'active'`` AND
+        ``expires_at > now``, otherwise None. ``now_iso`` is injectable for
+        deterministic tests; defaults to current UTC time.
+        """
+        self._check_open()
+        if now_iso is None:
+            now_iso = datetime.now(UTC).isoformat()
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM aigrp_directory_peerings "
+                "WHERE status = 'active' "
+                "AND ((from_enterprise = ? AND to_enterprise = ?) "
+                "  OR (from_enterprise = ? AND to_enterprise = ?)) "
+                "AND expires_at > ? "
+                "ORDER BY active_from DESC LIMIT 1",
+                (
+                    from_enterprise, to_enterprise,
+                    to_enterprise, from_enterprise,
+                    now_iso,
+                ),
+            ).fetchone()
+            if row is None:
+                return None
+            cols = [c[0] for c in self._conn.execute(
+                "SELECT * FROM aigrp_directory_peerings LIMIT 0"
+            ).description]
+        return dict(zip(cols, row, strict=True))
 
     def list_directory_peerings(
         self,

--- a/server/backend/src/cq_server/tables.py
+++ b/server/backend/src/cq_server/tables.py
@@ -254,7 +254,8 @@ CREATE TABLE IF NOT EXISTS aigrp_directory_peerings (
     accept_payload_canonical  TEXT NOT NULL,
     accept_signature_b64u     TEXT NOT NULL,
     accept_signing_key_id     TEXT NOT NULL,
-    last_synced_at            TEXT NOT NULL
+    last_synced_at            TEXT NOT NULL,
+    to_l2_endpoints_json      TEXT NOT NULL DEFAULT '[]'
 );
 CREATE INDEX IF NOT EXISTS idx_directory_peerings_from
     ON aigrp_directory_peerings(from_enterprise, status);
@@ -262,15 +263,36 @@ CREATE INDEX IF NOT EXISTS idx_directory_peerings_to
     ON aigrp_directory_peerings(to_enterprise, status);
 """
 
+# Sprint-4 additive — Track A phase 1. The directory's GET /peerings
+# response carries `to_l2_endpoints` (a roster snapshot of the OTHER
+# enterprise's L2s at peering time). The L2 directory client now
+# persists that JSON so cross-Enterprise consult forwards can resolve
+# the target L2 endpoint without a directory round-trip per request.
+_DIRECTORY_PEERINGS_NEW_COLUMNS = [
+    "ALTER TABLE aigrp_directory_peerings ADD COLUMN to_l2_endpoints_json TEXT NOT NULL DEFAULT '[]'",
+]
+
 
 def ensure_directory_peerings_schema(conn: sqlite3.Connection) -> None:
     """Create aigrp_directory_peerings table.
 
     Sprint 3 — local mirror of peering records pulled from the public
     8th-Layer Directory. Each row carries BOTH signed envelopes (offer
-    + accept) so any local consumer can re-verify offline. Idempotent.
+    + accept) so any local consumer can re-verify offline.
+
+    Sprint 4 (Track A phase 1) — additive ``to_l2_endpoints_json``
+    column for cross-Enterprise consult forward routing. Idempotent.
     """
     conn.executescript(DIRECTORY_PEERINGS_TABLE_SQL)
+    # Idempotent ADD COLUMN for pre-sprint-4 DBs. SQLite's
+    # `ALTER TABLE ... ADD COLUMN` raises on already-present columns
+    # so we probe table_info first.
+    cursor = conn.execute("PRAGMA table_info(aigrp_directory_peerings)")
+    existing = {row[1] for row in cursor.fetchall()}
+    for stmt in _DIRECTORY_PEERINGS_NEW_COLUMNS:
+        col_name = stmt.split("ADD COLUMN ")[1].split()[0]
+        if col_name not in existing:
+            conn.execute(stmt)
 
 
 def ensure_consults_schema(conn: sqlite3.Connection) -> None:

--- a/server/backend/tests/test_consults.py
+++ b/server/backend/tests/test_consults.py
@@ -249,12 +249,14 @@ def test_closed_thread_excluded_from_inbox_by_default(client: TestClient) -> Non
 # ---------------------------------------------------------------------------
 
 
-def test_cross_l2_target_unknown_peer_returns_404(client: TestClient) -> None:
-    """Cross-L2 to a peer not in this L2's AIGRP table returns 404.
+def test_cross_l2_unreachable_target_is_rejected(client: TestClient) -> None:
+    """Cross-L2 to an unreachable peer is rejected with 403 or 404.
 
-    Same-Enterprise different-Group works once AIGRP has converged
-    (covered separately in test_cross_l2_routing.py with a stubbed
-    peer table). Cross-Enterprise still 501 — gated on AI-BGP (#19).
+    The test fixture's enterprise is the default — so ``acme/solutions``
+    is a cross-Enterprise target with no active directory peering →
+    403 'no active peering'. (Pre-sprint-4: was 501 'AI-BGP roadmap'.
+    Pre-Track-A: was 404 'AIGRP peer table'.) Both flavours of
+    'unreachable' are rejected before any side effects.
     """
     r = client.post(
         "/api/v1/consults/request",
@@ -265,11 +267,8 @@ def test_cross_l2_target_unknown_peer_returns_404(client: TestClient) -> None:
             "content": "hi from engineering",
         },
     )
-    # No peer in the AIGRP table for this test fixture's enterprise,
-    # so we get 404 not 201. The forward path itself is exercised in
-    # test_cross_l2_routing.py.
-    assert r.status_code == 404, r.text
-    assert "AIGRP peer table" in r.json()["detail"]
+    assert r.status_code == 403, r.text
+    assert "no active peering" in r.json()["detail"].lower()
 
 
 # ---------------------------------------------------------------------------

--- a/server/backend/tests/test_cross_l2_routing.py
+++ b/server/backend/tests/test_cross_l2_routing.py
@@ -222,8 +222,14 @@ def test_cross_l2_message_forwards_to_other_side(
     assert forwarded[0]["json"]["from_persona"] == ALICE
 
 
-def test_cross_enterprise_target_returns_501(client: TestClient) -> None:
-    """A peer in a different Enterprise is gated until AI-BGP (issue #19)."""
+def test_cross_enterprise_no_peering_returns_403(client: TestClient) -> None:
+    """A peer in a different Enterprise needs an active directory peering.
+
+    Sprint 4 Track A: 501 (AI-BGP roadmap) is now 403 ("no active
+    peering"). Without a row in aigrp_directory_peerings between us
+    and the target enterprise, the cross-Enterprise forward path
+    refuses to route.
+    """
     r = client.post(
         "/api/v1/consults/request",
         headers=_headers(client, ALICE),
@@ -233,8 +239,8 @@ def test_cross_enterprise_target_returns_501(client: TestClient) -> None:
             "content": "hi from across the boundary",
         },
     )
-    assert r.status_code == 501, r.text
-    assert "AI-BGP" in r.json()["detail"]
+    assert r.status_code == 403, r.text
+    assert "no active peering" in r.json()["detail"].lower()
 
 
 def test_unknown_peer_returns_404(client: TestClient) -> None:

--- a/server/backend/tests/test_x_enterprise_consult.py
+++ b/server/backend/tests/test_x_enterprise_consult.py
@@ -1,0 +1,444 @@
+"""Sprint 4 Track A — cross-Enterprise consult forward (sender side).
+
+Phase 1 covers:
+- bearer derivation from a peering's bilateral signatures (HKDF)
+- find_active_directory_peering store method
+- consults.py /request routes cross-Enterprise via the directory peering
+  mirror when target enterprise differs from ours
+- 403 'no active peering' when no peering covers the target's enterprise
+- 403 when the peering exists but the target L2 isn't in the roster
+- consult_logging_policy from the peering applies to the asker-side
+  mirror-write (mutual_log_required full body, summary_only_log redacted,
+  no_log_consults skip-write)
+- forward call goes to the new x-enterprise-forward-request path with
+  per-pair bearer + Ed25519 sig
+
+Phase 2 (receiver side) is a separate test file landing with that PR.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import bcrypt
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from cq_server import consults, forward_sign
+from cq_server.app import _get_store, app
+
+ALICE = "alice"  # acme/engineering — this L2
+
+ACME_PEER_KEY = "test-acme-peer-key-thirty-two-chars"
+
+# A pre-built peering record from acme to globex (test enterprises). The
+# offer / accept signatures are arbitrary 64-byte b64u strings — the
+# sender side only derives the bearer from them, never re-verifies.
+_FAKE_OFFER_SIG = "iuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiuiu"
+_FAKE_ACCEPT_SIG = "abababababababababababababababababababababababababababababababababababababababababababab"
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "xent.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    monkeypatch.setenv("CQ_AIGRP_PEER_KEY", ACME_PEER_KEY)
+    monkeypatch.setenv("CQ_ENTERPRISE", "acme")
+    monkeypatch.setenv("CQ_GROUP", "engineering")
+    monkeypatch.setenv("CQ_AIGRP_L2_PRIVKEY_PATH", str(tmp_path / "l2.key"))
+
+    # Reset cached privkey across tests
+    forward_sign._cached_privkey = None
+    forward_sign._cached_loaded = False
+
+    with TestClient(app) as c:
+        store = _get_store()
+        # Seed alice as a real user
+        pw = bcrypt.hashpw(b"pw", bcrypt.gensalt()).decode()
+        store.create_user(ALICE, pw)
+        with store._lock, store._conn:
+            store._conn.execute(
+                "UPDATE users SET enterprise_id = ?, group_id = ? WHERE username = ?",
+                ("acme", "engineering", ALICE),
+            )
+        yield c
+
+
+def _login(client: TestClient, who: str = ALICE) -> str:
+    r = client.post("/api/v1/auth/login", json={"username": who, "password": "pw"})
+    assert r.status_code == 200, r.text
+    return r.json()["token"]
+
+
+def _seed_peering(
+    *,
+    offer_id: str,
+    from_ent: str = "acme",
+    to_ent: str = "globex",
+    status: str = "active",
+    expires_at: str = "2099-01-01T00:00:00Z",
+    consult_logging_policy: str = "mutual_log_required",
+    to_l2_endpoints: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    if to_l2_endpoints is None:
+        to_l2_endpoints = [
+            {
+                "l2_id": f"{to_ent}/eng",
+                "endpoint_url": f"https://{to_ent}-eng.example.com",
+                "groups": ["eng"],
+            }
+        ]
+    store = _get_store()
+    store.upsert_directory_peering(
+        offer_id=offer_id,
+        from_enterprise=from_ent,
+        to_enterprise=to_ent,
+        status=status,
+        content_policy="summary_only",
+        consult_logging_policy=consult_logging_policy,
+        topic_filters_json="[]",
+        active_from="2026-01-01T00:00:00Z",
+        expires_at=expires_at,
+        offer_payload_canonical='{"offer_id":"' + offer_id + '"}',
+        offer_signature_b64u=_FAKE_OFFER_SIG,
+        offer_signing_key_id="from-key",
+        accept_payload_canonical='{"accepted":true}',
+        accept_signature_b64u=_FAKE_ACCEPT_SIG,
+        accept_signing_key_id="to-key",
+        last_synced_at="2026-05-02T00:00:00Z",
+        to_l2_endpoints_json=json.dumps(to_l2_endpoints),
+    )
+    return {
+        "offer_id": offer_id,
+        "from_enterprise": from_ent,
+        "to_enterprise": to_ent,
+        "to_l2_endpoints": to_l2_endpoints,
+    }
+
+
+def _capture_x_enterprise_forwards(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[dict[str, Any]]:
+    """Patch consults._x_enterprise_forward_request to record the call rather than POST."""
+    captured: list[dict[str, Any]] = []
+
+    def _fake_x_enterprise_forward(
+        peering: dict[str, Any],
+        target_endpoint: dict[str, Any],
+        payload: dict[str, Any],
+    ) -> None:
+        captured.append({
+            "peering": peering,
+            "target_endpoint": target_endpoint,
+            "payload": payload,
+        })
+
+    monkeypatch.setattr(consults, "_x_enterprise_forward_request", _fake_x_enterprise_forward)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# Bearer derivation
+# ---------------------------------------------------------------------------
+
+
+def test_bearer_derivation_is_deterministic() -> None:
+    """Both sides of a peering compute the same bearer."""
+    b1 = forward_sign.derive_peering_bearer(_FAKE_OFFER_SIG, _FAKE_ACCEPT_SIG)
+    b2 = forward_sign.derive_peering_bearer(_FAKE_OFFER_SIG, _FAKE_ACCEPT_SIG)
+    assert b1 == b2
+    assert len(b1) >= 40  # base64url of 32 bytes
+
+
+def test_bearer_derivation_changes_with_signature_change() -> None:
+    """A renewed peering (different sigs) yields a different bearer."""
+    b1 = forward_sign.derive_peering_bearer(_FAKE_OFFER_SIG, _FAKE_ACCEPT_SIG)
+    new_offer = _FAKE_OFFER_SIG.replace("i", "j")  # different valid b64u
+    b2 = forward_sign.derive_peering_bearer(new_offer, _FAKE_ACCEPT_SIG)
+    assert b1 != b2
+
+
+def test_bearer_swap_yields_different_bearer() -> None:
+    """Argument order matters — sigs are concatenated, not symmetric."""
+    a = forward_sign.derive_peering_bearer(_FAKE_OFFER_SIG, _FAKE_ACCEPT_SIG)
+    b = forward_sign.derive_peering_bearer(_FAKE_ACCEPT_SIG, _FAKE_OFFER_SIG)
+    assert a != b
+
+
+# ---------------------------------------------------------------------------
+# Store: find_active_directory_peering
+# ---------------------------------------------------------------------------
+
+
+def test_find_active_peering_returns_match(client: TestClient) -> None:
+    _seed_peering(offer_id="off_a")
+    p = _get_store().find_active_directory_peering(
+        from_enterprise="acme", to_enterprise="globex"
+    )
+    assert p is not None
+    assert p["offer_id"] == "off_a"
+
+
+def test_find_active_peering_is_bidirectional(client: TestClient) -> None:
+    """Peering from A→B is also queryable as B→A."""
+    _seed_peering(offer_id="off_b", from_ent="acme", to_ent="globex")
+    p = _get_store().find_active_directory_peering(
+        from_enterprise="globex", to_enterprise="acme"
+    )
+    assert p is not None
+    assert p["offer_id"] == "off_b"
+
+
+def test_find_active_peering_skips_expired(client: TestClient) -> None:
+    """Past expires_at = no row."""
+    _seed_peering(offer_id="off_old", expires_at="2020-01-01T00:00:00Z")
+    p = _get_store().find_active_directory_peering(
+        from_enterprise="acme", to_enterprise="globex"
+    )
+    assert p is None
+
+
+def test_find_active_peering_skips_non_active(client: TestClient) -> None:
+    _seed_peering(offer_id="off_pending", status="pending")
+    p = _get_store().find_active_directory_peering(
+        from_enterprise="acme", to_enterprise="globex"
+    )
+    assert p is None
+
+
+# ---------------------------------------------------------------------------
+# Cross-Enterprise consult routing on /api/v1/consults/request
+# ---------------------------------------------------------------------------
+
+
+def test_cross_enterprise_routes_via_directory_peering(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_peering(offer_id="off_e2e")
+    captured = _capture_x_enterprise_forwards(monkeypatch)
+    token = _login(client)
+
+    r = client.post(
+        "/api/v1/consults/request",
+        headers={"authorization": f"Bearer {token}"},
+        json={
+            "to_l2_id": "globex/eng",
+            "to_persona": "their_alice",
+            "content": "cross-enterprise hello",
+        },
+    )
+    assert r.status_code == 201, r.text
+    assert len(captured) == 1
+    forward = captured[0]
+    assert forward["peering"]["offer_id"] == "off_e2e"
+    assert forward["target_endpoint"]["l2_id"] == "globex/eng"
+    assert forward["payload"]["to_l2_id"] == "globex/eng"
+    assert forward["payload"]["content"] == "cross-enterprise hello"
+
+
+def test_cross_enterprise_no_peering_returns_403(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured = _capture_x_enterprise_forwards(monkeypatch)
+    token = _login(client)
+    r = client.post(
+        "/api/v1/consults/request",
+        headers={"authorization": f"Bearer {token}"},
+        json={
+            "to_l2_id": "rival/somewhere",
+            "to_persona": "they",
+            "content": "x",
+        },
+    )
+    assert r.status_code == 403, r.text
+    assert "no active peering" in r.json()["detail"].lower()
+    assert captured == []
+
+
+def test_cross_enterprise_target_l2_not_in_roster_returns_403(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Peering covers globex/eng but client asks for globex/marketing."""
+    _seed_peering(
+        offer_id="off_partial",
+        to_l2_endpoints=[
+            {"l2_id": "globex/eng", "endpoint_url": "https://globex-eng.example.com", "groups": ["eng"]},
+        ],
+    )
+    captured = _capture_x_enterprise_forwards(monkeypatch)
+    token = _login(client)
+    r = client.post(
+        "/api/v1/consults/request",
+        headers={"authorization": f"Bearer {token}"},
+        json={
+            "to_l2_id": "globex/marketing",
+            "to_persona": "they",
+            "content": "x",
+        },
+    )
+    assert r.status_code == 403, r.text
+    assert captured == []
+
+
+def test_cross_enterprise_logging_policy_summary_only_redacts_local_mirror(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_peering(offer_id="off_summary", consult_logging_policy="summary_only_log")
+    _capture_x_enterprise_forwards(monkeypatch)
+    token = _login(client)
+
+    r = client.post(
+        "/api/v1/consults/request",
+        headers={"authorization": f"Bearer {token}"},
+        json={
+            "to_l2_id": "globex/eng",
+            "to_persona": "they",
+            "content": "secret content here",
+        },
+    )
+    assert r.status_code == 201, r.text
+    thread_id = r.json()["thread_id"]
+
+    # Local mirror should be redacted per the peering's logging policy.
+    msgs = client.get(
+        f"/api/v1/consults/{thread_id}/messages",
+        headers={"authorization": f"Bearer {token}"},
+    )
+    body = msgs.json()
+    assert body["messages"][0]["content"] == "<redacted: summary_only_log>"
+
+
+def test_cross_enterprise_logging_policy_no_log_skips_message_row(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_peering(offer_id="off_nolog", consult_logging_policy="no_log_consults")
+    _capture_x_enterprise_forwards(monkeypatch)
+    token = _login(client)
+
+    r = client.post(
+        "/api/v1/consults/request",
+        headers={"authorization": f"Bearer {token}"},
+        json={
+            "to_l2_id": "globex/eng",
+            "to_persona": "they",
+            "content": "ephemeral",
+        },
+    )
+    assert r.status_code == 201, r.text
+    thread_id = r.json()["thread_id"]
+
+    # Thread row exists (audit point: who tried to consult whom)
+    # but no message row was written.
+    msgs = client.get(
+        f"/api/v1/consults/{thread_id}/messages",
+        headers={"authorization": f"Bearer {token}"},
+    )
+    body = msgs.json()
+    assert body["messages"] == []
+
+
+def test_cross_enterprise_mutual_log_writes_full_body(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Default policy mutual_log_required → asker side sees full content."""
+    _seed_peering(offer_id="off_mutual")
+    _capture_x_enterprise_forwards(monkeypatch)
+    token = _login(client)
+
+    r = client.post(
+        "/api/v1/consults/request",
+        headers={"authorization": f"Bearer {token}"},
+        json={
+            "to_l2_id": "globex/eng",
+            "to_persona": "they",
+            "content": "full content visible",
+        },
+    )
+    assert r.status_code == 201, r.text
+    thread_id = r.json()["thread_id"]
+
+    msgs = client.get(
+        f"/api/v1/consults/{thread_id}/messages",
+        headers={"authorization": f"Bearer {token}"},
+    )
+    assert msgs.json()["messages"][0]["content"] == "full content visible"
+
+
+def test_malformed_to_l2_id_returns_400(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """to_l2_id without enterprise/group separator is rejected before lookup."""
+    _capture_x_enterprise_forwards(monkeypatch)
+    token = _login(client)
+    r = client.post(
+        "/api/v1/consults/request",
+        headers={"authorization": f"Bearer {token}"},
+        json={
+            "to_l2_id": "no-slash-here",
+            "to_persona": "they",
+            "content": "x",
+        },
+    )
+    assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# _x_enterprise_forward_request — wire-shape unit test (no real httpx)
+# ---------------------------------------------------------------------------
+
+
+def test_x_enterprise_forward_request_sends_bearer_and_sig_headers(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Forward call uses peering-derived bearer + per-L2 Ed25519 sig + offer-id header."""
+    _seed_peering(offer_id="off_wire")
+    captured: list[dict[str, Any]] = []
+
+    class _FakeClient:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            pass
+
+        def __enter__(self) -> "_FakeClient":
+            return self
+
+        def __exit__(self, *_a: Any) -> None:
+            pass
+
+        def post(
+            self, url: str, *, headers: dict[str, str], json: dict[str, Any]
+        ) -> httpx.Response:
+            captured.append({"url": url, "headers": headers, "json": json})
+            return httpx.Response(201)
+
+    monkeypatch.setattr(consults.httpx, "Client", _FakeClient)
+
+    peering = _get_store().find_active_directory_peering(
+        from_enterprise="acme", to_enterprise="globex"
+    )
+    assert peering is not None
+    target_endpoint = json.loads(peering["to_l2_endpoints_json"])[0]
+
+    payload = {
+        "thread_id": "th_x",
+        "from_l2_id": "acme/engineering",
+        "to_l2_id": "globex/eng",
+        "content": "hi",
+    }
+    consults._x_enterprise_forward_request(peering, target_endpoint, payload)
+
+    assert len(captured) == 1
+    sent = captured[0]
+    assert sent["url"].endswith("/api/v1/consults/x-enterprise-forward-request")
+    expected_bearer = forward_sign.derive_peering_bearer(_FAKE_OFFER_SIG, _FAKE_ACCEPT_SIG)
+    assert sent["headers"]["authorization"] == f"Bearer {expected_bearer}"
+    assert sent["headers"]["x-8l-peering-offer-id"] == "off_wire"
+    assert sent["headers"]["x-8l-forwarder-l2-id"] == "acme/engineering"
+    # Ed25519 sig is generated lazily on first call (key file in tmp_path)
+    assert "x-8l-forwarder-sig" in sent["headers"]
+    assert sent["json"] == payload


### PR DESCRIPTION
Replaces the 501 at consults.py:304 with cross-Enterprise routing via the directory peering mirror. Two-layer auth: HKDF-derived peering bearer + per-L2 Ed25519 sig (PR #53). consult_logging_policy enforced on asker-side mirror-write. New schema column to_l2_endpoints_json captures directory's roster snapshot at peering time. Refs decisions/15 (THE Dirk blocker), plans/13 (sprint-4 scope). 411 tests passing (+15 new). Phase 2 (receiver + verification) is the next PR.