### PR TITLE
[plugin] /cq:consult-* slash commands (open/inbox/reply/close)

### DIFF
--- a/plugins/cq/commands/consult-close.md
+++ b/plugins/cq/commands/consult-close.md
@@ -1,0 +1,81 @@
+---
+name: cq:consult-close
+description: Mark a consult thread resolved. Records the resolution reason for both reputation tracking and the peer's audit trail.
+---
+
+# /cq:consult-close
+
+Resolve a consult thread.
+
+## Instructions
+
+### Step 1 — Parse args
+
+- **`thread_id`** (required) — the thread to close.
+- **`resolution`** — one of `resolved` (default), `wont_fix`, `duplicate`, `stale`.
+- **`summary`** (optional) — one-paragraph explanation of how it was
+  resolved or why it isn't being addressed. Recommended for `wont_fix`
+  + `duplicate`. Surfaces in reputation log + the peer's audit trail.
+- **`duplicate_of`** — required when `resolution=duplicate`; the
+  thread_id this one duplicates.
+
+### Step 2 — Validate environment
+
+Same as `/cq:consult-open`.
+
+### Step 3 — Confirm before closing
+
+Closing is one-way (V1 has no reopen verb). Show:
+
+```
+About to close thread <thread_id> as <resolution>.
+  summary: <summary or "(no summary)">
+Confirm? (y/n)
+```
+
+If the user typed the close command with explicit args (`/cq:consult-close
+<thread_id> resolved -- here's the summary`), skip the confirmation —
+the command itself is the confirm.
+
+### Step 4 — Send
+
+POST `$CQ_ADDR/api/v1/consults/<thread_id>/close` with body:
+
+```json
+{
+  "resolution": "<resolution>",
+  "summary": "<summary>",
+  "duplicate_of": "<duplicate_of>"
+}
+```
+
+Omit nullable fields. `Authorization: Bearer $CQ_API_KEY`.
+
+### Step 5 — Render
+
+On 200:
+```
+Thread closed.
+  thread: <thread_id>
+  resolution: <resolution>
+  closed_at: <timestamp>
+```
+
+Common errors:
+
+- **404** — thread not found
+- **409** `already closed` — idempotent error; show current resolution.
+  Don't re-close.
+- **400** `duplicate_of required for duplicate resolution` — re-prompt
+  for the linked thread id.
+
+## Notes
+
+- Records cq attribution under
+  `kind=consult.close, resolution=<value>`.
+- Closing emits a reputation event (decision 13). Both sides' reputation
+  log include the close + resolution; the peer reads this when
+  evaluating future consult routing.
+- `wont_fix` and `duplicate` count differently in reputation than
+  `resolved` — be honest about which one applies. The peer's directory
+  client will eventually surface aggregate consult-resolution stats.

--- a/plugins/cq/commands/consult-inbox.md
+++ b/plugins/cq/commands/consult-inbox.md
@@ -1,0 +1,68 @@
+---
+name: cq:consult-inbox
+description: List incoming consult threads addressed to my personas — both intra-Enterprise and cross-Enterprise. Filters out resolved threads by default.
+---
+
+# /cq:consult-inbox
+
+Show consults waiting for a reply.
+
+## Instructions
+
+### Step 1 — Parse args (all optional)
+
+- **`limit`** — max threads to show (default 20).
+- **`only_open`** — `true` (default) or `false`. When `false`, includes
+  resolved/closed threads too.
+- **`from`** — filter to threads from a specific peer enterprise or
+  persona. Pass through to the API as a query string.
+- **`persona`** — filter to consults addressed to a specific local
+  persona. Useful when you operate multiple personas.
+
+### Step 2 — Validate environment
+
+Same as `/cq:consult-open` — `CQ_ADDR` + `CQ_API_KEY` required.
+
+### Step 3 — Fetch
+
+GET `$CQ_ADDR/api/v1/consults/inbox?limit=<limit>&only_open=<bool>&from=<from>&persona=<persona>`
+with `Authorization: Bearer $CQ_API_KEY`.
+
+### Step 4 — Render
+
+If empty:
+```
+No consult threads (matching filters).
+```
+
+Otherwise, render each thread on two lines:
+
+```
+<thread_id>  [<status>]
+  from <from_l2>:<from_persona> → <to_persona>  · <created_at> · <message_count> msgs
+  subject: <subject>
+  latest: <truncated to 80 chars>
+```
+
+Sort by `latest_at` descending unless the API already does. Group by
+peer enterprise if `from` filter is unset and there are >5 threads.
+
+### Step 5 — Suggest actions
+
+If exactly one open thread, append:
+```
+Reply: /cq:consult-reply <thread_id> <text>
+Close: /cq:consult-close <thread_id>
+```
+
+If many, append:
+```
+Reply to a thread: /cq:consult-reply <thread_id> <text>
+```
+
+## Notes
+
+- Inbox reads don't record cq attribution.
+- Status values are `open` (waiting on a reply from someone), `resolved`,
+  `wont_fix`, `duplicate`, `stale`. The "open" set excludes the
+  terminal four.

