### PR TITLE
[security] H-2 (#36) + M-1 — redact DSN/topology recon, generic forward errors

### DIFF
--- a/server/backend/src/cq_server/consults.py
+++ b/server/backend/src/cq_server/consults.py
@@ -202,15 +202,24 @@ def _forward_request(target: dict[str, Any], payload: dict[str, Any]) -> None:
                 json=payload,
             )
         if r.status_code >= 400:
-            raise HTTPException(
-                status_code=502,
-                detail=f"peer {target['l2_id']} returned {r.status_code} on /consults/forward-request: {r.text[:200]}",
+            # SEC-MED M-1 — log diagnosis-rich detail server-side; return
+            # a generic 502 to the client so peer response bodies (which
+            # may contain stack traces / config paths / tenant ids) don't
+            # leak through to the originating user.
+            logger.warning(
+                "consults forward-request: peer=%s status=%s body=%r",
+                target["l2_id"],
+                r.status_code,
+                r.text[:200],
             )
+            raise HTTPException(status_code=502, detail="peer unreachable")
     except httpx.RequestError as e:
-        raise HTTPException(
-            status_code=502,
-            detail=f"peer {target['l2_id']} unreachable: {e}",
-        ) from e
+        logger.warning(
+            "consults forward-request: peer=%s transport_error=%r",
+            target["l2_id"],
+            e,
+        )
+        raise HTTPException(status_code=502, detail="peer unreachable") from e
 
 
 def _forward_message(target: dict[str, Any], payload: dict[str, Any]) -> None:
@@ -231,15 +240,21 @@ def _forward_message(target: dict[str, Any], payload: dict[str, Any]) -> None:
                 json=payload,
             )
         if r.status_code >= 400:
