### PR TITLE
[fix] seed-users.py reads tenancy from CQ_ENTERPRISE/CQ_GROUP env

### DIFF
--- a/server/scripts/seed-users.py
+++ b/server/scripts/seed-users.py
@@ -1,6 +1,7 @@
 """Seed a user into the cq remote database."""
 
 import argparse
+import os
 import sqlite3
 import sys
 from pathlib import Path
@@ -14,11 +15,31 @@ def main() -> None:
     SEC-CRIT #32 (PR #42) added an admin gate on /review/* — users
     seeded without ``--role admin`` will get 403 on the review surface.
     Pass ``--role admin`` for any user expected to triage the queue.
+
+    Cross-Enterprise tenancy: the user row carries ``enterprise_id`` +
+    ``group_id`` columns that scope every query, propose, and consult
+    operation. Defaults read from ``CQ_ENTERPRISE`` / ``CQ_GROUP`` env
+    vars (the same vars the cq-server process uses for its own
+    identity). Override per-user via ``--enterprise`` / ``--group``.
+    Without a real tenancy, cross-Enterprise consults break: the
+    sender's body claims ``default-enterprise/default-group`` instead
+    of the L2's actual identity, and the receiver rejects with a
+    forwarder-mismatch 403.
     """
     parser = argparse.ArgumentParser(description="Seed a cq remote user.")
     parser.add_argument("--username", required=True)
     parser.add_argument("--password", required=True)
     parser.add_argument("--role", default="user", choices=["user", "admin"])
+    parser.add_argument(
+        "--enterprise",
+        default=os.environ.get("CQ_ENTERPRISE", "default-enterprise"),
+        help="Enterprise id for this user (defaults to $CQ_ENTERPRISE).",
+    )
+    parser.add_argument(
+        "--group",
+        default=os.environ.get("CQ_GROUP", "default-group"),
+        help="Group id for this user (defaults to $CQ_GROUP).",
+    )
     parser.add_argument("--db", default="/data/cq.db")
     args = parser.parse_args()
 
@@ -31,19 +52,25 @@ def main() -> None:
     conn = sqlite3.connect(str(db_path))
     try:
         conn.execute(
-            "INSERT INTO users (username, password_hash, created_at, role) "
-            "VALUES (?, ?, datetime('now'), ?)",
-            (args.username, password_hash, args.role),
+            "INSERT INTO users (username, password_hash, created_at, role, enterprise_id, group_id) "
+            "VALUES (?, ?, datetime('now'), ?, ?, ?)",
+            (args.username, password_hash, args.role, args.enterprise, args.group),
         )
         conn.commit()
-        print(f"User '{args.username}' created with role='{args.role}'.")
+        print(
+            f"User '{args.username}' created with role='{args.role}', "
+            f"enterprise='{args.enterprise}', group='{args.group}'."
+        )
     except sqlite3.IntegrityError:
         conn.execute(
-            "UPDATE users SET password_hash = ?, role = ? WHERE username = ?",
-            (password_hash, args.role, args.username),
+            "UPDATE users SET password_hash = ?, role = ?, enterprise_id = ?, group_id = ? WHERE username = ?",
+            (password_hash, args.role, args.enterprise, args.group, args.username),
         )
         conn.commit()
-        print(f"User '{args.username}' already exists — password + role='{args.role}' updated.")
+        print(
+            f"User '{args.username}' already exists — password + role='{args.role}' "
+            f"+ enterprise='{args.enterprise}' + group='{args.group}' updated."
+        )
     finally:
         conn.close()
 


### PR DESCRIPTION
## Real V1 bug — found via self-validation (#95)

The runbook for new customers walks them through deploy → announce → peer → seed admin → first cross-Enterprise consult. **Step 8 (seed admin) was the silent failure point.**

`seed-users.py` was inserting users with no `enterprise_id` / `group_id` columns set, so they defaulted to `'default-enterprise'`/`'default-group'`. On first cross-Enterprise consult attempt:

- Sender's request body says `from_l2_id='default-enterprise/default-group'`
- Forwarder header (correctly) says `'<enterprise>/<group>'`
- Receiver's SEC-CRIT #34 forwarder-identity binding catches the mismatch and 403s

I caught this running through Dirk's runbook end-to-end as 'dave-secondary'. The cross-Enterprise consult landed (`thread_id=th_0ab37fd0bd9f42f3`) only after manually patching `UPDATE users SET enterprise_id='dave-secondary', group_id='engineering'` on the dave-secondary L2's DB.

## Fix

`seed-users.py` now reads `CQ_ENTERPRISE` + `CQ_GROUP` from env (the same vars `aigrp.enterprise()` / `aigrp.group()` already use for the L2's own identity) and writes them into the user row. Adds explicit `--enterprise` / `--group` flags for override.

Runbook step 8 needs no change: customer already runs the seed command inside the container via `aws ecs execute-command`, where `CQ_ENTERPRISE` and `CQ_GROUP` are populated by the task definition.

## Live-stack follow-ups

- **mvp**: admin + 5 agent users (lambda-agent, bedrock-agent, step-fn-agent, dynamo-agent, etc.) all currently `enterprise_id='default-enterprise'`. Needs a one-shot UPDATE.
- **6 fleet L2s**: per-stack admin users likely same issue. Verify per stack.

These are live-DB patches, not code changes — separate from this PR.

## Test plan

- [x] Local lint clean
- [x] Manual: re-run dave-secondary self-validation with the new seed-users.py — verify cross-Enterprise consult succeeds without DB patch
- [ ] CI clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)