--- a/plugins/cq/commands/consult-open.md
+++ b/plugins/cq/commands/consult-open.md
@@ -1,0 +1,105 @@
+---
+name: cq:consult-open
+description: Open a new cross-Enterprise consult thread. Routes via the cq-server's directory-driven peering when the destination resolves to a peer enterprise.
+---
+
+# /cq:consult-open
+
+Open a consult to a persona on this L2 or on a peer Enterprise's L2.
+
+## Instructions
+
+### Step 1 — Parse the user's args
+
+The user invokes this command followed by free-form text. Extract:
+
+- **`to`** (required) — destination, in the form `<enterprise>/<group>:<persona>`.
+  Example: `8th-layer/engineering:david`. If the user gave only a persona
+  name, ask which enterprise and group. Don't guess.
+- **`subject`** (required) — short title (one line). If absent, prompt
+  for one before sending.
+- **`content`** (required) — the consult body (the question or context).
+  This is whatever the user wrote after the args; if it's empty, prompt
+  for it.
+- **`content_policy`** (optional) — `summary_only` (default) or `full`.
+  Override only when the user explicitly says "send full content."
+
+If the destination is `<enterprise>/<group>:<persona>` with `<enterprise>`
+matching `$CQ_ENTERPRISE`, this is a local consult; the same endpoint
+handles both cases.
+
+### Step 2 — Validate the environment
+
+Read `CQ_ADDR` and `CQ_API_KEY` from environment. If either is missing,
+respond:
+
+> `CQ_ADDR` and/or `CQ_API_KEY` not set. See the runbook step 9
+> (configure your Claude Code session) at
+> https://github.com/OneZero1ai/crosstalk-enterprise/blob/main/docs/runbooks/01-customer-onboarding-zero-to-peered.md
+
+…and stop.
+
+### Step 3 — Send
+
+Construct a JSON body:
+
+```json
+{
+  "to_l2_id": "<enterprise>/<group>",
+  "to_persona": "<persona>",
+  "subject": "<subject>",
+  "content": "<content>",
+  "content_policy": "<summary_only|full>"
+}
+```
+
+POST to `$CQ_ADDR/api/v1/consults/request` with header
+`Authorization: Bearer $CQ_API_KEY`. Use `curl -s -w '\n%{http_code}'` so
+status code is on the last line; parse it.
+
+### Step 4 — Render result
+
+On HTTP 201:
+
+```
+Consult opened.
+  thread: <thread_id>
+  to:     <to_l2_id>:<to_persona>
+  subject: <subject>
+  policy: <content_policy>
+```
+
+If the response includes `forwarded_to` (cross-Enterprise hop), show it.
+
+On HTTP 403 with `no active peering`:
+```
+Cross-Enterprise peering not active for <enterprise>.
+- Run `8l-directory peerings` on your workstation. If active there,
+  the L2 hasn't refreshed yet (hourly poll). Force a refresh by
+  restarting the cq-server task.
+```
+
+On HTTP 404 with `persona not found`:
+```
+Persona <persona> not registered on <to_l2_id>.
+- Browse the peer's roster: `8l-directory enterprises --enterprise <enterprise>`
+- Personas are registered server-side; check with the peer's operator.
+```
+
+On HTTP 413 (`content_policy=full not allowed by peering`):
+```
+Peer's peering contract restricts to summary_only.
+- Re-run with `content_policy=summary_only`, or
+- Open a peering renegotiation with the peer.
+```
+
+On any other non-2xx, show the status code and detail verbatim.
+
+## Notes
+
+- This command sends immediately — no preview / approval gate. If the
+  user said "consider sending …" or "draft a consult …", DON'T call
+  this; instead, draft + show + ask.
+- The cq-server decides intra- vs cross-Enterprise routing from the
+  `to_l2_id`'s enterprise prefix. The plugin is dumb on routing.
+- Records cq attribution under `kind=consult.open, scope=outbound`.

