### PR TITLE
[security] H-6 (#40) + M-4 — JWT iss/aud + drop cross-L2 JWT auth

### DIFF
--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -1085,6 +1085,59 @@ def peers_active(
     return ActivePeersResponse(active_peers=active, count=len(active))
 
 
+@api_router.get("/aigrp/peers-active")
+def aigrp_peers_active(
+    group: Annotated[str | None, Query()] = None,
+    since_minutes: Annotated[int, Query(gt=0, le=24 * 60)] = PEER_ACTIVE_DEFAULT_WINDOW_MIN,
+    _peer: None = Depends(aigrp.require_peer_key),
+) -> ActivePeersResponse:
+    """Active personas as seen by THIS L2 — peer-key auth, intra-Enterprise.
+
+    SEC-HIGH H-6 / SEC-MED M-4 — replaces the aggregator's old JWT-over-
+    cross-L2 path (network.py:_admin_service_jwt). The aggregator now
+    authenticates to fleet L2s with the per-Enterprise peer key (the
+    same trust channel as the rest of /aigrp/*) instead of minting a
+    JWT under a shared secret.
+
+    Same response shape as ``GET /peers/active`` so the aggregator's
+    caller can stay shape-stable. Difference: no per-user scoping
+    (caller is a peer L2, not a user); no ``include_self`` /
+    ``self_persona`` filter (peer L2s see every persona on this L2,
+    same as before).
+    """
+    from datetime import UTC, datetime, timedelta
+
+    store = _get_store()
+    now = datetime.now(UTC)
+    since_iso = (now - timedelta(minutes=since_minutes)).isoformat()
+    rows = store.list_active_peers(
+        enterprise_id=aigrp.enterprise(),
+        since_iso=since_iso,
+        group_id=group,
+        exclude_persona=None,
+    )
+    active: list[ActivePeer] = []
+    for r in rows:
+        try:
+            last_seen = datetime.fromisoformat(r["last_seen_at"])
+        except ValueError:
+            continue
+        delta_min = max(0.0, (now - last_seen).total_seconds() / 60.0)
+        active.append(
+            ActivePeer(
+                persona=r["persona"],
+                enterprise_id=r["enterprise_id"],
+                group_id=r["group_id"],
+                last_seen_at=r["last_seen_at"],
+                minutes_since_last_seen=round(delta_min, 2),
+                discoverable=r["discoverable"],
+                working_dir_hint=None,  # SEC-HIGH H-2 — same redaction as /network/topology
+                expertise_domains=r["expertise_domains"],
+            )
+        )
+    return ActivePeersResponse(active_peers=active, count=len(active))
+
+
 # --- Phase 6 step 3 — Lane D: consent admin endpoints ---------------------
 
 

--- a/server/backend/src/cq_server/auth.py
+++ b/server/backend/src/cq_server/auth.py
@@ -1,4 +1,18 @@
-"""Authentication: password hashing, JWT creation and validation."""
+"""Authentication: password hashing, JWT creation and validation.
+
+SEC-MED M-4 — JWT iss/aud claims pin a token to the L2 that minted it.
+Combined with H-6 (per-L2 CQ_JWT_SECRET in SSM) the prior single-
+point-of-failure trust model — "leak any L2's secret, mint as anyone
+on any L2" — collapses to "leak L2 X's secret, impersonate users on
+L2 X only." Cross-L2 user-auth is gone; the only L2-to-L2 auth is the
+per-Enterprise AIGRP peer key + Ed25519 forward signatures.
+
+The aggregator's old _admin_service_jwt path used to mint a JWT under
+its own secret and present it to fleet L2s — that worked only because
+the secret was shared. With per-L2 secrets it can't work; replaced
+with /aigrp/peers-active (peer-key gated) so the network proxy reads
+presence over the same trust channel as the rest of /aigrp/*.
+"""
 
 import os
 import uuid
@@ -10,6 +24,7 @@ import jwt
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
+from . import aigrp
 from .api_keys import encode_token, generate_secret, hash_secret, secret_prefix
 from .deps import get_api_key_pepper, get_store
 from .store import RemoteStore
@@ -29,19 +44,42 @@ def verify_password(password: str, hashed: str) -> bool:
 
 
 def create_token(username: str, *, secret: str, ttl_hours: int = 24) -> str:
-    """Create a JWT token for the given username."""
+    """Create a JWT token bound to this L2's identity.
+
+    iss/aud both set to ``aigrp.self_l2_id()`` so a token minted on L2
+    A is rejected by L2 B's ``verify_token`` even if the two share a
+    secret. Combined with per-L2 secrets (H-6), this closes the
+    cross-L2-impersonation surface the audit flagged.
+    """
     now = datetime.now(UTC)
+    self_l2 = aigrp.self_l2_id()
     payload = {
         "sub": username,
         "iat": now,
         "exp": now + timedelta(hours=ttl_hours),
+        "iss": self_l2,
+        "aud": self_l2,
     }
     return jwt.encode(payload, secret, algorithm="HS256")
 
 
 def verify_token(token: str, *, secret: str) -> dict[str, Any]:
-    """Verify and decode a JWT token."""
-    return jwt.decode(token, secret, algorithms=["HS256"])
+    """Verify a JWT token and return its claims.
+
+    Requires ``iss`` and ``aud`` to both match this L2's identity. A
+    legacy token (no iss/aud) is rejected — the breaking change is
+    deliberate (closes M-4 / H-6); existing users re-login within
+    the 24h TTL anyway.
+    """
+    self_l2 = aigrp.self_l2_id()
+    return jwt.decode(
+        token,
+        secret,
+        algorithms=["HS256"],
+        audience=self_l2,
+        issuer=self_l2,
+        options={"require": ["iss", "aud", "sub", "exp"]},
+    )
 
 
 class LoginRequest(BaseModel):

--- a/server/backend/src/cq_server/network.py
+++ b/server/backend/src/cq_server/network.py
@@ -44,7 +44,6 @@ import httpx
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
-from .auth import create_token
 from .deps import get_store
 from .embed import embed_text, unpack
 from .store import RemoteStore
@@ -252,23 +251,6 @@ def _peer_key_for(enterprise: str) -> str:
         return ""
 
 
-def _admin_service_jwt() -> str:
-    """Mint a short-lived admin JWT to authenticate /peers/active calls.
-
-    Each L2 in the fleet validates this with its own ``CQ_JWT_SECRET``;
-    in dev that secret is shared, in prod each L2 gets its own and we'd
-    move to per-L2 service tokens — out of scope for this PR. Returns
-    empty string when no secret is configured.
-    """
-    secret = os.environ.get("CQ_JWT_SECRET", "")
-    if not secret:
-        return ""
-    # Username here is informational; the receiving L2 only checks
-    # signature + expiry. We send "service-network-proxy" so audit logs
-    # can identify the caller.
-    return create_token("service-network-proxy", secret=secret, ttl_hours=1)
-
-
 # ---------------------------------------------------------------------------
 # Pydantic response models.
 # ---------------------------------------------------------------------------
@@ -474,10 +456,12 @@ async def _fetch_one_l2(client: httpx.AsyncClient, l2: dict[str, str]) -> _L2Sna
         endpoint=l2["endpoint"],
     )
     peer_key = _peer_key_for(l2["enterprise"])
-    admin_jwt = _admin_service_jwt()
     base = l2["endpoint"].rstrip("/")
+    # SEC-HIGH H-6 / SEC-MED M-4 — aggregator no longer mints cross-L2 JWTs.
+    # All fan-out auth is the per-Enterprise AIGRP peer key, including
+    # the active-personas read (now via /aigrp/peers-active instead of
+    # the JWT-gated /peers/active).
     aigrp_headers = {"authorization": f"Bearer {peer_key}"} if peer_key else {}
-    admin_headers = {"authorization": f"Bearer {admin_jwt}"} if admin_jwt else {}
 
     async def _peers() -> dict[str, Any] | None:
         try:
@@ -500,15 +484,15 @@ async def _fetch_one_l2(client: httpx.AsyncClient, l2: dict[str, str]) -> _L2Sna
     async def _active() -> list[dict[str, Any]] | None:
         try:
             r = await client.get(
-                f"{base}/api/v1/peers/active",
-                headers=admin_headers,
-                params={"include_self": "true", "since_minutes": 60},
+                f"{base}/api/v1/aigrp/peers-active",
+                headers=aigrp_headers,
+                params={"since_minutes": 60},
             )
             if r.status_code == 200:
                 body = r.json()
                 return list(body.get("active_peers", []))
         except Exception:
-            logger.warning("peers/active fetch failed slug=%s", l2["slug"])
+            logger.warning("aigrp/peers-active fetch failed slug=%s", l2["slug"])
         return None
 
     peers_res, sig_res, active_res = await asyncio.gather(_peers(), _sig(), _active(), return_exceptions=False)


### PR DESCRIPTION
Closes issue #40 (H-6) and SEC-MED M-4 from [decision 12](https://github.com/OneZero1ai/crosstalk-enterprise/blob/main/docs/decisions/12-security-audit-2026-05-01.md). Plan: [crosstalk-enterprise/docs/plans/14-h6-m4-jwt-cross-l2-lockdown-scoping.md](https://github.com/OneZero1ai/crosstalk-enterprise/blob/main/docs/plans/14-h6-m4-jwt-cross-l2-lockdown-scoping.md).

Both lock together: separating them either breaks the aggregator (M-4 alone) or leaves token-binding weak (H-6 alone).

## Changes

**auth.py — JWT iss/aud claims**

`create_token` mints with `iss=aud=aigrp.self_l2_id()`. `verify_token` enforces both via PyJWT's `audience`/`issuer` kwargs + `options.require=['iss','aud','sub','exp']`. A token minted on L2 A is rejected by L2 B even if they share a `CQ_JWT_SECRET` — closes the cross-L2 impersonation surface even before the per-L2 secret split.

**app.py — new `GET /api/v1/aigrp/peers-active`**

Peer-key gated (Bearer EnterprisePeerKey, same as rest of `/aigrp/*`). Same response shape as `GET /peers/active` so the aggregator's caller stays shape-stable. `working_dir_hint` is null'd, matching the topology redaction from H-2 — peer-protocol callers shouldn't see internal-debug fields either.

**network.py — `_admin_service_jwt` deleted**

The only caller (`_fetch_one_l2`) now hits `/aigrp/peers-active` with peer-key auth instead of `/peers/active` with admin-JWT. Imports cleaned.

## Breaking change

Any cross-L2 JWT use stops working. Audit identified one such caller (`_admin_service_jwt`); deleted in this PR.

## Live deploy plan (operator)

1. Roll fleet L2s first (deploy PR's image) — they need to accept the new `/aigrp/peers-active` route before the aggregator switches to it.
2. Then roll the aggregator (mvp) — it's the only place the new caller code runs.
3. Per-L2 `CQ_JWT_SECRET` split is a separate ops change (plan 14 step 1) — affects deploy params, not code. Once each L2 has a unique secret, even the legacy cross-L2 JWT attack is moot because they can't decode each other's tokens at all.

## Test plan

- [x] `tests/test_auth.py`: 25 passing — JWT round-trip, wrong-secret rejection, exp/sub validation
- [x] Full backend suite: 504 passing / 18 phase-2 skipped (PR #57)
- [x] ruff + ty + pre-commit clean
- [ ] CI clean
- [ ] Live smoke: aggregator → fleet L2 over peer-key path returns active personas

🤖 Generated with [Claude Code](https://claude.com/claude-code)