-            raise HTTPException(
-                status_code=502,
-                detail=f"peer {target['l2_id']} returned {r.status_code} on /consults/forward-message",
+            # SEC-MED M-1 — log server-side, return generic to client.
+            logger.warning(
+                "consults forward-message: peer=%s status=%s body=%r",
+                target["l2_id"],
+                r.status_code,
+                r.text[:200],
             )
+            raise HTTPException(status_code=502, detail="peer unreachable")
     except httpx.RequestError as e:
-        raise HTTPException(
-            status_code=502,
-            detail=f"peer {target['l2_id']} unreachable: {e}",
-        ) from e
+        logger.warning(
+            "consults forward-message: peer=%s transport_error=%r",
+            target["l2_id"],
+            e,
+        )
+        raise HTTPException(status_code=502, detail="peer unreachable") from e
 
 
 def _resolve_x_enterprise_target(

--- a/server/backend/src/cq_server/network.py
+++ b/server/backend/src/cq_server/network.py
@@ -38,7 +38,7 @@ import struct
 import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any
+from typing import Annotated, Any
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
@@ -355,7 +355,10 @@ class DsnResolveRequest(BaseModel):
     # resolver consults each peer's Bloom filter (already exchanged via
     # AIGRP) and drops peers whose Bloom doesn't claim any of these
     # domains BEFORE cosine ranking. Issue #22.
-    query_domains: list[str] = Field(default_factory=list, max_length=20)
+    # SEC-HIGH #35 — per-item max_length=64 caps a malicious caller from
+    # smuggling a 1MB string in via a single domain entry; max_items=20
+    # caps total list size.
+    query_domains: list[Annotated[str, Field(max_length=64)]] = Field(default_factory=list, max_length=20)
 
 
 class DsnCandidate(BaseModel):
@@ -562,7 +565,11 @@ def _build_topology(snapshots: list[_L2Snapshot], consents: list[dict[str, Any]]
             TopologyActivePersona(
                 persona=row.get("persona", ""),
                 last_seen_at=row.get("last_seen_at", ""),
-                working_dir_hint=row.get("working_dir_hint"),
+                # SEC-HIGH #36 — working_dir_hint is internal-debug,
+                # not public-marketing-site data. Topology is
+                # unauthenticated; always redact. If an authed caller
+                # needs the hint, add a separate authed endpoint.
+                working_dir_hint=None,
                 expertise_domains=list(row.get("expertise_domains") or []),
             )
             for row in active
@@ -837,14 +844,24 @@ async def network_dsn_resolve(
             continue
         l2_id = sig.get("l2_id") or f"{snap.enterprise}/{snap.group}"
         active = snap.active_personas or []
-        expert_personas = [p.get("persona", "") for p in active if p.get("discoverable") is not False][:5]
+        # SEC-HIGH #36 — when policy says the caller can't query, redact
+        # the recon-relevant metadata too. Otherwise an anonymous viewer
+        # walks every fleet L2's persona list + KU counts via DSN even
+        # though they can't actually query. The candidate still surfaces
+        # so the policy story is honest ("here's the L2, but you'd be
+        # denied"); the personas + counts are not.
+        leak_safe = policy not in ("denied", "summary_only")
+        expert_personas = (
+            [p.get("persona", "") for p in active if p.get("discoverable") is not False][:5] if leak_safe else []
+        )
+        ku_count = int(sig.get("ku_count", 0)) if leak_safe else 0
         candidates.append(
             DsnCandidate(
                 l2_id=l2_id,
                 enterprise=snap.enterprise,
                 group=snap.group,
                 sim_score=round(sim, 4),
-                ku_count_in_topic=int(sig.get("ku_count", 0)),
+                ku_count_in_topic=ku_count,
                 top_domains=[],
                 expert_personas=expert_personas,
                 policy_if_queried=policy,


### PR DESCRIPTION
## Sprint C task #98 — partial

Closes #36 (H-2) and the M-1 stringification leak flagged in [decision 12](https://github.com/OneZero1ai/crosstalk-enterprise/blob/main/docs/decisions/12-security-audit-2026-05-01.md).

H-1, H-3, H-5 were already closed in earlier sprints — verified:
- H-1 (`/dsn/resolve` caps): `intent: max_length=512`, `query_domains: max_length=20` already there. This PR adds per-item `max_length=64` to query_domains entries (audit called for it but missed in the prior pass).
- H-3 (consult content caps): `ConsultRequest.content` and `ConsultMessage.content` already have `max_length=4096`.
- H-5 (`/stats` auth): already requires `require_api_key`.

## H-2 — DSN/topology recon redaction

When the candidate's `policy_if_queried` is `denied` or `summary_only` (the public marketing scope's default for unconsented cross-Enterprise pairs), redact:
- `expert_personas` → `[]`
- `ku_count_in_topic` → `0`

The candidate still surfaces in the response so the policy story is honest — \"here's the L2 that scored high; you'd be denied if you queried\" — but the recon-grade metadata (active personas + KU counts on unconsented peers) is not.

For topology specifically: `working_dir_hint` is set to `None` unconditionally. Topology is unauthenticated and intended for the public marketing site; that field is internal-debug, not public data.

## M-1 — forward-error stringification leak

Both `_forward_request` and `_forward_message` previously raised `HTTPException` with f-string detail that bubbled the peer's response body (200 chars) and L2 ID to the originating client. Peer responses can contain stack traces, config paths, or tenant ids; this leaks across the Enterprise boundary.

Now: log diagnosis-rich detail at WARN server-side, return generic `peer unreachable` 502 to the originating client.

## What's not in this PR

- **#38 (H-4)** — ALB Listener Rules to deny `/aigrp/*` + `/consults/forward-*` on the aggregator. Lives in `OneZero1ai/8th-layer:deploy/aws/mvp.yaml`, separate PR.
- **#40 (H-6)** — Per-L2 `CQ_JWT_SECRET` + refactor `/peers/active` fan-out to use peer-key auth. Multi-day refactor; separate PR.
- **M-3** — SSM-only mode enforcement (CFN Rules tightening). Lives in 8th-layer repo, separate PR.

## Test plan

- [x] All affected tests pass locally (53 tests in test_consults.py + test_dsn_resolve.py + test_network_topology.py + test_network_dsn_cache.py + test_x_enterprise_consult.py)
- [x] Full suite: 504 pass / 18 skipped (no regressions)
- [x] ruff + ty + pre-commit clean
- [ ] CI clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)