--- a/plugins/cq/commands/consult-reply.md
+++ b/plugins/cq/commands/consult-reply.md
@@ -1,0 +1,74 @@
+---
+name: cq:consult-reply
+description: Append a reply to an existing consult thread. Routes via the same cq-server forwarding that opened the thread.
+---
+
+# /cq:consult-reply
+
+Send a follow-up message on an existing consult thread.
+
+## Instructions
+
+### Step 1 — Parse args
+
+- **`thread_id`** (required) — the consult thread id (looks like
+  `cns_<hex>` or similar).
+- **`content`** (required) — the reply body. Whatever the user wrote
+  after the thread id.
+
+If `thread_id` looks malformed (no expected prefix), confirm with the
+user before sending. Don't guess.
+
+### Step 2 — Validate environment
+
+Same as `/cq:consult-open`.
+
+### Step 3 — Optional context fetch
+
+If the user hasn't seen the thread recently in the conversation, fetch
+the most recent few messages so the reply has context:
+
+GET `$CQ_ADDR/api/v1/consults/<thread_id>/messages?limit=5`
+
+Show the user the latest 1-2 inbound messages briefly, then ask: "Send
+this reply as-is?" — if they confirm or already typed the reply
+explicitly, proceed. If they want changes, draft + iterate.
+
+This step is *optional* — skip when the user has clearly already
+written a deliberate reply (long, on-topic, no doubt about intent).
+
+### Step 4 — Send
+
+POST `$CQ_ADDR/api/v1/consults/<thread_id>/messages` with body:
+
+```json
+{ "content": "<content>" }
+```
+
+`Authorization: Bearer $CQ_API_KEY`.
+
+### Step 5 — Render
+
+On 201:
+```
+Reply sent.
+  thread: <thread_id>
+  message: <message_id>
+  at: <timestamp>
+```
+
+Common errors:
+
+- **404** `thread not found` — wrong id, or thread was hard-deleted.
+  Suggest `/cq:consult-inbox` to relocate.
+- **409** `thread closed` — thread was resolved before your reply
+  landed. Suggest reopening if needed (V2 — for now, open a new
+  thread that references this one in subject).
+- **413** `content too long` — server's `consult_messages.content`
+  max_length is enforced. Suggest splitting into multiple replies.
+
+## Notes
+
+- Records cq attribution under `kind=consult.reply, scope=existing-thread`.
+- Markdown in `content` is preserved as-is and rendered by the recipient
+  per their L2's policy.


### PR DESCRIPTION
## Sprint C task #97

Closes the runbook step 10 gap: customers needed to curl the cross-Enterprise consult API by hand. Now they get four slash commands that drive Claude through the full open → reply → close lifecycle.

**Spec:** [`crosstalk-enterprise/docs/specs/cq-consult-slash-commands-v1.md`](https://github.com/OneZero1ai/crosstalk-enterprise/blob/main/docs/specs/cq-consult-slash-commands-v1.md)

## V1 implementation pattern

Prompt-only markdown commands. Each instructs Claude to construct + run HTTP calls against the cq-server REST API via the Bash tool, reading `CQ_ADDR` + `CQ_API_KEY` from env. No new MCP tools required (would need upstream Go binary changes); V2 can switch to native MCP tools when those land.

## The four commands

| Command | API call |
|---|---|
| `/cq:consult-open` | `POST /api/v1/consults/request` (server auto-routes intra- vs cross-Enterprise based on `to_l2_id` prefix) |
| `/cq:consult-inbox` | `GET /api/v1/consults/inbox` with filters |
| `/cq:consult-reply` | `POST /api/v1/consults/{thread_id}/messages` |
| `/cq:consult-close` | `POST /api/v1/consults/{thread_id}/close` with resolution + summary + duplicate_of |

## Failure mode coverage

Each command handles documented failure modes with copy that points at concrete next actions:

- 403 `no active peering` → check via `8l-directory peerings` and force task restart
- 404 `persona not found` → check peer's roster
- 413 `content_policy=full not allowed by peering` → suggest `summary_only` or peering renegotiation
- 409 `thread closed` → suggest opening new thread referencing the old one
- 400 `duplicate_of required` → re-prompt for linked thread id
- Missing `CQ_API_KEY` → point at runbook step 9

## Test plan

- [ ] Install plugin in fresh Claude Code session, run `/cq:consult-open --to 8th-layer/engineering:david --subject test --content hi`
- [ ] Verify it lands on the receiving L2's `/api/v1/consults/inbox`
- [ ] Reply via `/cq:consult-reply <thread> ...` from the receiving side
- [ ] Close via `/cq:consult-close <thread> resolved`
- [ ] Verify reputation event recorded on close

## Out of V1

- Streaming responses (V1 returns once server confirms send)
- Attachments (text only)
- Approval workflow / dry-run flag
- Group consults (3+ enterprises in one thread)

🤖 Generated with [Claude Code](https://claude.com/claude-code)