### PR TITLE
[fix] plugin.json: add explicit homepage field

### DIFF
--- a/plugins/cq/.claude-plugin/plugin.json
+++ b/plugins/cq/.claude-plugin/plugin.json
@@ -2,6 +2,7 @@
   "name": "8l-cq",
   "version": "0.8.0+8l-dev",
   "description": "8th-Layer.ai agent — Apache-2.0 fork of Mozilla.AI's cq plugin (https://github.com/mozilla-ai/cq) adding enterprise execution: AIGRP intra-Enterprise routing, DSN intent resolution, L3 live consults, multi-tenant scope, directory + reputation log primitives. Speaks the cq protocol natively (MCP server is still named 'cq' for protocol compatibility); pair with an 8th-Layer.ai tenant Remote for the enterprise feature set.",
+  "homepage": "https://8thlayer.onezero1.ai",
   "author": {
     "name": "OneZero1.ai",
     "email": "support@onezero1.ai",


### PR DESCRIPTION
Without an explicit homepage field, Claude Code's plugin viewer falls back to extracting the first domain-shaped string from the description prose — which is the literal brand 'https://8th-Layer.ai'. That domain is real and is NOT ours. Clicking 'Open homepage' on the install dialog opened the wrong site. Fix: add explicit homepage pointing at https://8thlayer.onezero1.ai (the deployed page; the hyphenated form 8th-layer.onezero1.ai does not currently resolve).