### PR TITLE
[x-enterprise] sprint 4 Track A phase 2 — receiver + logging-policy enforcement

### DIFF
--- a/server/backend/src/cq_server/consults.py
+++ b/server/backend/src/cq_server/consults.py
@@ -794,6 +794,175 @@ def forward_consult_message(
     return {"status": "mirrored", "thread_id": body.thread_id}
 
 
+# ---------------------------------------------------------------------------
+# Cross-Enterprise forward — receiver side (sprint 4 Track A phase 2)
+# ---------------------------------------------------------------------------
+
+
+def _hmac_eq(a: str, b: str) -> bool:
+    """Constant-time equality for two strings of arbitrary length."""
+    import hmac
+
+    return hmac.compare_digest(a.encode("utf-8"), b.encode("utf-8"))
+
+
+def _require_x_enterprise_auth(
+    request: Request,
+    body: ForwardRequestBody,
+    store: RemoteStore,
+) -> dict[str, Any]:
+    """Validate a cross-Enterprise forward.
+
+    Returns the active peering row that authorised this forward — caller
+    uses ``consult_logging_policy`` from it.
+
+    Raises:
+        HTTPException 400 — missing/malformed required headers.
+        HTTPException 401 — bearer doesn't match the peering's derived bearer.
+        HTTPException 403 — body identity doesn't match headers, or the peering
+                            is unknown / inactive on this L2.
+    """
+    auth = request.headers.get("authorization", "")
+    if not auth.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="missing bearer auth")
+    presented_bearer = auth[7:]
+
+    forwarder_l2_id = request.headers.get(aigrp_mod.FORWARDER_HEADER, "").strip()
+    if not forwarder_l2_id:
+        raise HTTPException(
+            status_code=400,
+            detail=f"missing {aigrp_mod.FORWARDER_HEADER} header",
+        )
+    offer_id = request.headers.get("x-8l-peering-offer-id", "").strip()
+    if not offer_id:
+        raise HTTPException(
+            status_code=400,
+            detail="missing x-8l-peering-offer-id header",
+        )
+
+    # Identity binding — the body's from_l2_id must match the header.
+    if body.from_l2_id != forwarder_l2_id:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"forwarder identity mismatch: header={forwarder_l2_id!r} "
+                f"body.from_l2_id={body.from_l2_id!r}"
+            ),
+        )
+
+    # Peering lookup — by offer_id directly.
+    peerings = [
+        p for p in store.list_directory_peerings(status="active")
+        if p["offer_id"] == offer_id
+    ]
+    if not peerings:
+        raise HTTPException(
+            status_code=403,
+            detail=f"no active peering with offer_id={offer_id!r} on this L2",
+        )
+    peering = peerings[0]
+
+    # Per-spec: at expires_at, peering rolls off. Belt + braces (also
+    # filtered server-side via find_active_directory_peering, but this
+    # path uses list which doesn't expire-filter).
+    if peering.get("expires_at") and peering["expires_at"] < datetime.now(UTC).isoformat():
+        raise HTTPException(status_code=403, detail="peering expired")
+
+    # Forwarder enterprise must match the OTHER side of the peering.
+    forwarder_enterprise, _, _ = forwarder_l2_id.partition("/")
+    self_enterprise = aigrp_mod.enterprise()
+    other_enterprise = (
+        peering["from_enterprise"]
+        if peering["to_enterprise"] == self_enterprise
+        else peering["to_enterprise"]
+    )
+    if forwarder_enterprise != other_enterprise:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"forwarder enterprise {forwarder_enterprise!r} is not the "
+                f"other side of peering {offer_id!r} (other_side={other_enterprise!r})"
+            ),
+        )
+
+    # Bearer derivation — both sides compute the same value from the
+    # bilateral signatures. Constant-time compare.
+    expected_bearer = forward_sign.derive_peering_bearer(
+        peering["offer_signature_b64u"],
+        peering["accept_signature_b64u"],
+    )
+    if not _hmac_eq(presented_bearer, expected_bearer):
+        raise HTTPException(status_code=401, detail="invalid peering bearer")
+
+    # Sprint-4 V1: Ed25519 forwarder-sig verification is deferred —
+    # roster doesn't yet carry per-L2 pubkeys. The signature, when
+    # present, is recorded but not enforced. V2 adds pubkeys to the
+    # roster + flips this to enforced.
+    return peering
+
+
+@router.post("/x-enterprise-forward-request", status_code=201)
+def x_enterprise_forward_consult_request(
+    body: ForwardRequestBody,
+    request: Request,
+    store: RemoteStore = Depends(get_store),
+) -> dict[str, str]:
+    """Mirror a cross-Enterprise consult request onto this L2.
+
+    Auth is two-layer (sprint 4 Track A — see ``_require_x_enterprise_auth``):
+    bearer derived from the peering's bilateral signatures + body/header
+    identity binding. The shared EnterprisePeerKey is intentionally NOT
+    used here — it's intra-Enterprise only.
+
+    Logging is governed by ``consult_logging_policy`` from the peering:
+
+    - ``mutual_log_required`` (default) — full body persisted both sides
+    - ``summary_only_log`` — thread row + redacted message body
+    - ``no_log_consults`` — thread row only (audit point: who asked whom),
+      message body discarded after the receiver agent reads it in real time
+
+    Idempotent on ``(thread_id, message_id)`` like the same-Enterprise
+    forward path. Body shape matches ForwardRequestBody for consistency.
+    """
+    peering = _require_x_enterprise_auth(request, body, store)
+    policy = peering["consult_logging_policy"]
+
+    # Thread row: always created (audit point: cross-Enterprise consult
+    # was attempted, regardless of policy).
+    if store.get_consult(body.thread_id) is None:
+        store.create_consult(
+            thread_id=body.thread_id,
+            from_l2_id=body.from_l2_id,
+            from_persona=body.from_persona,
+            to_l2_id=body.to_l2_id,
+            to_persona=body.to_persona,
+            subject=body.subject,
+            created_at=body.created_at,
+        )
+
+    # Message body: only persisted under mutual_log_required (full) or
+    # summary_only_log (redacted). no_log_consults skips the row.
+    if policy != "no_log_consults":
+        try:
+            store.append_consult_message(
+                message_id=body.message_id,
+                thread_id=body.thread_id,
+                from_l2_id=body.from_l2_id,
+                from_persona=body.from_persona,
+                content=_redact_for_policy(body.content, policy),
+                created_at=body.created_at,
+            )
+        except Exception as e:
+            if "UNIQUE constraint failed" not in str(e):
+                raise
+
+    return {
+        "status": "mirrored",
+        "thread_id": body.thread_id,
+        "logging_policy_applied": policy,
+    }
+
+
 @router.get("/inbox", response_model=InboxResponse)
 def get_inbox(
     include_closed: bool = False,

--- a/server/backend/tests/test_x_enterprise_consult.py
+++ b/server/backend/tests/test_x_enterprise_consult.py
@@ -442,3 +442,244 @@ def test_x_enterprise_forward_request_sends_bearer_and_sig_headers(
     # Ed25519 sig is generated lazily on first call (key file in tmp_path)
     assert "x-8l-forwarder-sig" in sent["headers"]
     assert sent["json"] == payload
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — receiver side: /api/v1/consults/x-enterprise-forward-request
+# ---------------------------------------------------------------------------
+#
+# These tests exercise the receiver. The fixture's L2 is acme/engineering;
+# we simulate forwards arriving from globex (the OTHER side of the peering).
+# We seed peerings with from_ent="globex", to_ent="acme" so this L2 is the
+# receiver and globex is the sender.
+
+
+def _x_enterprise_headers(
+    *,
+    bearer: str,
+    forwarder_l2_id: str = "globex/eng",
+    offer_id: str = "off_recv",
+) -> dict[str, str]:
+    return {
+        "authorization": f"Bearer {bearer}",
+        "x-8l-forwarder-l2-id": forwarder_l2_id,
+        "x-8l-peering-offer-id": offer_id,
+    }
+
+
+def _x_enterprise_payload(
+    thread_id: str = "th_recv_1",
+    message_id: str = "msg_recv_1",
+    content: str = "incoming from globex",
+) -> dict[str, Any]:
+    return {
+        "thread_id": thread_id,
+        "message_id": message_id,
+        "from_l2_id": "globex/eng",
+        "from_persona": "their_alice",
+        "to_l2_id": "acme/engineering",
+        "to_persona": ALICE,
+        "subject": "x-ent test",
+        "content": content,
+        "created_at": "2026-05-02T10:00:00Z",
+    }
+
+
+def test_x_enterprise_receiver_happy_path(client: TestClient) -> None:
+    """Bearer matches, body identity matches, forwarder enterprise is the peer."""
+    _seed_peering(offer_id="off_recv", from_ent="globex", to_ent="acme")
+    bearer = forward_sign.derive_peering_bearer(_FAKE_OFFER_SIG, _FAKE_ACCEPT_SIG)
+    r = client.post(
+        "/api/v1/consults/x-enterprise-forward-request",
+        headers=_x_enterprise_headers(bearer=bearer),
+        json=_x_enterprise_payload(),
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["status"] == "mirrored"
+    assert body["logging_policy_applied"] == "mutual_log_required"
+
+
+def test_x_enterprise_receiver_bad_bearer_401(client: TestClient) -> None:
+    _seed_peering(offer_id="off_recv", from_ent="globex", to_ent="acme")
+    r = client.post(
+        "/api/v1/consults/x-enterprise-forward-request",
+        headers=_x_enterprise_headers(bearer="not-the-real-bearer"),
+        json=_x_enterprise_payload(),
+    )
+    assert r.status_code == 401, r.text
+    assert "bearer" in r.json()["detail"].lower()
+
+
+def test_x_enterprise_receiver_missing_bearer_401(client: TestClient) -> None:
+    _seed_peering(offer_id="off_recv", from_ent="globex", to_ent="acme")
+    headers = _x_enterprise_headers(bearer="x")
+    del headers["authorization"]  # remove the bearer
+    r = client.post(
+        "/api/v1/consults/x-enterprise-forward-request",
+        headers=headers,
+        json=_x_enterprise_payload(),
+    )
+    assert r.status_code == 401, r.text
+
+
+def test_x_enterprise_receiver_missing_offer_id_400(client: TestClient) -> None:
+    _seed_peering(offer_id="off_recv", from_ent="globex", to_ent="acme")
+    bearer = forward_sign.derive_peering_bearer(_FAKE_OFFER_SIG, _FAKE_ACCEPT_SIG)
+    headers = _x_enterprise_headers(bearer=bearer)
+    del headers["x-8l-peering-offer-id"]
+    r = client.post(
+        "/api/v1/consults/x-enterprise-forward-request",
+        headers=headers,
+        json=_x_enterprise_payload(),
+    )
+    assert r.status_code == 400, r.text
+    assert "offer-id" in r.json()["detail"].lower()
+
+
+def test_x_enterprise_receiver_unknown_offer_id_403(client: TestClient) -> None:
+    """The sender claims a peering offer_id we don't have on file."""
+    _seed_peering(offer_id="off_recv", from_ent="globex", to_ent="acme")
+    bearer = forward_sign.derive_peering_bearer(_FAKE_OFFER_SIG, _FAKE_ACCEPT_SIG)
+    r = client.post(
+        "/api/v1/consults/x-enterprise-forward-request",
+        headers=_x_enterprise_headers(bearer=bearer, offer_id="off_unknown"),
+        json=_x_enterprise_payload(),
+    )
+    assert r.status_code == 403, r.text
+    assert "no active peering" in r.json()["detail"].lower()
+
+
+def test_x_enterprise_receiver_body_header_mismatch_403(client: TestClient) -> None:
+    """X-8L-Forwarder-L2-Id and body.from_l2_id must agree."""
+    _seed_peering(offer_id="off_recv", from_ent="globex", to_ent="acme")
+    bearer = forward_sign.derive_peering_bearer(_FAKE_OFFER_SIG, _FAKE_ACCEPT_SIG)
+    payload = _x_enterprise_payload()
+    payload["from_l2_id"] = "globex/marketing"  # different from header
+    r = client.post(
+        "/api/v1/consults/x-enterprise-forward-request",
+        headers=_x_enterprise_headers(bearer=bearer),  # header says globex/eng
+        json=payload,
+    )
+    assert r.status_code == 403, r.text
+    assert "mismatch" in r.json()["detail"].lower()
+
+
+def test_x_enterprise_receiver_wrong_enterprise_403(client: TestClient) -> None:
+    """Forwarder claims to be from an enterprise that's not the peer."""
+    _seed_peering(offer_id="off_recv", from_ent="globex", to_ent="acme")
+    bearer = forward_sign.derive_peering_bearer(_FAKE_OFFER_SIG, _FAKE_ACCEPT_SIG)
+    payload = _x_enterprise_payload()
+    payload["from_l2_id"] = "rival/eng"
+    r = client.post(
+        "/api/v1/consults/x-enterprise-forward-request",
+        headers=_x_enterprise_headers(bearer=bearer, forwarder_l2_id="rival/eng"),
+        json=payload,
+    )
+    assert r.status_code == 403, r.text
+    detail = r.json()["detail"].lower()
+    assert "rival" in detail and "other side" in detail
+
+
+def test_x_enterprise_receiver_logging_policy_summary_only_redacts(
+    client: TestClient,
+) -> None:
+    _seed_peering(
+        offer_id="off_recv",
+        from_ent="globex",
+        to_ent="acme",
+        consult_logging_policy="summary_only_log",
+    )
+    bearer = forward_sign.derive_peering_bearer(_FAKE_OFFER_SIG, _FAKE_ACCEPT_SIG)
+    r = client.post(
+        "/api/v1/consults/x-enterprise-forward-request",
+        headers=_x_enterprise_headers(bearer=bearer),
+        json=_x_enterprise_payload(content="confidential"),
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["logging_policy_applied"] == "summary_only_log"
+
+    # Verify the receiver-side message row is redacted.
+    msg_rows = _get_store().list_consult_messages("th_recv_1")
+    assert len(msg_rows) == 1
+    assert msg_rows[0]["content"] == "<redacted: summary_only_log>"
+
+
+def test_x_enterprise_receiver_logging_policy_no_log_skips_message(
+    client: TestClient,
+) -> None:
+    _seed_peering(
+        offer_id="off_recv",
+        from_ent="globex",
+        to_ent="acme",
+        consult_logging_policy="no_log_consults",
+    )
+    bearer = forward_sign.derive_peering_bearer(_FAKE_OFFER_SIG, _FAKE_ACCEPT_SIG)
+    r = client.post(
+        "/api/v1/consults/x-enterprise-forward-request",
+        headers=_x_enterprise_headers(bearer=bearer),
+        json=_x_enterprise_payload(content="ephemeral"),
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["logging_policy_applied"] == "no_log_consults"
+
+    # Thread row exists (audit point) but no message row.
+    thread = _get_store().get_consult("th_recv_1")
+    assert thread is not None
+    msg_rows = _get_store().list_consult_messages("th_recv_1")
+    assert msg_rows == []
+
+
+def test_x_enterprise_receiver_idempotent_on_redelivery(client: TestClient) -> None:
+    """Same offer_id + thread_id + message_id replayed → 201, no dup row."""
+    _seed_peering(offer_id="off_recv", from_ent="globex", to_ent="acme")
+    bearer = forward_sign.derive_peering_bearer(_FAKE_OFFER_SIG, _FAKE_ACCEPT_SIG)
+    payload = _x_enterprise_payload()
+    h = _x_enterprise_headers(bearer=bearer)
+
+    r1 = client.post("/api/v1/consults/x-enterprise-forward-request", headers=h, json=payload)
+    r2 = client.post("/api/v1/consults/x-enterprise-forward-request", headers=h, json=payload)
+    assert r1.status_code == 201
+    assert r2.status_code == 201
+
+    msg_rows = _get_store().list_consult_messages("th_recv_1")
+    assert len(msg_rows) == 1
+
+
+def test_x_enterprise_receiver_does_not_use_enterprise_peer_key(
+    client: TestClient,
+) -> None:
+    """Even with a valid EnterprisePeerKey, no peering means 403.
+
+    Defensive — the cross-Enterprise endpoint must NOT fall back to
+    the intra-Enterprise auth shape.
+    """
+    bearer = forward_sign.derive_peering_bearer(_FAKE_OFFER_SIG, _FAKE_ACCEPT_SIG)
+    r = client.post(
+        "/api/v1/consults/x-enterprise-forward-request",
+        headers={
+            "authorization": f"Bearer {bearer}",  # arbitrary bearer, no peering registered
+            "x-8l-forwarder-l2-id": "globex/eng",
+            "x-8l-peering-offer-id": "off_does_not_exist",
+        },
+        json=_x_enterprise_payload(),
+    )
+    assert r.status_code == 403, r.text
+
+
+def test_x_enterprise_receiver_inbox_visibility(client: TestClient) -> None:
+    """After the receiver mirrors, alice's inbox shows the cross-Enterprise thread."""
+    _seed_peering(offer_id="off_recv", from_ent="globex", to_ent="acme")
+    bearer = forward_sign.derive_peering_bearer(_FAKE_OFFER_SIG, _FAKE_ACCEPT_SIG)
+    r = client.post(
+        "/api/v1/consults/x-enterprise-forward-request",
+        headers=_x_enterprise_headers(bearer=bearer),
+        json=_x_enterprise_payload(),
+    )
+    assert r.status_code == 201
+
+    token = _login(client)
+    inbox = client.get("/api/v1/consults/inbox", headers={"authorization": f"Bearer {token}"})
+    assert inbox.status_code == 200
+    threads = inbox.json()["threads"]
+    assert any(t["thread_id"] == "th_recv_1" for t in threads)


### PR DESCRIPTION
Companion to PR #54 (phase 1, just merged). Implements the receiver: POST /api/v1/consults/x-enterprise-forward-request with bearer + body-identity auth, logging-policy enforcement (mutual_log_required / summary_only_log / no_log_consults). 12 new tests. Suite: 423 passing.