### PR TITLE
fix(auth): get_current_user accepts API keys, not just JWTs (closes #86)

### DIFF
--- a/server/backend/src/cq_server/auth.py
+++ b/server/backend/src/cq_server/auth.py
@@ -220,28 +220,30 @@ def _get_jwt_secret() -> str:
     return secret
 
 
-def get_current_user(request: Request) -> str:
-    """FastAPI dependency that extracts and validates the JWT from the Authorization header.
+async def get_current_user(
+    request: Request,
+    store: SqliteStore = Depends(get_store),
+) -> str:
+    """FastAPI dependency: authenticate the caller and return their username.
+
+    Accepts either a JWT (issued by ``POST /auth/login``) or an API key
+    (minted by ``POST /auth/api-keys``). Tokens prefixed with ``cqa.v1.``
+    are verified as API keys; everything else is JWT-verified. The
+    dispatch matches ``_resolve_caller`` so every route protected by
+    this dep gets both bearer shapes for free.
 
     Args:
         request: The incoming FastAPI request.
+        store: The store dependency, used to resolve API-key rows.
 
     Returns:
-        The username extracted from the validated token.
+        The username extracted from whichever bearer shape validated.
 
     Raises:
-        HTTPException: With status 401 if the header is missing, malformed, or the token is invalid.
+        HTTPException: 401 on missing header or either-shape failure.
     """
-    auth_header = request.headers.get("Authorization")
-    if not auth_header or not auth_header.startswith("Bearer "):
-        raise HTTPException(status_code=401, detail="Missing or invalid authorization header")
-    token = auth_header.removeprefix("Bearer ")
-    secret = _get_jwt_secret()
-    try:
-        payload = verify_token(token, secret=secret)
-    except jwt.PyJWTError as exc:
-        raise HTTPException(status_code=401, detail="Invalid or expired token") from exc
-    return payload["sub"]
+    caller = await _resolve_caller(request, store)
+    return caller.username
 
 
 async def require_admin(

--- a/server/backend/tests/test_auth.py
+++ b/server/backend/tests/test_auth.py
@@ -147,6 +147,38 @@ class TestAuthMe:
         assert body["expires_at"] is not None
         assert body["issued_at"] is not None
 
+    def test_get_current_user_accepts_api_key(self, api_key_client: TestClient) -> None:
+        """Regression for issue #86 — Bran-style API-key call against a
+        ``get_current_user``-protected endpoint must not fall back to the
+        JWT path's ``Invalid or expired token`` error.
+
+        Before the fix: ``get_current_user`` only verified JWTs; an API
+        key (``cqa.v1.<keyid>.<secret>``) was passed to PyJWT which raised
+        ``DecodeError`` and the caller saw 401 ``Invalid or expired token``.
+        After: ``get_current_user`` delegates to ``_resolve_caller`` and
+        accepts both bearer shapes. The consults inbox endpoint is the
+        canonical user-protected route to exercise this through.
+        """
+        jwt_token = _login(api_key_client)
+        created = api_key_client.post(
+            "/auth/api-keys",
+            headers={"Authorization": f"Bearer {jwt_token}"},
+            json={"name": "regression-86", "ttl": "30d"},
+        )
+        assert created.status_code == 201
+        api_key_token = created.json()["token"]
+        # Sanity: this token would have triggered Bran's failure mode pre-fix.
+        assert api_key_token.startswith("cqa.v1.")
+
+        # /consults/inbox uses get_current_user (JWT-only pre-fix).
+        resp = api_key_client.get(
+            "/api/v1/consults/inbox",
+            headers={"Authorization": f"Bearer {api_key_token}"},
+        )
+        # Pre-fix: 401 "Invalid or expired token". Post-fix: 200 with empty inbox.
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["self_l2_id"]  # tenancy populated from API-key user
+
 
 @pytest.fixture()
 def api_key_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:


### PR DESCRIPTION
Bran's onboarding (#86) hit `Invalid or expired token` when minting an API key and using it on /consults/request. Root cause: `get_current_user` was JWT-only — API-key tokens (`cqa.v1.<keyid>.<secret>`) were passed to PyJWT, which raised DecodeError → 401. Fix: `get_current_user` now delegates to `_resolve_caller` (already correct for /auth/me). All routes via `Depends(get_current_user)` now accept both shapes. Tests: regression test exercising /consults/inbox with API-key bearer; full suite 572 passed, 5 skipped.