### PR TITLE
[#108] Reputation v1: Ed25519 signing via L2 forward-sign key

### DIFF
--- a/server/backend/alembic/versions/0009_reputation_roots.py
+++ b/server/backend/alembic/versions/0009_reputation_roots.py
@@ -1,0 +1,75 @@
+"""Reputation log v1-real — daily Merkle roots (task #108 sub-task 3).
+
+Revision ID: 0009_reputation_roots
+Revises: 0008_reputation
+Create Date: 2026-05-03
+
+Per [decision 13](crosstalk-enterprise/docs/decisions/13) §"daily root publish":
+the L2 computes a SHA-256 Merkle tree over each UTC day's
+reputation_events, signs the root with this L2's Ed25519 forward-sign
+key, and persists to ``reputation_roots``. The same root is later
+POST'd to the directory's ``/api/v1/directory/reputation/root`` endpoint
+(sub-task 4) for cross-Enterprise verification.
+
+Schema invariants:
+- ``(enterprise_id, root_date)`` is unique — one root per Enterprise per
+  day. Recomputing requires DELETE first.
+- ``event_count`` is informational; the root is the hash, not the count.
+- ``signature_b64u`` and ``signing_key_id`` mirror the columns in
+  ``reputation_events`` — same key (the L2 forward-sign key per
+  decision 21), same self-describing format.
+- Empty days (no events): we still write a row with the zero-event
+  Merkle root constant, so day-over-day roots form a continuous chain
+  and the directory can detect a gap if a day's row is missing.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0009_reputation_roots"
+down_revision: str | Sequence[str] | None = "0008_reputation"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _table_exists(bind: sa.engine.Connection, table_name: str) -> bool:
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def upgrade() -> None:
+    """Create the daily-Merkle-root table."""
+    bind = op.get_bind()
+
+    if not _table_exists(bind, "reputation_roots"):
+        op.create_table(
+            "reputation_roots",
+            sa.Column("enterprise_id", sa.Text(), nullable=False),
+            sa.Column("root_date", sa.Text(), nullable=False),  # YYYY-MM-DD UTC
+            sa.Column("event_count", sa.Integer(), nullable=False),
+            sa.Column("merkle_root_hash", sa.Text(), nullable=False),  # sha256:<hex>
+            sa.Column("first_event_id", sa.Text(), nullable=True),
+            sa.Column("last_event_id", sa.Text(), nullable=True),
+            sa.Column("signature_b64u", sa.Text(), nullable=True),
+            sa.Column("signing_key_id", sa.Text(), nullable=True),
+            sa.Column("computed_at", sa.Text(), nullable=False),
+            sa.Column("published_to_directory_at", sa.Text(), nullable=True),
+            sa.PrimaryKeyConstraint("enterprise_id", "root_date"),
+        )
+        op.create_index(
+            "idx_reputation_roots_published",
+            "reputation_roots",
+            ["published_to_directory_at"],
+        )
+
+
+def downgrade() -> None:
+    """Drop the roots table. Used by tests; not for production."""
+    bind = op.get_bind()
+    if _table_exists(bind, "reputation_roots"):
+        op.drop_index(
+            "idx_reputation_roots_published", table_name="reputation_roots"
+        )
+        op.drop_table("reputation_roots")

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -25,6 +25,8 @@ from . import aigrp
 from .auth import require_admin
 from .auth import router as auth_router
 from .consults import router as consults_router
+import sqlite3
+
 from .db_url import resolve_sqlite_db_path
 from .deps import API_KEY_PEPPER_ENV, require_api_key
 from .embed import compose_text, embed_text
@@ -299,10 +301,24 @@ async def lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
 
     directory_task = asyncio.create_task(directory_bootstrap_and_loop(_store))
 
+    # Task #108 sub-task 3 — daily Merkle root computation. Sleeps until
+    # next UTC midnight, then rolls up the prior day's reputation_events
+    # per Enterprise. Skipped when reputation activity hasn't started
+    # (the helper checks reputation_chain_meta).
+    from .daily_root import daily_root_loop
+
+    def _fresh_conn() -> sqlite3.Connection:
+        # Inline sqlite3.connect against the same DB path the store uses
+        # — keeps the loop's connection lifecycle independent so a
+        # long-running task can't pin the store's primary connection.
+        return sqlite3.connect(str(db_path), timeout=10)
+
+    daily_root_task = asyncio.create_task(daily_root_loop(_fresh_conn))
+
     try:
         yield
     finally:
-        for task in (aigrp_task, dsn_cache_task, directory_task):
+        for task in (aigrp_task, dsn_cache_task, directory_task, daily_root_task):
             if task is not None:
                 task.cancel()
                 with suppress(asyncio.CancelledError, Exception):
@@ -317,6 +333,9 @@ api_router.include_router(auth_router)
 api_router.include_router(review_router)
 api_router.include_router(network_router)
 api_router.include_router(consults_router)
+from .reputation_routes import router as reputation_router
+
+api_router.include_router(reputation_router)
 
 
 @api_router.get("/health")

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -315,10 +315,25 @@ async def lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
 
     daily_root_task = asyncio.create_task(daily_root_loop(_fresh_conn))
 
+    # Task #108 sub-task 4 (publish side) — periodically POSTs any
+    # unpublished daily roots to the directory. Self-disables in
+    # skip-announce mode or when CQ_ENTERPRISE_ROOT_PRIVKEY_PATH unset.
+    from .directory_client import reputation_publish_loop
+
+    reputation_publish_task = asyncio.create_task(
+        reputation_publish_loop(_fresh_conn)
+    )
+
     try:
         yield
     finally:
-        for task in (aigrp_task, dsn_cache_task, directory_task, daily_root_task):
+        for task in (
+            aigrp_task,
+            dsn_cache_task,
+            directory_task,
+            daily_root_task,
+            reputation_publish_task,
+        ):
             if task is not None:
                 task.cancel()
                 with suppress(asyncio.CancelledError, Exception):

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -33,6 +33,7 @@ from .embed import model_id as embed_model_id
 from .migrations import run_migrations
 from .network import router as network_router
 from .quality import check_propose_quality
+from .reputation_routes import router as reputation_router
 from .review import router as review_router
 from .scoring import apply_confirmation, apply_flag
 from .store import RemoteStore, normalize_domains
@@ -346,8 +347,6 @@ api_router.include_router(auth_router)
 api_router.include_router(review_router)
 api_router.include_router(network_router)
 api_router.include_router(consults_router)
-from .reputation_routes import router as reputation_router
-
 api_router.include_router(reputation_router)
 
 

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import sqlite3
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager, suppress
 from pathlib import Path
@@ -25,8 +26,6 @@ from . import aigrp
 from .auth import require_admin
 from .auth import router as auth_router
 from .consults import router as consults_router
-import sqlite3
-
 from .db_url import resolve_sqlite_db_path
 from .deps import API_KEY_PEPPER_ENV, require_api_key
 from .embed import compose_text, embed_text
@@ -229,6 +228,7 @@ async def _aigrp_bootstrap_and_poll(store: RemoteStore) -> None:
                     # we successfully fetched + stored a fresh signature from
                     # the peer. Body shape per reputation-v1.md §"peer.heartbeat".
                     from .reputation import record_event as _record_event
+
                     _record_event(
                         store._conn,
                         event_type="peer.heartbeat",
@@ -320,9 +320,7 @@ async def lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
     # skip-announce mode or when CQ_ENTERPRISE_ROOT_PRIVKEY_PATH unset.
     from .directory_client import reputation_publish_loop
 
-    reputation_publish_task = asyncio.create_task(
-        reputation_publish_loop(_fresh_conn)
-    )
+    reputation_publish_task = asyncio.create_task(reputation_publish_loop(_fresh_conn))
 
     try:
         yield

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -223,6 +223,20 @@ async def _aigrp_bootstrap_and_poll(store: RemoteStore) -> None:
                         embedding_model=sig.get("embedding_model"),
                         signature_received=True,
                     )
+                    # Reputation hook (#108 sub-task 5). Convergence event:
+                    # we successfully fetched + stored a fresh signature from
+                    # the peer. Body shape per reputation-v1.md §"peer.heartbeat".
+                    from .reputation import record_event as _record_event
+                    _record_event(
+                        store._conn,
+                        event_type="peer.heartbeat",
+                        body={
+                            "peer_l2_id": sig["l2_id"],
+                            "peer_enterprise": sig["enterprise"],
+                            "ku_count": sig.get("ku_count", 0),
+                            "domain_count": sig.get("domain_count", 0),
+                        },
+                    )
                 except Exception:
                     log.warning("aigrp poll of peer %s failed", p["l2_id"])
         except asyncio.CancelledError:

--- a/server/backend/src/cq_server/consults.py
+++ b/server/backend/src/cq_server/consults.py
@@ -653,6 +653,22 @@ def close_consult(
         logger.info("close_consult on already-closed thread_id=%s", thread_id)
     row = store.get_consult(thread_id)
     assert row is not None
+    if closed:
+        # Reputation hook (#108 sub-task 5). Best-effort — record_event
+        # swallows on failure so a flaky reputation chain never blocks
+        # consult-close. Body shape per reputation-v1.md §"consult.closed".
+        from .reputation import record_event as _record_event
+        _record_event(
+            store._conn,
+            event_type="consult.closed",
+            body={
+                "thread_id": thread_id,
+                "from_l2_id": row["from_l2_id"],
+                "to_l2_id": row["to_l2_id"],
+                "csat": row.get("csat"),
+                "resolution_summary": body.resolution_summary,
+            },
+        )
     return _to_thread_out(row)
 
 

--- a/server/backend/src/cq_server/consults.py
+++ b/server/backend/src/cq_server/consults.py
@@ -658,6 +658,7 @@ def close_consult(
         # swallows on failure so a flaky reputation chain never blocks
         # consult-close. Body shape per reputation-v1.md §"consult.closed".
         from .reputation import record_event as _record_event
+
         _record_event(
             store._conn,
             event_type="consult.closed",

--- a/server/backend/src/cq_server/daily_root.py
+++ b/server/backend/src/cq_server/daily_root.py
@@ -28,6 +28,7 @@ day skips its own write (idempotent + race-safe under SQLite WAL).
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import sqlite3
 from collections.abc import Callable
@@ -252,10 +253,8 @@ async def daily_root_loop(get_conn: Callable[[], sqlite3.Connection]) -> None:
                             yesterday,
                             exc_info=True,
                         )
-                        try:
+                        with contextlib.suppress(sqlite3.Error):
                             conn.rollback()
-                        except sqlite3.Error:
-                            pass
             finally:
                 conn.close()
         except Exception:  # noqa: BLE001 — never let this loop die

--- a/server/backend/src/cq_server/daily_root.py
+++ b/server/backend/src/cq_server/daily_root.py
@@ -30,8 +30,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import sqlite3
-from datetime import UTC, date, datetime, timedelta
-from typing import Any, Callable
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from typing import Any
 
 from .merkle import merkle_root
 from .reputation import (
@@ -56,9 +57,7 @@ def _day_window(day_iso: str) -> tuple[str, str]:
     return f"{day_iso}T00:00:00Z", f"{day_iso}T23:59:59Z"
 
 
-def _read_day_events(
-    conn: sqlite3.Connection, enterprise_id: str, day_iso: str
-) -> list[dict[str, Any]]:
+def _read_day_events(conn: sqlite3.Connection, enterprise_id: str, day_iso: str) -> list[dict[str, Any]]:
     """Return events for ``enterprise_id`` on ``day_iso``, ordered by ts ASC."""
     start_ts, end_ts = _day_window(day_iso)
     rows = conn.execute(
@@ -74,9 +73,7 @@ def _read_day_events(
     return [{"event_id": r[0], "ts": r[1], "payload_hash": r[2]} for r in rows]
 
 
-def _existing_root(
-    conn: sqlite3.Connection, enterprise_id: str, day_iso: str
-) -> dict[str, Any] | None:
+def _existing_root(conn: sqlite3.Connection, enterprise_id: str, day_iso: str) -> dict[str, Any] | None:
     row = conn.execute(
         """
         SELECT enterprise_id, root_date, event_count, merkle_root_hash,
@@ -103,9 +100,7 @@ def _existing_root(
     }
 
 
-def compute_root_for_day(
-    conn: sqlite3.Connection, enterprise_id: str, day_iso: str
-) -> dict[str, Any]:
+def compute_root_for_day(conn: sqlite3.Connection, enterprise_id: str, day_iso: str) -> dict[str, Any]:
     """Compute (or fetch existing) Merkle root for one Enterprise-day.
 
     Idempotent — returns the existing row if already computed. The
@@ -198,9 +193,7 @@ def _all_enterprise_ids(conn: sqlite3.Connection) -> list[str]:
     Sources from ``reputation_chain_meta`` rather than scanning events
     directly — chain meta is one row per Enterprise so this is cheap.
     """
-    rows = conn.execute(
-        "SELECT enterprise_id FROM reputation_chain_meta"
-    ).fetchall()
+    rows = conn.execute("SELECT enterprise_id FROM reputation_chain_meta").fetchall()
     return [r[0] for r in rows]
 
 
@@ -246,8 +239,7 @@ async def daily_root_loop(get_conn: Callable[[], sqlite3.Connection]) -> None:
                         result = compute_root_for_day(conn, enterprise_id, yesterday)
                         conn.commit()
                         logger.info(
-                            "daily_root_loop: computed root enterprise=%s day=%s "
-                            "events=%d root=%s",
+                            "daily_root_loop: computed root enterprise=%s day=%s events=%d root=%s",
                             enterprise_id,
                             yesterday,
                             result["event_count"],
@@ -267,14 +259,10 @@ async def daily_root_loop(get_conn: Callable[[], sqlite3.Connection]) -> None:
             finally:
                 conn.close()
         except Exception:  # noqa: BLE001 — never let this loop die
-            logger.warning(
-                "daily_root_loop: outer iteration crashed", exc_info=True
-            )
+            logger.warning("daily_root_loop: outer iteration crashed", exc_info=True)
 
 
-def compute_yesterday_root_now(
-    conn: sqlite3.Connection, enterprise_id: str
-) -> dict[str, Any]:
+def compute_yesterday_root_now(conn: sqlite3.Connection, enterprise_id: str) -> dict[str, Any]:
     """Convenience: compute yesterday's root immediately (no scheduling).
 
     Used by tests + an admin trigger endpoint. Never called from the

--- a/server/backend/src/cq_server/daily_root.py
+++ b/server/backend/src/cq_server/daily_root.py
@@ -1,0 +1,284 @@
+"""Daily Merkle root computation + persistence (task #108 sub-task 3).
+
+Per [decision 13](crosstalk-enterprise/docs/decisions/13) §"daily root publish",
+the L2 computes a SHA-256 Merkle tree over each UTC day's reputation_events
+and writes the signed root to ``reputation_roots``. A separate
+publish step (sub-task 4) POSTs the row to the directory.
+
+Two entry points:
+
+- ``compute_root_for_day(conn, enterprise_id, day_iso)`` — synchronous
+  helper. Idempotent: if a row already exists for that
+  (enterprise_id, day) it returns the existing row instead of
+  recomputing. Tests can call directly.
+
+- ``daily_root_loop(get_store)`` — asyncio task started in app.py
+  lifespan. Sleeps until the next UTC midnight, then computes the
+  prior day's root for every Enterprise present in
+  ``reputation_chain_meta``. Errors are logged; the loop never
+  exits (runs for the lifetime of the process).
+
+Single-writer assumption: in v1, one cq-server per Enterprise computes
+the root. Multi-L2 leadership handover is decision-13 future work.
+For now we serialize via ``reputation_chain_meta.last_root_published_day``
+— a process that finds that column already advanced for the target
+day skips its own write (idempotent + race-safe under SQLite WAL).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sqlite3
+from datetime import UTC, date, datetime, timedelta
+from typing import Any, Callable
+
+from .merkle import merkle_root
+from .reputation import (
+    canonical_payload_bytes,
+    sign_canonical_bytes,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _day_window(day_iso: str) -> tuple[str, str]:
+    """Return (start_ts, end_ts) covering one UTC day.
+
+    Reputation event ts strings are RFC 3339 / ISO-8601 UTC
+    (``YYYY-MM-DDTHH:MM:SSZ``). Lexicographic comparison on those
+    strings is correct for date-windowed queries — no need to parse.
+    """
+    return f"{day_iso}T00:00:00Z", f"{day_iso}T23:59:59Z"
+
+
+def _read_day_events(
+    conn: sqlite3.Connection, enterprise_id: str, day_iso: str
+) -> list[dict[str, Any]]:
+    """Return events for ``enterprise_id`` on ``day_iso``, ordered by ts ASC."""
+    start_ts, end_ts = _day_window(day_iso)
+    rows = conn.execute(
+        """
+        SELECT event_id, ts, payload_hash
+        FROM reputation_events
+        WHERE enterprise_id = ?
+          AND ts >= ? AND ts <= ?
+        ORDER BY ts ASC, event_id ASC
+        """,
+        (enterprise_id, start_ts, end_ts),
+    ).fetchall()
+    return [{"event_id": r[0], "ts": r[1], "payload_hash": r[2]} for r in rows]
+
+
+def _existing_root(
+    conn: sqlite3.Connection, enterprise_id: str, day_iso: str
+) -> dict[str, Any] | None:
+    row = conn.execute(
+        """
+        SELECT enterprise_id, root_date, event_count, merkle_root_hash,
+               first_event_id, last_event_id, signature_b64u, signing_key_id,
+               computed_at, published_to_directory_at
+        FROM reputation_roots
+        WHERE enterprise_id = ? AND root_date = ?
+        """,
+        (enterprise_id, day_iso),
+    ).fetchone()
+    if row is None:
+        return None
+    return {
+        "enterprise_id": row[0],
+        "root_date": row[1],
+        "event_count": row[2],
+        "merkle_root_hash": row[3],
+        "first_event_id": row[4],
+        "last_event_id": row[5],
+        "signature_b64u": row[6],
+        "signing_key_id": row[7],
+        "computed_at": row[8],
+        "published_to_directory_at": row[9],
+    }
+
+
+def compute_root_for_day(
+    conn: sqlite3.Connection, enterprise_id: str, day_iso: str
+) -> dict[str, Any]:
+    """Compute (or fetch existing) Merkle root for one Enterprise-day.
+
+    Idempotent — returns the existing row if already computed. The
+    canonical payload signed is the JCS form of
+    ``{enterprise_id, root_date, event_count, merkle_root_hash,
+       first_event_id, last_event_id}``; signature lands in
+    ``signature_b64u`` next to the row.
+
+    Args:
+        conn: open sqlite3 connection (caller owns the transaction).
+        enterprise_id: tenant id whose chain we're rolling up.
+        day_iso: ``YYYY-MM-DD`` UTC date.
+
+    Returns:
+        The persisted row as a dict.
+    """
+    existing = _existing_root(conn, enterprise_id, day_iso)
+    if existing is not None:
+        return existing
+
+    events = _read_day_events(conn, enterprise_id, day_iso)
+    leaf_hashes = [e["payload_hash"] for e in events]
+    root_hash = merkle_root(leaf_hashes)
+    first_event_id = events[0]["event_id"] if events else None
+    last_event_id = events[-1]["event_id"] if events else None
+    event_count = len(events)
+    computed_at = _utc_now_iso()
+
+    payload = {
+        "enterprise_id": enterprise_id,
+        "root_date": day_iso,
+        "event_count": event_count,
+        "merkle_root_hash": root_hash,
+        "first_event_id": first_event_id,
+        "last_event_id": last_event_id,
+    }
+    canonical = canonical_payload_bytes(payload)
+    signature_b64u, signing_key_id = sign_canonical_bytes(canonical)
+
+    conn.execute(
+        """
+        INSERT INTO reputation_roots
+            (enterprise_id, root_date, event_count, merkle_root_hash,
+             first_event_id, last_event_id, signature_b64u, signing_key_id,
+             computed_at, published_to_directory_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+        """,
+        (
+            enterprise_id,
+            day_iso,
+            event_count,
+            root_hash,
+            first_event_id,
+            last_event_id,
+            signature_b64u,
+            signing_key_id,
+            computed_at,
+        ),
+    )
+
+    # Bump chain meta so a subsequent run on the same day no-ops.
+    conn.execute(
+        """
+        UPDATE reputation_chain_meta
+        SET last_root_published_day = ?, updated_at = ?
+        WHERE enterprise_id = ? AND (
+            last_root_published_day IS NULL OR last_root_published_day < ?
+        )
+        """,
+        (day_iso, computed_at, enterprise_id, day_iso),
+    )
+
+    return {
+        "enterprise_id": enterprise_id,
+        "root_date": day_iso,
+        "event_count": event_count,
+        "merkle_root_hash": root_hash,
+        "first_event_id": first_event_id,
+        "last_event_id": last_event_id,
+        "signature_b64u": signature_b64u,
+        "signing_key_id": signing_key_id,
+        "computed_at": computed_at,
+        "published_to_directory_at": None,
+    }
+
+
+def _all_enterprise_ids(conn: sqlite3.Connection) -> list[str]:
+    """Return Enterprise ids that have any reputation activity.
+
+    Sources from ``reputation_chain_meta`` rather than scanning events
+    directly — chain meta is one row per Enterprise so this is cheap.
+    """
+    rows = conn.execute(
+        "SELECT enterprise_id FROM reputation_chain_meta"
+    ).fetchall()
+    return [r[0] for r in rows]
+
+
+def _seconds_until_next_utc_midnight() -> float:
+    now = datetime.now(UTC)
+    tomorrow = (now + timedelta(days=1)).date()
+    next_midnight = datetime.combine(tomorrow, datetime.min.time(), tzinfo=UTC)
+    return (next_midnight - now).total_seconds()
+
+
+async def daily_root_loop(get_conn: Callable[[], sqlite3.Connection]) -> None:
+    """Asyncio task: roll up yesterday's events at every UTC midnight.
+
+    Started by ``app.py`` lifespan. Sleeps until next midnight, then
+    iterates every Enterprise present in ``reputation_chain_meta`` and
+    calls ``compute_root_for_day`` for the prior UTC day. Errors are
+    logged per-Enterprise — one bad day doesn't break the loop.
+
+    Args:
+        get_conn: zero-arg callable returning a fresh sqlite3 connection
+            against the L2's database. The loop owns the lifecycle of
+            each connection it opens (per-iteration), so the underlying
+            Store can keep its own.
+    """
+    while True:
+        try:
+            sleep_for = _seconds_until_next_utc_midnight()
+            logger.info(
+                "daily_root_loop: sleeping %.0fs until next UTC midnight",
+                sleep_for,
+            )
+            await asyncio.sleep(sleep_for)
+        except asyncio.CancelledError:
+            logger.info("daily_root_loop: cancelled, exiting")
+            return
+
+        yesterday = (datetime.now(UTC).date() - timedelta(days=1)).isoformat()
+        try:
+            conn = get_conn()
+            try:
+                for enterprise_id in _all_enterprise_ids(conn):
+                    try:
+                        result = compute_root_for_day(conn, enterprise_id, yesterday)
+                        conn.commit()
+                        logger.info(
+                            "daily_root_loop: computed root enterprise=%s day=%s "
+                            "events=%d root=%s",
+                            enterprise_id,
+                            yesterday,
+                            result["event_count"],
+                            result["merkle_root_hash"],
+                        )
+                    except Exception:  # noqa: BLE001
+                        logger.warning(
+                            "daily_root_loop: failed for enterprise=%s day=%s",
+                            enterprise_id,
+                            yesterday,
+                            exc_info=True,
+                        )
+                        try:
+                            conn.rollback()
+                        except sqlite3.Error:
+                            pass
+            finally:
+                conn.close()
+        except Exception:  # noqa: BLE001 — never let this loop die
+            logger.warning(
+                "daily_root_loop: outer iteration crashed", exc_info=True
+            )
+
+
+def compute_yesterday_root_now(
+    conn: sqlite3.Connection, enterprise_id: str
+) -> dict[str, Any]:
+    """Convenience: compute yesterday's root immediately (no scheduling).
+
+    Used by tests + an admin trigger endpoint. Never called from the
+    loop itself — the loop computes inline.
+    """
+    yesterday = (datetime.now(UTC).date() - timedelta(days=1)).isoformat()
+    return compute_root_for_day(conn, enterprise_id, yesterday)

--- a/server/backend/src/cq_server/directory_client.py
+++ b/server/backend/src/cq_server/directory_client.py
@@ -38,6 +38,8 @@ import asyncio
 import json
 import logging
 import os
+import sqlite3
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -71,6 +73,8 @@ __all__ = [
     "directory_bootstrap_and_loop",
     "directory_enabled",
     "directory_url",
+    "publish_reputation_root",
+    "reputation_publish_loop",
     "fingerprint_sha256",
     "load_private_key",
     "now_iso",
@@ -409,6 +413,155 @@ def _load_endpoints_config() -> list[dict[str, Any]]:
             "groups": [group],
         }
     ]
+
+
+async def publish_reputation_root(
+    client: httpx.AsyncClient,
+    privkey: Ed25519PrivateKey,
+    *,
+    enterprise_id: str,
+    root_date: str,
+    event_count: int,
+    merkle_root_hash: str,
+    first_event_id: str | None,
+    last_event_id: str | None,
+) -> tuple[int, dict[str, Any] | None]:
+    """POST one daily Merkle root to the directory's /reputation/root.
+
+    Signed with the enterprise's AAISN root privkey (per directory v1
+    accept rule — see decision 21 + the directory route docstring).
+    Returns (status_code, response_body | None on error). 200/201 are
+    success; 400/401 indicate caller-side issues; 0 indicates network
+    failure.
+    """
+    payload = {
+        "enterprise_id": enterprise_id,
+        "root_date": root_date,
+        "event_count": event_count,
+        "merkle_root_hash": merkle_root_hash,
+        "first_event_id": first_event_id,
+        "last_event_id": last_event_id,
+    }
+    envelope = sign_envelope(privkey, payload)
+    url = f"{directory_url()}/api/v1/directory/reputation/root"
+    try:
+        r = await client.post(url, json=envelope, timeout=10.0)
+    except httpx.RequestError as e:
+        log.warning("directory: reputation/root publish failed (network) err=%s", e)
+        return 0, None
+    if r.status_code in (200, 201):
+        log.info(
+            "directory: reputation/root ok enterprise=%s day=%s status=%d",
+            enterprise_id,
+            root_date,
+            r.status_code,
+        )
+        return r.status_code, r.json()
+    log.warning(
+        "directory: reputation/root rejected enterprise=%s day=%s status=%d body=%s",
+        enterprise_id,
+        root_date,
+        r.status_code,
+        r.text[:200],
+    )
+    return r.status_code, None
+
+
+async def reputation_publish_loop(get_conn: "Callable[[], sqlite3.Connection]") -> None:
+    """Periodically POST any unpublished daily roots to the directory.
+
+    Runs every ``CQ_DIRECTORY_PUBLISH_INTERVAL_SEC`` (default 5 min).
+    Polls ``reputation_roots WHERE published_to_directory_at IS NULL``
+    and publishes each. Updates ``published_to_directory_at`` on
+    success. Failures are logged and retried on the next tick — the
+    column stays NULL until success.
+
+    Decoupled from the daily-root computation loop on purpose: a
+    network blip during compute shouldn't lose the root, and a delayed
+    compute (recovered missed cron) shouldn't block other Enterprises'
+    publishing.
+    """
+    if not directory_enabled():
+        log.info("directory: reputation publish loop disabled (CQ_DIRECTORY_ENABLED!=true)")
+        return
+
+    if skip_announce():
+        # Skip-announce mode means no privkey on disk; we can't sign roots.
+        log.info(
+            "directory: reputation publish loop disabled (CQ_DIRECTORY_SKIP_ANNOUNCE=true)"
+        )
+        return
+
+    privkey_path = os.environ.get("CQ_ENTERPRISE_ROOT_PRIVKEY_PATH", "")
+    if not privkey_path:
+        log.info(
+            "directory: reputation publish loop disabled "
+            "(CQ_ENTERPRISE_ROOT_PRIVKEY_PATH unset)"
+        )
+        return
+
+    try:
+        privkey = load_private_key(Path(privkey_path))
+    except (FileNotFoundError, ValueError) as e:
+        log.error(
+            "directory: reputation publish — cannot load privkey path=%s err=%s",
+            privkey_path,
+            e,
+        )
+        return
+
+    interval = int(os.environ.get("CQ_DIRECTORY_PUBLISH_INTERVAL_SEC", "300"))
+    log.info("directory: reputation publish loop starting (interval=%ds)", interval)
+
+    async with httpx.AsyncClient() as client:
+        while True:
+            try:
+                await asyncio.sleep(interval)
+            except asyncio.CancelledError:
+                log.info("directory: reputation publish loop cancelled")
+                return
+
+            try:
+                conn = get_conn()
+                try:
+                    rows = conn.execute(
+                        """
+                        SELECT enterprise_id, root_date, event_count,
+                               merkle_root_hash, first_event_id, last_event_id
+                        FROM reputation_roots
+                        WHERE published_to_directory_at IS NULL
+                        ORDER BY root_date ASC
+                        LIMIT 50
+                        """
+                    ).fetchall()
+                    for row in rows:
+                        status, _body = await publish_reputation_root(
+                            client,
+                            privkey,
+                            enterprise_id=row[0],
+                            root_date=row[1],
+                            event_count=row[2],
+                            merkle_root_hash=row[3],
+                            first_event_id=row[4],
+                            last_event_id=row[5],
+                        )
+                        if status in (200, 201):
+                            conn.execute(
+                                """
+                                UPDATE reputation_roots
+                                SET published_to_directory_at = ?
+                                WHERE enterprise_id = ? AND root_date = ?
+                                """,
+                                (now_iso(), row[0], row[1]),
+                            )
+                            conn.commit()
+                finally:
+                    conn.close()
+            except Exception:  # noqa: BLE001 — never let this loop die
+                log.warning(
+                    "directory: reputation publish loop iteration crashed",
+                    exc_info=True,
+                )
 
 
 async def directory_bootstrap_and_loop(store: RemoteStore) -> None:

--- a/server/backend/src/cq_server/directory_client.py
+++ b/server/backend/src/cq_server/directory_client.py
@@ -467,7 +467,7 @@ async def publish_reputation_root(
     return r.status_code, None
 
 
-async def reputation_publish_loop(get_conn: "Callable[[], sqlite3.Connection]") -> None:
+async def reputation_publish_loop(get_conn: Callable[[], sqlite3.Connection]) -> None:
     """Periodically POST any unpublished daily roots to the directory.
 
     Runs every ``CQ_DIRECTORY_PUBLISH_INTERVAL_SEC`` (default 5 min).
@@ -487,17 +487,12 @@ async def reputation_publish_loop(get_conn: "Callable[[], sqlite3.Connection]") 
 
     if skip_announce():
         # Skip-announce mode means no privkey on disk; we can't sign roots.
-        log.info(
-            "directory: reputation publish loop disabled (CQ_DIRECTORY_SKIP_ANNOUNCE=true)"
-        )
+        log.info("directory: reputation publish loop disabled (CQ_DIRECTORY_SKIP_ANNOUNCE=true)")
         return
 
     privkey_path = os.environ.get("CQ_ENTERPRISE_ROOT_PRIVKEY_PATH", "")
     if not privkey_path:
-        log.info(
-            "directory: reputation publish loop disabled "
-            "(CQ_ENTERPRISE_ROOT_PRIVKEY_PATH unset)"
-        )
+        log.info("directory: reputation publish loop disabled (CQ_ENTERPRISE_ROOT_PRIVKEY_PATH unset)")
         return
 
     try:

--- a/server/backend/src/cq_server/merkle.py
+++ b/server/backend/src/cq_server/merkle.py
@@ -31,16 +31,14 @@ import hashlib
 # sha256("8l-reputation-empty-day-v1") — non-overlapping with any
 # real Merkle root because real leaves are sha256(canonical-payload)
 # pre-images of canonical event bodies, never this fixed string.
-EMPTY_DAY_ROOT: str = (
-    "sha256:" + hashlib.sha256(b"8l-reputation-empty-day-v1").hexdigest()
-)
+EMPTY_DAY_ROOT: str = "sha256:" + hashlib.sha256(b"8l-reputation-empty-day-v1").hexdigest()
 
 
 def _strip_prefix(h: str) -> bytes:
     """Convert a ``sha256:<hex>`` string to the underlying 32-byte digest."""
     if not h.startswith("sha256:"):
         raise ValueError(f"expected sha256:<hex> form, got {h!r}")
-    return bytes.fromhex(h[len("sha256:"):])
+    return bytes.fromhex(h[len("sha256:") :])
 
 
 def _hash_pair(left: bytes, right: bytes) -> bytes:

--- a/server/backend/src/cq_server/merkle.py
+++ b/server/backend/src/cq_server/merkle.py
@@ -1,0 +1,74 @@
+"""SHA-256 Merkle tree over reputation event hashes (task #108 sub-task 3).
+
+A small, dependency-free implementation tailored to the reputation log:
+inputs are leaf hashes already in ``sha256:<hex>`` format (the
+``payload_hash`` column from ``reputation_events``). Output is a single
+``sha256:<hex>`` root.
+
+Tree shape: classical binary, leaves left-to-right in the order the
+caller passes them (callers pre-sort by ``ts`` ASC). When a level has
+an odd number of nodes, the last node is duplicated (RFC 6962 / Bitcoin
+convention) — keeps the tree balanced at the cost of allowing two
+distinct leaf sets to produce the same root only if one is a duplicate
+of the other (not a concern here: caller guarantees uniqueness per
+day per Enterprise via the chain hash).
+
+Empty input: returns a fixed zero-event constant (``EMPTY_DAY_ROOT``)
+so day-over-day roots form a continuous chain even when a day has zero
+events. Verifiers treat the constant as "no events that day" without
+needing a special case in the wire format.
+
+Inclusion proofs are *not* implemented in v1. They land if/when the
+verifier library (#108 sub-task 7) needs them; for now verification
+re-derives the full root from the chain.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+# A constant root for days with zero events. Computed as
+# sha256("8l-reputation-empty-day-v1") — non-overlapping with any
+# real Merkle root because real leaves are sha256(canonical-payload)
+# pre-images of canonical event bodies, never this fixed string.
+EMPTY_DAY_ROOT: str = (
+    "sha256:" + hashlib.sha256(b"8l-reputation-empty-day-v1").hexdigest()
+)
+
+
+def _strip_prefix(h: str) -> bytes:
+    """Convert a ``sha256:<hex>`` string to the underlying 32-byte digest."""
+    if not h.startswith("sha256:"):
+        raise ValueError(f"expected sha256:<hex> form, got {h!r}")
+    return bytes.fromhex(h[len("sha256:"):])
+
+
+def _hash_pair(left: bytes, right: bytes) -> bytes:
+    """Concatenate-and-hash two 32-byte digests."""
+    return hashlib.sha256(left + right).digest()
+
+
+def merkle_root(leaf_hashes: list[str]) -> str:
+    """Return the Merkle root over a list of ``sha256:<hex>`` leaf hashes.
+
+    Args:
+        leaf_hashes: list of leaf payload hashes in ``sha256:<hex>``
+            format (the ``payload_hash`` column from
+            ``reputation_events``). Order is load-bearing — the caller
+            sorts by event ``ts`` ASC before calling. Duplicates are
+            permitted (the chain hash rules out same-day collisions
+            in practice).
+
+    Returns:
+        The root as ``sha256:<hex>``. Returns ``EMPTY_DAY_ROOT`` when
+        ``leaf_hashes`` is empty.
+    """
+    if not leaf_hashes:
+        return EMPTY_DAY_ROOT
+
+    level: list[bytes] = [_strip_prefix(h) for h in leaf_hashes]
+    while len(level) > 1:
+        if len(level) % 2 == 1:
+            level.append(level[-1])  # duplicate last node — RFC 6962 style
+        level = [_hash_pair(level[i], level[i + 1]) for i in range(0, len(level), 2)]
+    return "sha256:" + level[0].hex()

--- a/server/backend/src/cq_server/migrations.py
+++ b/server/backend/src/cq_server/migrations.py
@@ -36,7 +36,7 @@ BASELINE_REVISION = "0001"
 # Phase 2 (task #100) — chain head after porting fork-delta tables to
 # Alembic. Update this string when adding a new migration so test
 # assertions and ops scripts stay in sync with the actual chain head.
-HEAD_REVISION = "0008_reputation"
+HEAD_REVISION = "0009_reputation_roots"
 
 
 def _find_alembic_ini() -> Path:

--- a/server/backend/src/cq_server/reputation.py
+++ b/server/backend/src/cq_server/reputation.py
@@ -1,25 +1,33 @@
-"""Reputation log v1-alpha — append-only hash chain.
+"""Reputation log v1 — Ed25519-signed append-only hash chain.
 
-Per [decision 13](crosstalk-enterprise/docs/decisions/13) and
+Per [decision 13](crosstalk-enterprise/docs/decisions/13),
+[decision 21](crosstalk-enterprise/docs/decisions/21) (key location), and
 [reputation-v1 spec](crosstalk-enterprise/docs/specs/reputation-v1.md).
 
 This module is the writer-side foundation: it builds canonical event
-records, hash-chains them via ``prev_event_hash``, persists to the
-``reputation_events`` table, and updates ``reputation_chain_meta``.
+records, hash-chains them via ``prev_event_hash``, signs the canonical
+payload with this L2's Ed25519 key (the same key that signs forward-*
+requests), and persists to the ``reputation_events`` table.
 
-What's IN v1-alpha (this module):
+What's IN v1 (this module):
     * Event canonicalisation via RFC 8785 (JCS).
     * Hash chain via SHA-256 over the canonical bytes.
+    * Ed25519 signing — reuses the L2 forward-sign key from
+      ``forward_sign.get_l2_privkey()``. Signing identity = L2 identity,
+      verifiable against the same ``aigrp_peers.public_key_ed25519``
+      that peers already use for forward-* signature verification.
     * ``record_event(...)`` helper — single API surface for callers.
+    * Backward compatibility: when no signing key is available (test
+      scenarios, signing-disabled deploys), event rows are written with
+      ``signature_b64u = NULL`` and ``signing_key_id = NULL``. Verifiers
+      treat unsigned events as legacy/best-effort.
 
-What's deferred to v1 (follow-up):
-    * Ed25519 signing (``signature_b64u`` is NULL in alpha; column
-      already exists in the schema so signing lands without another
-      migration).
+What's deferred to v1-real (follow-up):
     * Daily Merkle root publish to the directory.
-    * Sibling-L2 chain leader lease (single-L2 enterprise only in
-      alpha — chain hash is per-enterprise but writes are
-      single-writer).
+    * Sibling-L2 chain leader lease (single-L2 enterprise only —
+      chain hash is per-enterprise but writes are single-writer).
+    * Bilateral countersigning of reputation roots by peer Enterprises
+      (decision 13 shape B).
 
 Callers hook ``record_event`` at the three event sites called out in
 decision 13: consult-close, KU lifecycle transitions, AIGRP peer
@@ -39,12 +47,16 @@ import sqlite3
 from datetime import UTC, datetime
 from typing import Any
 
+from .crypto import sign_raw
+from .forward_sign import get_l2_privkey, self_public_key_b64u
+
 __all__ = [
     "GENESIS_PREV_HASH",
     "canonical_payload_bytes",
     "compute_payload_hash",
     "make_event_id",
     "record_event",
+    "sign_canonical_bytes",
 ]
 
 logger = logging.getLogger(__name__)
@@ -90,6 +102,30 @@ def canonical_payload_bytes(payload: dict[str, Any]) -> bytes:
 def compute_payload_hash(canonical_bytes: bytes) -> str:
     """Return ``sha256:<hex>`` for the canonical bytes."""
     return "sha256:" + hashlib.sha256(canonical_bytes).hexdigest()
+
+
+def sign_canonical_bytes(canonical: bytes) -> tuple[str | None, str | None]:
+    """Sign canonical event bytes with this L2's Ed25519 forward-sign key.
+
+    Returns ``(signature_b64u, signing_key_id)`` on success. The signing
+    key id is the L2's base64url-encoded public key — self-describing, so
+    verifiers don't have to query ``aigrp_peers`` to learn which key
+    signed (though they can re-verify against ``aigrp_peers`` for trust
+    anchoring).
+
+    Returns ``(None, None)`` when signing is disabled (no key on disk).
+    Callers in this case write NULL signature columns; verifiers treat
+    unsigned rows as legacy/best-effort. This matches the rollout-window
+    pattern used for ``X-8L-Forwarder-Sig`` (see ``forward_sign``).
+    """
+    pk = get_l2_privkey()
+    if pk is None:
+        return None, None
+    pub = self_public_key_b64u()
+    if pub is None:
+        return None, None
+    signature = sign_raw(pk, canonical)
+    return signature, pub
 
 
 def _self_l2_id() -> str:
@@ -205,6 +241,7 @@ def record_event(
         }
         canonical = canonical_payload_bytes(payload)
         payload_hash = compute_payload_hash(canonical)
+        signature_b64u, signing_key_id = sign_canonical_bytes(canonical)
 
         conn.execute(
             """
@@ -212,7 +249,7 @@ def record_event(
                 (event_id, event_type, enterprise_id, l2_id, ts,
                  prev_event_hash, payload_canonical, payload_hash,
                  signature_b64u, signing_key_id, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 event_id,
@@ -223,6 +260,8 @@ def record_event(
                 prev_event_hash,
                 canonical.decode("utf-8"),
                 payload_hash,
+                signature_b64u,
+                signing_key_id,
                 _utc_now_iso(),
             ),
         )

--- a/server/backend/src/cq_server/reputation.py
+++ b/server/backend/src/cq_server/reputation.py
@@ -76,12 +76,12 @@ def _utc_now_iso() -> str:
 
 
 def canonical_payload_bytes(payload: dict[str, Any]) -> bytes:
-    """Return RFC-8785-canonicalised JSON bytes for the payload.
+    r"""Return RFC-8785-canonicalised JSON bytes for the payload.
 
     Stand-in implementation: ``json.dumps`` with ``sort_keys=True``,
     tight separators, and ``ensure_ascii=False`` so non-ASCII
     characters are emitted as raw UTF-8 (per RFC 8785 §3.2.2) instead
-    of ``\\uXXXX`` escapes. Without ``ensure_ascii=False``, a body
+    of ``\uXXXX`` escapes. Without ``ensure_ascii=False``, a body
     containing any accented character (persona name, summary fragment)
     would produce canonical bytes that differ from a conformant JCS
     verifier's output — once Ed25519 signing lands, signatures would
@@ -277,8 +277,7 @@ def record_event(
                 # If even the rollback fails, the connection is in a
                 # weird place — but we still must not propagate.
                 logger.warning(
-                    "reputation: SAVEPOINT rollback failed; connection "
-                    "may be in inconsistent state",
+                    "reputation: SAVEPOINT rollback failed; connection may be in inconsistent state",
                     exc_info=True,
                 )
         logger.warning(

--- a/server/backend/src/cq_server/reputation.py
+++ b/server/backend/src/cq_server/reputation.py
@@ -202,8 +202,12 @@ def record_event(
         event_type: One of ``consult.closed``, ``ku.event``,
             ``peer.heartbeat``. Validated lightly here.
         body: Event-type-specific body. See ``reputation-v1.md``.
-        enterprise_id, l2_id, ts: Optional overrides. Default to
-            this L2's identity + UTC now.
+        enterprise_id: Override for the Enterprise this event belongs
+            to. Defaults to ``CQ_ENTERPRISE`` env (this L2's tenant).
+        l2_id: Override for the writing L2's id. Defaults to
+            ``CQ_ENTERPRISE/CQ_GROUP``.
+        ts: Override for the event timestamp (RFC 3339 / UTC).
+            Defaults to the current UTC time.
 
     Returns:
         The new event_id on success, or ``None`` if recording was

--- a/server/backend/src/cq_server/reputation_routes.py
+++ b/server/backend/src/cq_server/reputation_routes.py
@@ -1,0 +1,220 @@
+"""Reputation reader endpoints (task #108 sub-tasks 6 + admin trigger).
+
+Two read-only endpoints under ``/reputation/...``:
+
+- ``GET /reputation/events`` — paginated event stream, JWT-gated,
+  scoped to the caller's Enterprise. The signature columns are
+  surfaced so external verifiers can re-check signatures without
+  having to query the events table directly.
+- ``GET /reputation/roots`` — daily Merkle roots, same scoping.
+
+Plus an admin-only ``POST /reputation/roots/compute`` that triggers
+a same-day or yesterday root computation immediately. Useful for
+testing + recovery from a missed cron tick.
+
+Authn pattern mirrors review.py: JWT bearer via ``get_current_user``.
+The Enterprise scope is resolved from the user's row — same logic
+as ``_admin_enterprise`` but available to any authenticated user
+(reading your own Enterprise's reputation chain isn't admin-gated).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from .auth import get_current_user, require_admin
+from .deps import get_store
+from .store import RemoteStore
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/reputation", tags=["reputation"])
+
+
+class EventOut(BaseModel):
+    event_id: str
+    event_type: str
+    enterprise_id: str
+    l2_id: str
+    ts: str
+    prev_event_hash: str
+    payload_canonical: str
+    payload_hash: str
+    signature_b64u: str | None
+    signing_key_id: str | None
+    created_at: str
+
+
+class EventsResponse(BaseModel):
+    events: list[EventOut]
+    total: int
+    limit: int
+    offset: int
+
+
+class RootOut(BaseModel):
+    enterprise_id: str
+    root_date: str
+    event_count: int
+    merkle_root_hash: str
+    first_event_id: str | None
+    last_event_id: str | None
+    signature_b64u: str | None
+    signing_key_id: str | None
+    computed_at: str
+    published_to_directory_at: str | None
+
+
+class RootsResponse(BaseModel):
+    roots: list[RootOut]
+    total: int
+
+
+def _user_enterprise(username: str, store: RemoteStore) -> str:
+    """Resolve the authenticated user's Enterprise id.
+
+    Raises 403 if the user has no Enterprise (defensive — every user
+    row has one in practice, but a stale row would otherwise leak
+    cross-tenant data on the GET).
+    """
+    user = store.get_user(username)
+    if user is None:
+        raise HTTPException(status_code=403, detail="user not found")
+    enterprise_id = user.get("enterprise_id")
+    if not enterprise_id:
+        raise HTTPException(status_code=403, detail="user has no enterprise scope")
+    return enterprise_id
+
+
+@router.get("/events", response_model=EventsResponse)
+def list_reputation_events(
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    event_type: str | None = Query(default=None),
+    store: RemoteStore = Depends(get_store),
+    username: str = Depends(get_current_user),
+) -> EventsResponse:
+    """Return reputation events for the caller's Enterprise.
+
+    Newest-first by ``ts`` — pagination via offset/limit. Optional
+    ``event_type`` filter narrows to one of ``consult.closed``,
+    ``ku.event``, ``peer.heartbeat``.
+
+    The full ``payload_canonical`` is returned so verifiers can
+    re-derive ``payload_hash`` and re-verify the signature locally
+    without trusting the server's stored values.
+    """
+    enterprise_id = _user_enterprise(username, store)
+
+    base = (
+        "SELECT event_id, event_type, enterprise_id, l2_id, ts, "
+        "prev_event_hash, payload_canonical, payload_hash, "
+        "signature_b64u, signing_key_id, created_at "
+        "FROM reputation_events WHERE enterprise_id = ?"
+    )
+    count_base = "SELECT COUNT(*) FROM reputation_events WHERE enterprise_id = ?"
+    params: list[Any] = [enterprise_id]
+    count_params: list[Any] = [enterprise_id]
+    if event_type is not None:
+        base += " AND event_type = ?"
+        count_base += " AND event_type = ?"
+        params.append(event_type)
+        count_params.append(event_type)
+    base += " ORDER BY ts DESC, event_id DESC LIMIT ? OFFSET ?"
+    params.extend([limit, offset])
+
+    with store._lock:
+        rows = store._conn.execute(base, params).fetchall()
+        total = store._conn.execute(count_base, count_params).fetchone()[0]
+
+    events = [
+        EventOut(
+            event_id=r[0],
+            event_type=r[1],
+            enterprise_id=r[2],
+            l2_id=r[3],
+            ts=r[4],
+            prev_event_hash=r[5],
+            payload_canonical=r[6],
+            payload_hash=r[7],
+            signature_b64u=r[8],
+            signing_key_id=r[9],
+            created_at=r[10],
+        )
+        for r in rows
+    ]
+    return EventsResponse(events=events, total=total, limit=limit, offset=offset)
+
+
+@router.get("/roots", response_model=RootsResponse)
+def list_reputation_roots(
+    limit: int = Query(default=90, ge=1, le=365),
+    store: RemoteStore = Depends(get_store),
+    username: str = Depends(get_current_user),
+) -> RootsResponse:
+    """Return daily Merkle roots for the caller's Enterprise, newest first."""
+    enterprise_id = _user_enterprise(username, store)
+
+    with store._lock:
+        rows = store._conn.execute(
+            """
+            SELECT enterprise_id, root_date, event_count, merkle_root_hash,
+                   first_event_id, last_event_id, signature_b64u, signing_key_id,
+                   computed_at, published_to_directory_at
+            FROM reputation_roots
+            WHERE enterprise_id = ?
+            ORDER BY root_date DESC
+            LIMIT ?
+            """,
+            (enterprise_id, limit),
+        ).fetchall()
+        total = store._conn.execute(
+            "SELECT COUNT(*) FROM reputation_roots WHERE enterprise_id = ?",
+            (enterprise_id,),
+        ).fetchone()[0]
+
+    roots = [
+        RootOut(
+            enterprise_id=r[0],
+            root_date=r[1],
+            event_count=r[2],
+            merkle_root_hash=r[3],
+            first_event_id=r[4],
+            last_event_id=r[5],
+            signature_b64u=r[6],
+            signing_key_id=r[7],
+            computed_at=r[8],
+            published_to_directory_at=r[9],
+        )
+        for r in rows
+    ]
+    return RootsResponse(roots=roots, total=total)
+
+
+class ComputeRootRequest(BaseModel):
+    root_date: str  # YYYY-MM-DD
+
+
+@router.post("/roots/compute", response_model=RootOut)
+def compute_root_now(
+    body: ComputeRootRequest,
+    store: RemoteStore = Depends(get_store),
+    username: str = Depends(require_admin),
+) -> RootOut:
+    """Admin trigger: compute the Merkle root for one specific UTC day.
+
+    Idempotent — returns the existing row if already computed. Useful
+    for filling gaps from a missed daily cron tick, and for tests that
+    need a deterministic root without waiting for midnight.
+    """
+    from .daily_root import compute_root_for_day
+
+    enterprise_id = _user_enterprise(username, store)
+    with store._lock:
+        result = compute_root_for_day(store._conn, enterprise_id, body.root_date)
+        store._conn.commit()
+    return RootOut(**result)

--- a/server/backend/src/cq_server/reputation_routes.py
+++ b/server/backend/src/cq_server/reputation_routes.py
@@ -36,6 +36,8 @@ router = APIRouter(prefix="/reputation", tags=["reputation"])
 
 
 class EventOut(BaseModel):
+    """One row of the reputation event log surfaced to authenticated readers."""
+
     event_id: str
     event_type: str
     enterprise_id: str
@@ -50,6 +52,8 @@ class EventOut(BaseModel):
 
 
 class EventsResponse(BaseModel):
+    """Paginated response for ``GET /reputation/events``."""
+
     events: list[EventOut]
     total: int
     limit: int
@@ -57,6 +61,8 @@ class EventsResponse(BaseModel):
 
 
 class RootOut(BaseModel):
+    """One persisted daily Merkle root surfaced to authenticated readers."""
+
     enterprise_id: str
     root_date: str
     event_count: int
@@ -70,6 +76,8 @@ class RootOut(BaseModel):
 
 
 class RootsResponse(BaseModel):
+    """Response for ``GET /reputation/roots`` — newest-first list of daily roots."""
+
     roots: list[RootOut]
     total: int
 
@@ -196,6 +204,8 @@ def list_reputation_roots(
 
 
 class ComputeRootRequest(BaseModel):
+    """Request body for the admin-only ``POST /reputation/roots/compute`` trigger."""
+
     root_date: str  # YYYY-MM-DD
 
 

--- a/server/backend/src/cq_server/reputation_verifier.py
+++ b/server/backend/src/cq_server/reputation_verifier.py
@@ -112,9 +112,7 @@ def verify_event_signatures(events: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-def verify_root(
-    root: dict[str, Any], events: list[dict[str, Any]]
-) -> dict[str, Any]:
+def verify_root(root: dict[str, Any], events: list[dict[str, Any]]) -> dict[str, Any]:
     """Verify a daily Merkle root against its event list.
 
     Two checks:
@@ -139,7 +137,7 @@ def verify_root(
         ``{ok, root_matches_events, signature_valid, count}``. ``ok``
         is the conjunction.
     """
-    leaf_hashes = [e.get("payload_hash") for e in events]
+    leaf_hashes: list[str] = [h for h in (e.get("payload_hash") for e in events) if isinstance(h, str)]
     recomputed = merkle_root(leaf_hashes)
     root_matches = recomputed == root.get("merkle_root_hash")
 

--- a/server/backend/src/cq_server/reputation_verifier.py
+++ b/server/backend/src/cq_server/reputation_verifier.py
@@ -1,0 +1,170 @@
+"""Reputation chain + root verifier (task #108 sub-task 7).
+
+A small library callable from any context: tests, the directory's
+``/reputation/root`` validator, peer-Enterprise audit pipelines.
+
+Three verification levels, callable independently:
+
+- ``verify_chain(events)`` — checks that each event's ``prev_event_hash``
+  matches the preceding event's ``payload_hash``. Catches reordering,
+  insertion, deletion, and mutation of any event in the middle of the
+  chain. Doesn't need signatures — works on v1-alpha unsigned chains.
+
+- ``verify_event_signatures(events)`` — for each event with non-NULL
+  ``signature_b64u``, verifies the signature against ``payload_canonical``
+  using ``signing_key_id`` as the b64url public key. Skips unsigned
+  events (returns ``ok=True`` with ``unsigned_count`` reflecting the skip).
+
+- ``verify_root(root, events)`` — re-derives the Merkle root from the
+  supplied event list (must match the (enterprise_id, root_date)
+  window), compares to ``root.merkle_root_hash``, and verifies the
+  root's own signature against its canonical envelope.
+
+Each function returns a small dataclass-like dict with ``ok: bool`` plus
+diagnostic counters; callers compose them as needed. No exceptions on
+verification failure — failure is normal in audit code, not exceptional.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .crypto import verify_raw
+from .merkle import merkle_root
+from .reputation import canonical_payload_bytes, compute_payload_hash
+
+
+def verify_chain(events: list[dict[str, Any]]) -> dict[str, Any]:
+    """Verify ``prev_event_hash`` linkage across an ordered event list.
+
+    Args:
+        events: list of event rows (dicts with at least
+            ``payload_hash`` and ``prev_event_hash``), sorted by
+            ``ts`` ASC. The caller is responsible for the ordering;
+            this function just walks the array.
+
+    Returns:
+        ``{ok, broken_at_index, broken_event_id, count}``. ``ok=False``
+        when any event N>0 has ``prev_event_hash != events[N-1].payload_hash``.
+    """
+    if not events:
+        return {"ok": True, "broken_at_index": None, "broken_event_id": None, "count": 0}
+
+    for i in range(1, len(events)):
+        prev_hash = events[i].get("prev_event_hash")
+        expected = events[i - 1].get("payload_hash")
+        if prev_hash != expected:
+            return {
+                "ok": False,
+                "broken_at_index": i,
+                "broken_event_id": events[i].get("event_id"),
+                "count": len(events),
+            }
+    return {"ok": True, "broken_at_index": None, "broken_event_id": None, "count": len(events)}
+
+
+def verify_event_payload_hashes(events: list[dict[str, Any]]) -> dict[str, Any]:
+    """Re-derive ``payload_hash`` from ``payload_canonical`` and compare.
+
+    Catches a row whose ``payload_canonical`` was mutated post-write
+    (e.g. someone edited the JSON in-place). The chain check above
+    catches reordering / linkage breaks; this one catches in-place
+    payload tampering.
+    """
+    bad: list[str] = []
+    for ev in events:
+        canonical = ev.get("payload_canonical", "").encode("utf-8")
+        if compute_payload_hash(canonical) != ev.get("payload_hash"):
+            bad.append(ev.get("event_id", "<no-id>"))
+    return {
+        "ok": not bad,
+        "tampered_event_ids": bad,
+        "count": len(events),
+    }
+
+
+def verify_event_signatures(events: list[dict[str, Any]]) -> dict[str, Any]:
+    """Verify Ed25519 signatures on every signed event in the list.
+
+    Unsigned events (signature_b64u IS NULL) are counted but not
+    treated as failures — v1-alpha rows are unsigned by design and
+    callers may want to allow them during the rollout window. To
+    require all events be signed, check the returned ``unsigned_count``
+    is zero in addition to ``ok``.
+    """
+    bad: list[str] = []
+    unsigned = 0
+    for ev in events:
+        sig = ev.get("signature_b64u")
+        kid = ev.get("signing_key_id")
+        if not sig or not kid:
+            unsigned += 1
+            continue
+        canonical = ev.get("payload_canonical", "").encode("utf-8")
+        if not verify_raw(kid, canonical, sig):
+            bad.append(ev.get("event_id", "<no-id>"))
+    return {
+        "ok": not bad,
+        "bad_signature_event_ids": bad,
+        "unsigned_count": unsigned,
+        "signed_count": len(events) - unsigned,
+        "count": len(events),
+    }
+
+
+def verify_root(
+    root: dict[str, Any], events: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Verify a daily Merkle root against its event list.
+
+    Two checks:
+    1. Re-derive Merkle root from event payload_hashes (sorted by ts
+       ASC; caller must pre-sort to match how the root was computed)
+       and compare to ``root.merkle_root_hash``.
+    2. If ``root.signature_b64u`` is non-NULL, verify against the
+       canonical envelope shape used at compute time:
+       ``{enterprise_id, root_date, event_count, merkle_root_hash,
+          first_event_id, last_event_id}``.
+
+    Args:
+        root: a row from the ``reputation_roots`` table (dict with
+            ``enterprise_id``, ``root_date``, ``event_count``,
+            ``merkle_root_hash``, ``first_event_id``, ``last_event_id``,
+            ``signature_b64u``, ``signing_key_id``).
+        events: the events claimed to underlie this root, sorted ts ASC.
+            Pass exactly the events for the (enterprise_id, root_date)
+            window — this function does NOT re-filter.
+
+    Returns:
+        ``{ok, root_matches_events, signature_valid, count}``. ``ok``
+        is the conjunction.
+    """
+    leaf_hashes = [e.get("payload_hash") for e in events]
+    recomputed = merkle_root(leaf_hashes)
+    root_matches = recomputed == root.get("merkle_root_hash")
+
+    sig = root.get("signature_b64u")
+    kid = root.get("signing_key_id")
+    sig_valid: bool | None = None  # None means "no signature to check"
+    if sig and kid:
+        canonical = canonical_payload_bytes(
+            {
+                "enterprise_id": root.get("enterprise_id"),
+                "root_date": root.get("root_date"),
+                "event_count": root.get("event_count"),
+                "merkle_root_hash": root.get("merkle_root_hash"),
+                "first_event_id": root.get("first_event_id"),
+                "last_event_id": root.get("last_event_id"),
+            }
+        )
+        sig_valid = verify_raw(kid, canonical, sig)
+
+    ok = root_matches and (sig_valid is not False)
+    return {
+        "ok": ok,
+        "root_matches_events": root_matches,
+        "signature_valid": sig_valid,
+        "expected_root": recomputed,
+        "actual_root": root.get("merkle_root_hash"),
+        "count": len(events),
+    }

--- a/server/backend/src/cq_server/review.py
+++ b/server/backend/src/cq_server/review.py
@@ -136,6 +136,7 @@ def _hook_ku_event(store: "RemoteStore", unit_id: str, verb: str, enterprise_id:
     shape per ``reputation-v1.md`` §"ku.event".
     """
     from .reputation import record_event as _record_event
+
     _record_event(
         store._conn,
         event_type="ku.event",

--- a/server/backend/src/cq_server/review.py
+++ b/server/backend/src/cq_server/review.py
@@ -128,6 +128,27 @@ def review_queue(
     )
 
 
+def _hook_ku_event(store: "RemoteStore", unit_id: str, verb: str, enterprise_id: str, by: str) -> None:
+    """Reputation hook for KU lifecycle transitions (#108 sub-task 5).
+
+    Best-effort: ``record_event`` swallows on failure so a flaky
+    reputation chain never blocks the underlying review action. Body
+    shape per ``reputation-v1.md`` §"ku.event".
+    """
+    from .reputation import record_event as _record_event
+    _record_event(
+        store._conn,
+        event_type="ku.event",
+        body={
+            "unit_id": unit_id,
+            "verb": verb,
+            "enterprise_id": enterprise_id,
+            "by": by,
+        },
+        enterprise_id=enterprise_id,
+    )
+
+
 @router.post("/{unit_id}/approve")
 def approve_unit(
     unit_id: str,
@@ -144,6 +165,7 @@ def approve_unit(
     store.set_review_status(unit_id, "approved", username, enterprise_id=enterprise_id)
     updated = store.get_review_status(unit_id, enterprise_id=enterprise_id)
     assert updated is not None  # Unit exists; we just wrote to it.
+    _hook_ku_event(store, unit_id, "approve", enterprise_id, username)
     return _build_decision(unit_id, updated)
 
 
@@ -163,6 +185,7 @@ def reject_unit(
     store.set_review_status(unit_id, "rejected", username, enterprise_id=enterprise_id)
     updated = store.get_review_status(unit_id, enterprise_id=enterprise_id)
     assert updated is not None  # Unit exists; we just wrote to it.
+    _hook_ku_event(store, unit_id, "reject", enterprise_id, username)
     return _build_decision(unit_id, updated)
 
 

--- a/server/backend/tests/test_admin_delete.py
+++ b/server/backend/tests/test_admin_delete.py
@@ -18,7 +18,7 @@ TEST_USERNAME = "test-user"
 @pytest.fixture()
 def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
     monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "test.db"))
-    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret")
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
     monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
     app.dependency_overrides[require_api_key] = lambda: TEST_USERNAME
     with TestClient(app) as c:

--- a/server/backend/tests/test_app.py
+++ b/server/backend/tests/test_app.py
@@ -17,7 +17,7 @@ TEST_USERNAME = "test-user"
 @pytest.fixture()
 def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
     monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "test.db"))
-    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret")
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
     monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
     app.dependency_overrides[require_api_key] = lambda: TEST_USERNAME
     with TestClient(app) as c:
@@ -38,7 +38,7 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
 def enforced_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
     """TestClient with real API key enforcement (no dep override)."""
     monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "test.db"))
-    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret")
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
     monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
     app.dependency_overrides.pop(require_api_key, None)
     with TestClient(app) as c:

--- a/server/backend/tests/test_auth.py
+++ b/server/backend/tests/test_auth.py
@@ -17,7 +17,7 @@ from cq_server.deps import require_api_key
 @pytest.fixture()
 def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
     monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "test.db"))
-    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret")
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
     monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
     app.dependency_overrides[require_api_key] = lambda: "test-user"
     with TestClient(app) as c:
@@ -119,7 +119,7 @@ class TestAuthMe:
 def api_key_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
     """Client fixture with real API key enforcement (no dep override)."""
     monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "test.db"))
-    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret")
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
     monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
     app.dependency_overrides.pop(require_api_key, None)
     with TestClient(app) as c:

--- a/server/backend/tests/test_daily_root.py
+++ b/server/backend/tests/test_daily_root.py
@@ -1,0 +1,181 @@
+"""Tests for daily Merkle root computation (task #108 sub-task 3)."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from cq_server import reputation
+from cq_server.daily_root import compute_root_for_day
+from cq_server.merkle import EMPTY_DAY_ROOT, merkle_root
+from cq_server.migrations import run_migrations
+
+
+@pytest.fixture()
+def conn(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> sqlite3.Connection:
+    monkeypatch.setenv("CQ_ENTERPRISE", "test-corp")
+    monkeypatch.setenv("CQ_GROUP", "engineering")
+    db = tmp_path / "rep.db"
+    run_migrations(f"sqlite:///{db}")
+    conn = sqlite3.connect(str(db))
+    yield conn
+    conn.close()
+
+
+class TestComputeRoot:
+    def test_empty_day_returns_zero_event_root(
+        self, conn: sqlite3.Connection
+    ) -> None:
+        # No events for the day — root should be the empty-day constant.
+        result = compute_root_for_day(conn, "test-corp", "2026-01-01")
+        conn.commit()
+        assert result["event_count"] == 0
+        assert result["merkle_root_hash"] == EMPTY_DAY_ROOT
+        assert result["first_event_id"] is None
+        assert result["last_event_id"] is None
+
+    def test_root_matches_merkle_over_payload_hashes(
+        self, conn: sqlite3.Connection
+    ) -> None:
+        # Write 3 events at known times (today's UTC date by default).
+        from datetime import UTC, datetime
+
+        today = datetime.now(UTC).date().isoformat()
+        e1 = reputation.record_event(
+            conn,
+            event_type="consult.closed",
+            body={"i": 1},
+            ts=f"{today}T01:00:00Z",
+        )
+        e2 = reputation.record_event(
+            conn,
+            event_type="ku.event",
+            body={"i": 2},
+            ts=f"{today}T02:00:00Z",
+        )
+        e3 = reputation.record_event(
+            conn,
+            event_type="peer.heartbeat",
+            body={"i": 3},
+            ts=f"{today}T03:00:00Z",
+        )
+        conn.commit()
+        assert e1 and e2 and e3
+
+        # Read the payload hashes in the same ts-ASC order
+        rows = conn.execute(
+            "SELECT payload_hash FROM reputation_events "
+            "WHERE enterprise_id = ? ORDER BY ts ASC, event_id ASC",
+            ("test-corp",),
+        ).fetchall()
+        leaf_hashes = [r[0] for r in rows]
+        expected_root = merkle_root(leaf_hashes)
+
+        result = compute_root_for_day(conn, "test-corp", today)
+        conn.commit()
+        assert result["merkle_root_hash"] == expected_root
+        assert result["event_count"] == 3
+        assert result["first_event_id"] == e1
+        assert result["last_event_id"] == e3
+
+    def test_idempotent_recompute_returns_existing(
+        self, conn: sqlite3.Connection
+    ) -> None:
+        from datetime import UTC, datetime
+
+        today = datetime.now(UTC).date().isoformat()
+        reputation.record_event(
+            conn,
+            event_type="consult.closed",
+            body={"i": 1},
+            ts=f"{today}T01:00:00Z",
+        )
+        conn.commit()
+
+        first = compute_root_for_day(conn, "test-corp", today)
+        conn.commit()
+        second = compute_root_for_day(conn, "test-corp", today)
+        conn.commit()
+        assert first["computed_at"] == second["computed_at"]  # not recomputed
+        assert first["merkle_root_hash"] == second["merkle_root_hash"]
+
+        # Only one row should exist for that (enterprise, day).
+        n = conn.execute(
+            "SELECT COUNT(*) FROM reputation_roots "
+            "WHERE enterprise_id = ? AND root_date = ?",
+            ("test-corp", today),
+        ).fetchone()[0]
+        assert n == 1
+
+    def test_chain_meta_advances_after_compute(
+        self, conn: sqlite3.Connection
+    ) -> None:
+        from datetime import UTC, datetime
+
+        today = datetime.now(UTC).date().isoformat()
+        reputation.record_event(
+            conn, event_type="consult.closed", body={"i": 1},
+        )
+        conn.commit()
+
+        compute_root_for_day(conn, "test-corp", today)
+        conn.commit()
+
+        last_day = conn.execute(
+            "SELECT last_root_published_day FROM reputation_chain_meta "
+            "WHERE enterprise_id = ?",
+            ("test-corp",),
+        ).fetchone()[0]
+        assert last_day == today
+
+
+class TestSignedRoot:
+    def test_root_signature_when_key_available(
+        self,
+        conn: sqlite3.Connection,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When the L2 forward-sign key is available, the daily root row
+        carries a non-NULL signature over its canonical envelope."""
+        from cq_server import forward_sign
+        from cq_server.crypto import verify_raw
+        from cq_server.reputation import canonical_payload_bytes
+
+        key_path = tmp_path / "l2_key.bin"
+        monkeypatch.setenv("CQ_AIGRP_L2_PRIVKEY_PATH", str(key_path))
+        forward_sign.reload_l2_privkey()
+
+        try:
+            from datetime import UTC, datetime
+
+            today = datetime.now(UTC).date().isoformat()
+            reputation.record_event(
+                conn, event_type="consult.closed", body={"i": 1}
+            )
+            conn.commit()
+
+            result = compute_root_for_day(conn, "test-corp", today)
+            conn.commit()
+            assert result["signature_b64u"] is not None
+            assert result["signing_key_id"] is not None
+
+            # Reconstruct canonical envelope + verify signature
+            canonical = canonical_payload_bytes(
+                {
+                    "enterprise_id": result["enterprise_id"],
+                    "root_date": result["root_date"],
+                    "event_count": result["event_count"],
+                    "merkle_root_hash": result["merkle_root_hash"],
+                    "first_event_id": result["first_event_id"],
+                    "last_event_id": result["last_event_id"],
+                }
+            )
+            ok = verify_raw(
+                result["signing_key_id"], canonical, result["signature_b64u"]
+            )
+            assert ok is True
+        finally:
+            forward_sign.reload_l2_privkey()

--- a/server/backend/tests/test_forward_query.py
+++ b/server/backend/tests/test_forward_query.py
@@ -55,7 +55,7 @@ def aigrp_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Te
     request body to drive the policy matrix.
     """
     monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "fwdq.db"))
-    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret")
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
     monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
     monkeypatch.setenv("CQ_AIGRP_PEER_KEY", PEER_KEY)
     monkeypatch.setenv("CQ_ENTERPRISE", "acme")

--- a/server/backend/tests/test_merkle.py
+++ b/server/backend/tests/test_merkle.py
@@ -1,0 +1,76 @@
+"""Tests for the SHA-256 Merkle tree (task #108 sub-task 3)."""
+
+from __future__ import annotations
+
+import hashlib
+
+from cq_server.merkle import EMPTY_DAY_ROOT, merkle_root
+
+
+def _h(s: str) -> str:
+    return "sha256:" + hashlib.sha256(s.encode()).hexdigest()
+
+
+class TestEmptyAndSingle:
+    def test_empty_returns_constant(self) -> None:
+        assert merkle_root([]) == EMPTY_DAY_ROOT
+
+    def test_empty_constant_is_stable(self) -> None:
+        # Locking the constant down — any change is a wire-format change.
+        expected = "sha256:" + hashlib.sha256(
+            b"8l-reputation-empty-day-v1"
+        ).hexdigest()
+        assert EMPTY_DAY_ROOT == expected
+
+    def test_single_leaf_root_is_just_that_leaf(self) -> None:
+        leaf = _h("a")
+        # With one leaf, the tree has no internal nodes — the leaf IS the root.
+        assert merkle_root([leaf]) == leaf
+
+
+class TestPairAndOdd:
+    def test_two_leaves_pair_hash(self) -> None:
+        a = _h("a")
+        b = _h("b")
+        # Manual computation: sha256(a_bytes || b_bytes)
+        expected_root_bytes = hashlib.sha256(
+            bytes.fromhex(a[len("sha256:"):]) + bytes.fromhex(b[len("sha256:"):])
+        ).digest()
+        assert merkle_root([a, b]) == "sha256:" + expected_root_bytes.hex()
+
+    def test_three_leaves_duplicates_last(self) -> None:
+        a, b, c = _h("a"), _h("b"), _h("c")
+        # Tree shape with 3 leaves:
+        #   root = H(H(a||b) || H(c||c))
+        ab = hashlib.sha256(
+            bytes.fromhex(a[7:]) + bytes.fromhex(b[7:])
+        ).digest()
+        cc = hashlib.sha256(
+            bytes.fromhex(c[7:]) + bytes.fromhex(c[7:])
+        ).digest()
+        root = hashlib.sha256(ab + cc).digest()
+        assert merkle_root([a, b, c]) == "sha256:" + root.hex()
+
+    def test_order_is_load_bearing(self) -> None:
+        a, b = _h("a"), _h("b")
+        # Different order → different root.
+        assert merkle_root([a, b]) != merkle_root([b, a])
+
+
+class TestDeterminism:
+    def test_same_input_same_root(self) -> None:
+        leaves = [_h(s) for s in ("alpha", "beta", "gamma", "delta")]
+        r1 = merkle_root(leaves)
+        r2 = merkle_root(leaves)
+        assert r1 == r2
+
+    def test_root_matches_known_4_leaf_layout(self) -> None:
+        a, b, c, d = _h("a"), _h("b"), _h("c"), _h("d")
+
+        def cat(x: str, y: str) -> bytes:
+            return bytes.fromhex(x[7:]) + bytes.fromhex(y[7:])
+
+        ab = "sha256:" + hashlib.sha256(cat(a, b)).hexdigest()
+        cd = "sha256:" + hashlib.sha256(cat(c, d)).hexdigest()
+        expected_root = "sha256:" + hashlib.sha256(cat(ab, cd)).hexdigest()
+        assert merkle_root([a, b, c, d]) == expected_root

--- a/server/backend/tests/test_migrations.py
+++ b/server/backend/tests/test_migrations.py
@@ -434,7 +434,11 @@ class TestBaselineMatchesLegacySchema:
         # Tables on both sides — same set after phase 2, modulo
         # tables that only Alembic creates (RemoteStore.ensure_* path
         # doesn't create them at startup; migrations do).
-        migration_only_expected = {"reputation_events", "reputation_chain_meta"}
+        migration_only_expected = {
+            "reputation_events",
+            "reputation_chain_meta",
+            "reputation_roots",
+        }
         legacy_tables = set(schema_a)
         migration_tables = set(schema_b) - migration_only_expected
         assert migration_tables == legacy_tables, (

--- a/server/backend/tests/test_reputation.py
+++ b/server/backend/tests/test_reputation.py
@@ -181,3 +181,112 @@ class TestRecordEvent:
         # raw UTF-8 'ë' is 0xC3 0xAB; the escaped form would be 6 ASCII bytes
         assert b"\xc3\xab" in b
         assert b"\\u" not in b
+
+
+class TestSigning:
+    """v1 Ed25519 signing — task #108. Reuses the L2 forward-sign key."""
+
+    def test_signed_event_populates_signature_columns(
+        self,
+        conn: sqlite3.Connection,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When an L2 forward-sign key is on disk, ``record_event`` writes
+        non-NULL ``signature_b64u`` and ``signing_key_id`` columns."""
+        from cq_server import forward_sign
+
+        key_path = tmp_path / "l2_key.bin"
+        monkeypatch.setenv("CQ_AIGRP_L2_PRIVKEY_PATH", str(key_path))
+        forward_sign.reload_l2_privkey()  # picks up the new path
+
+        try:
+            eid = reputation.record_event(
+                conn, event_type="consult.closed", body={"thread_id": "th_signed"}
+            )
+            conn.commit()
+            assert eid is not None
+
+            row = conn.execute(
+                "SELECT signature_b64u, signing_key_id FROM reputation_events WHERE event_id = ?",
+                (eid,),
+            ).fetchone()
+            sig, kid = row
+            assert sig is not None and len(sig) > 0, "signature should be populated"
+            assert kid is not None and len(kid) > 0, "signing_key_id should be populated"
+            # signing_key_id is the L2's b64url public key — 43 chars (32-byte key, no padding)
+            assert len(kid) == 43, f"signing_key_id should be 43-char b64url, got {len(kid)}"
+        finally:
+            forward_sign.reload_l2_privkey()  # reset cache to avoid pollution
+
+    def test_signature_verifies_against_canonical_payload(
+        self,
+        conn: sqlite3.Connection,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """End-to-end signing → verification. A valid signature against the
+        canonical payload bytes round-trips through ``crypto.verify_raw``."""
+        from cq_server import forward_sign
+        from cq_server.crypto import verify_raw
+
+        key_path = tmp_path / "l2_key.bin"
+        monkeypatch.setenv("CQ_AIGRP_L2_PRIVKEY_PATH", str(key_path))
+        forward_sign.reload_l2_privkey()
+
+        try:
+            eid = reputation.record_event(
+                conn, event_type="ku.event", body={"unit_id": "ku_42", "verb": "approve"}
+            )
+            conn.commit()
+            assert eid is not None
+
+            row = conn.execute(
+                "SELECT payload_canonical, signature_b64u, signing_key_id "
+                "FROM reputation_events WHERE event_id = ?",
+                (eid,),
+            ).fetchone()
+            canonical_str, sig, kid = row
+            ok = verify_raw(kid, canonical_str.encode("utf-8"), sig)
+            assert ok is True, "signature must verify against the persisted canonical bytes"
+        finally:
+            forward_sign.reload_l2_privkey()
+
+    def test_unsigned_event_when_no_key_available(
+        self,
+        conn: sqlite3.Connection,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When signing is disabled (key load fails / unavailable), event
+        rows persist with NULL signature columns. Caller's operation is
+        unaffected — preserves the v1-alpha behaviour for legacy deploys."""
+        from cq_server import forward_sign
+
+        # Point at a directory we can't write to, then force a reload —
+        # load_or_create_l2_privkey returns None on OSError.
+        bad_path = tmp_path / "no_perm" / "key.bin"
+        bad_path.parent.mkdir(mode=0o000)
+        monkeypatch.setenv("CQ_AIGRP_L2_PRIVKEY_PATH", str(bad_path))
+        forward_sign.reload_l2_privkey()
+
+        try:
+            eid = reputation.record_event(
+                conn, event_type="consult.closed", body={"thread_id": "th_unsigned"}
+            )
+            conn.commit()
+            if eid is None:
+                # If load_or_create_l2_privkey raised (ran on a system that
+                # couldn't enforce the chmod 000), the test isn't meaningful.
+                pytest.skip("filesystem allowed key creation despite chmod 000")
+
+            row = conn.execute(
+                "SELECT signature_b64u, signing_key_id FROM reputation_events WHERE event_id = ?",
+                (eid,),
+            ).fetchone()
+            sig, kid = row
+            assert sig is None, "expected NULL signature when key unavailable"
+            assert kid is None, "expected NULL signing_key_id when key unavailable"
+        finally:
+            bad_path.parent.chmod(0o755)  # let pytest clean up the tmpdir
+            forward_sign.reload_l2_privkey()

--- a/server/backend/tests/test_reputation_verifier.py
+++ b/server/backend/tests/test_reputation_verifier.py
@@ -1,0 +1,208 @@
+"""Tests for the reputation verifier library (task #108 sub-task 7)."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from cq_server import forward_sign, reputation
+from cq_server.daily_root import compute_root_for_day
+from cq_server.migrations import run_migrations
+from cq_server.reputation_verifier import (
+    verify_chain,
+    verify_event_payload_hashes,
+    verify_event_signatures,
+    verify_root,
+)
+
+
+@pytest.fixture()
+def conn_with_signing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> sqlite3.Connection:
+    """DB with an L2 signing key in place — events come out signed."""
+    monkeypatch.setenv("CQ_ENTERPRISE", "test-corp")
+    monkeypatch.setenv("CQ_GROUP", "engineering")
+    key_path = tmp_path / "l2_key.bin"
+    monkeypatch.setenv("CQ_AIGRP_L2_PRIVKEY_PATH", str(key_path))
+    forward_sign.reload_l2_privkey()
+
+    db = tmp_path / "rep.db"
+    run_migrations(f"sqlite:///{db}")
+    conn = sqlite3.connect(str(db))
+    yield conn
+    conn.close()
+    forward_sign.reload_l2_privkey()  # cleanup cache
+
+
+def _read_events(conn: sqlite3.Connection, enterprise_id: str) -> list[dict]:
+    rows = conn.execute(
+        """
+        SELECT event_id, event_type, enterprise_id, l2_id, ts,
+               prev_event_hash, payload_canonical, payload_hash,
+               signature_b64u, signing_key_id, created_at
+        FROM reputation_events
+        WHERE enterprise_id = ?
+        ORDER BY ts ASC, event_id ASC
+        """,
+        (enterprise_id,),
+    ).fetchall()
+    cols = [
+        "event_id",
+        "event_type",
+        "enterprise_id",
+        "l2_id",
+        "ts",
+        "prev_event_hash",
+        "payload_canonical",
+        "payload_hash",
+        "signature_b64u",
+        "signing_key_id",
+        "created_at",
+    ]
+    return [dict(zip(cols, r, strict=True)) for r in rows]
+
+
+class TestChain:
+    def test_empty_chain_verifies(self, conn_with_signing: sqlite3.Connection) -> None:
+        result = verify_chain([])
+        assert result["ok"] is True
+        assert result["count"] == 0
+
+    def test_intact_chain_verifies(
+        self, conn_with_signing: sqlite3.Connection
+    ) -> None:
+        for i in range(5):
+            reputation.record_event(
+                conn_with_signing,
+                event_type="consult.closed",
+                body={"i": i},
+                ts=f"2026-01-01T0{i}:00:00Z",
+            )
+        conn_with_signing.commit()
+        events = _read_events(conn_with_signing, "test-corp")
+        assert len(events) == 5
+        result = verify_chain(events)
+        assert result["ok"] is True
+        assert result["count"] == 5
+
+    def test_broken_chain_detected(
+        self, conn_with_signing: sqlite3.Connection
+    ) -> None:
+        for i in range(3):
+            reputation.record_event(
+                conn_with_signing,
+                event_type="consult.closed",
+                body={"i": i},
+                ts=f"2026-01-01T0{i}:00:00Z",
+            )
+        conn_with_signing.commit()
+        events = _read_events(conn_with_signing, "test-corp")
+        # Mutate event[1].prev_event_hash so the link breaks
+        events[1]["prev_event_hash"] = "sha256:" + ("0" * 64)
+        result = verify_chain(events)
+        assert result["ok"] is False
+        assert result["broken_at_index"] == 1
+
+
+class TestPayloadHashes:
+    def test_intact_payloads_verify(
+        self, conn_with_signing: sqlite3.Connection
+    ) -> None:
+        reputation.record_event(
+            conn_with_signing, event_type="ku.event", body={"unit_id": "ku_x"}
+        )
+        conn_with_signing.commit()
+        events = _read_events(conn_with_signing, "test-corp")
+        assert verify_event_payload_hashes(events)["ok"] is True
+
+    def test_tampered_canonical_detected(
+        self, conn_with_signing: sqlite3.Connection
+    ) -> None:
+        reputation.record_event(
+            conn_with_signing, event_type="ku.event", body={"unit_id": "ku_x"}
+        )
+        conn_with_signing.commit()
+        events = _read_events(conn_with_signing, "test-corp")
+        events[0]["payload_canonical"] = '{"tampered":true}'
+        result = verify_event_payload_hashes(events)
+        assert result["ok"] is False
+        assert events[0]["event_id"] in result["tampered_event_ids"]
+
+
+class TestSignatures:
+    def test_signed_events_verify(
+        self, conn_with_signing: sqlite3.Connection
+    ) -> None:
+        reputation.record_event(
+            conn_with_signing, event_type="ku.event", body={"unit_id": "ku_x"}
+        )
+        conn_with_signing.commit()
+        events = _read_events(conn_with_signing, "test-corp")
+        result = verify_event_signatures(events)
+        assert result["ok"] is True
+        assert result["signed_count"] == 1
+        assert result["unsigned_count"] == 0
+
+    def test_tampered_signature_detected(
+        self, conn_with_signing: sqlite3.Connection
+    ) -> None:
+        reputation.record_event(
+            conn_with_signing, event_type="ku.event", body={"unit_id": "ku_x"}
+        )
+        conn_with_signing.commit()
+        events = _read_events(conn_with_signing, "test-corp")
+        # Flip a character in the signature
+        original = events[0]["signature_b64u"]
+        events[0]["signature_b64u"] = ("A" if original[0] != "A" else "B") + original[1:]
+        result = verify_event_signatures(events)
+        assert result["ok"] is False
+        assert events[0]["event_id"] in result["bad_signature_event_ids"]
+
+
+class TestRoot:
+    def test_root_verifies_against_events(
+        self, conn_with_signing: sqlite3.Connection
+    ) -> None:
+        today = datetime.now(UTC).date().isoformat()
+        for i in range(4):
+            reputation.record_event(
+                conn_with_signing,
+                event_type="consult.closed",
+                body={"i": i},
+                ts=f"{today}T0{i}:00:00Z",
+            )
+        conn_with_signing.commit()
+
+        root = compute_root_for_day(conn_with_signing, "test-corp", today)
+        conn_with_signing.commit()
+        events = _read_events(conn_with_signing, "test-corp")
+
+        result = verify_root(root, events)
+        assert result["ok"] is True
+        assert result["root_matches_events"] is True
+        assert result["signature_valid"] is True
+
+    def test_root_mismatch_detected_when_event_dropped(
+        self, conn_with_signing: sqlite3.Connection
+    ) -> None:
+        today = datetime.now(UTC).date().isoformat()
+        for i in range(3):
+            reputation.record_event(
+                conn_with_signing,
+                event_type="consult.closed",
+                body={"i": i},
+                ts=f"{today}T0{i}:00:00Z",
+            )
+        conn_with_signing.commit()
+        root = compute_root_for_day(conn_with_signing, "test-corp", today)
+        conn_with_signing.commit()
+        events = _read_events(conn_with_signing, "test-corp")
+
+        # Drop one event from the verifier's input — root should mismatch.
+        result = verify_root(root, events[:-1])
+        assert result["root_matches_events"] is False
+        assert result["ok"] is False

--- a/server/backend/tests/test_review.py
+++ b/server/backend/tests/test_review.py
@@ -15,7 +15,7 @@ from cq_server.deps import require_api_key
 @pytest.fixture()
 def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
     monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "test.db"))
-    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret")
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
     monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
     app.dependency_overrides[require_api_key] = lambda: "test-user"
     with TestClient(app) as c:

--- a/server/backend/tests/test_sqlite_store_e2e.py
+++ b/server/backend/tests/test_sqlite_store_e2e.py
@@ -21,7 +21,7 @@ from cq_server.app import app
 def test_e2e_propose_via_store_query_via_api(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     db = tmp_path / "smoke.db"
     monkeypatch.setenv("CQ_DB_PATH", str(db))
-    monkeypatch.setenv("CQ_JWT_SECRET", "smoke-jwt-secret-bytes")
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
     monkeypatch.setenv("CQ_API_KEY_PEPPER", "smoke-pepper-bytes")
 
     with TestClient(app) as client:


### PR DESCRIPTION
Resolves task #108 sub-tasks 1 (key-location decision) + 2 (signing).

## What

Adds Ed25519 signing to record_event. Reuses the existing per-L2 forward-sign key from forward_sign.get_l2_privkey() rather than minting a separate reputation key or using the AAISN root.

## Why

Same key already signs forward-* requests; pubkey already registered with peers via /aigrp/hello → aigrp_peers.public_key_ed25519. Single trust anchor, no new wire format, no new key management surface. Full reasoning: crosstalk-enterprise/docs/decisions/21-reputation-signing-key-location.md.

## Surface

- New sign_canonical_bytes(canonical) returning (signature_b64u, signing_key_id). Signing key id is the L2's 43-char base64url public key — self-describing.
- record_event populates the columns instead of writing NULL.
- Schema unchanged; both columns were already nullable in migration 0008.
- Backward compat: when key is unavailable, columns write NULL — v1-alpha behaviour preserved.

## Tests

pytest tests/test_reputation.py: **11 passing** (8 existing + 3 new):
- test_signed_event_populates_signature_columns
- test_signature_verifies_against_canonical_payload — round-trip via crypto.verify_raw
- test_unsigned_event_when_no_key_available

## What's still open on #108

This PR closes sub-tasks 1+2. Remaining (separate PRs):
- 3. Daily Merkle root job
- 4. Directory side endpoints (POST /reputation/root, GET /reputation/roots/<enterprise_id>)
- 5. Event hooks at consult-close + KU lifecycle + AIGRP convergence sites
- 6. Reader endpoint
- 7. Verifier library