### PR TITLE
[security] M-6 — suppress bloom_dropped oracle for anonymous DSN callers

### DIFF
--- a/server/backend/src/cq_server/network.py
+++ b/server/backend/src/cq_server/network.py
@@ -794,6 +794,17 @@ async def network_dsn_resolve(
     # toward keeping peers and just rely on cosine to deprioritize.
     # When query_domains is empty (the public marketing case), the
     # prefilter is a no-op and behavior is unchanged.
+    #
+    # SEC-MED M-6 — bloom_dropped count is a topic-discovery oracle for
+    # anonymous callers: a public visitor submits query_domains=["x"]
+    # and observes which fleet L2s drop (= don't claim that domain in
+    # their Bloom). With binary search across L2s, this leaks "does
+    # L2 X know about topic Y" even though the caller can't actually
+    # query. For anonymous callers (no caller_enterprise/group), the
+    # prefilter still RUNS to give cosine a tighter peer set (perf
+    # win), but the per-call bloom_dropped count is suppressed in the
+    # response. Authenticated callers see the full count.
+    is_anonymous = not (request.caller_enterprise or request.caller_group)
     t_bloom = time.monotonic()
     bloom_dropped = 0
     if request.query_domains:
@@ -813,6 +824,8 @@ async def network_dsn_resolve(
             else:
                 bloom_dropped += 1
         snapshots = kept
+    # SEC-MED M-6 — anonymous oracle suppression.
+    bloom_dropped_reported: int | None = None if is_anonymous else bloom_dropped
     bloom_ms = int((time.monotonic() - t_bloom) * 1000)
     if request.query_domains:
         path.append(
@@ -820,7 +833,7 @@ async def network_dsn_resolve(
                 step="bloom_prefilter",
                 latency_ms=bloom_ms,
                 l2_count=len(snapshots),
-                bloom_dropped=bloom_dropped,
+                bloom_dropped=bloom_dropped_reported,
             )
         )
 

--- a/server/backend/tests/test_bloom_prefilter.py
+++ b/server/backend/tests/test_bloom_prefilter.py
@@ -198,10 +198,19 @@ def test_query_domains_drops_peers_whose_bloom_doesnt_match(client, monkeypatch)
 
     jwt = _login(client)
     # Only orion-eng (cloudfront,lambda) and acme-sol (cloudfront,edge,cdn) have cloudfront.
+    # SEC-MED M-6 — pass caller_enterprise/group so bloom_dropped is reported.
+    # Anonymous (marketing/public) callers get null'd bloom_dropped to suppress
+    # the topic-discovery oracle. Internal callers see the full count.
     resp = client.post(
         "/api/v1/network/dsn/resolve",
         headers={"Authorization": f"Bearer {jwt}"},
-        json={"intent": "cloudfront origin failover", "query_domains": ["cloudfront"], "max_candidates": 10},
+        json={
+            "intent": "cloudfront origin failover",
+            "query_domains": ["cloudfront"],
+            "max_candidates": 10,
+            "caller_enterprise": "orion",
+            "caller_group": "engineering",
+        },
     )
     assert resp.status_code == 200, resp.text
     body = resp.json()


### PR DESCRIPTION
Closes M-6 from [decision 12](https://github.com/OneZero1ai/crosstalk-enterprise/blob/main/docs/decisions/12-security-audit-2026-05-01.md).

The DSN bloom prefilter was a topic-discovery oracle for anonymous public visitors: submitting `query_domains=['secret-project-falcon']` and observing `bloom_dropped` count via the per-step trace told you whether any fleet L2 claimed that domain (false-positive rate <1% for low-cardinality names = reliable signal). With binary search across queries, an attacker could fingerprint exactly which L2 knows about which proprietary topic.

## Fix

When the caller is anonymous (no `caller_enterprise`/`caller_group` — the marketing/public scope used by 8thlayer.onezero1.ai), the prefilter still RUNS (cosine wants the tighter peer set; perf win preserved) but the per-call `bloom_dropped` count is null'd in the `DsnPathStep` response.

Authenticated callers see the full count unchanged.

## Test plan

- [x] Affected tests pass: 21 in test_dsn_resolve.py + test_consults.py + test_network_topology.py
- [x] ruff + ty + pre-commit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)