### PR TITLE
fix(consults): validate to_persona on x-enterprise-forward-request (closes #98)

### DIFF
--- a/server/backend/src/cq_server/consults.py
+++ b/server/backend/src/cq_server/consults.py
@@ -685,7 +685,7 @@ class ForwardRequestBody(BaseModel):
     from_l2_id: str
     from_persona: str
     to_l2_id: str
-    to_persona: str
+    to_persona: str = Field(min_length=1)
     subject: str | None = Field(default=None, max_length=512)
     content: str = Field(min_length=1, max_length=4096)
     created_at: str

--- a/server/backend/src/cq_server/consults.py
+++ b/server/backend/src/cq_server/consults.py
@@ -952,6 +952,27 @@ async def x_enterprise_forward_consult_request(
     peering = await _require_x_enterprise_auth(request, body, store)
     policy = peering["consult_logging_policy"]
 
+    # Issue #98 — validate that body.to_persona corresponds to a real
+    # user on this L2 (matching enterprise + group). Without this guard,
+    # a typo'd or stale persona name produces a thread+message pair
+    # nobody can ever read (no inbox surface for a non-existent user)
+    # and the sender gets a false-positive "delivered" signal.
+    #
+    # Group-scoped consults (to_persona empty/None) are allowed through
+    # without persona validation — current schema requires non-empty
+    # to_persona but we keep the conditional for forward compatibility
+    # with a future Group-only address shape.
+    if body.to_persona:
+        user = await store.get_user(body.to_persona)
+        self_enterprise = aigrp_mod.enterprise()
+        self_group = aigrp_mod.group()
+        if (
+            user is None
+            or str(user.get("enterprise_id") or "default-enterprise") != self_enterprise
+            or str(user.get("group_id") or "default-group") != self_group
+        ):
+            raise HTTPException(status_code=404, detail="to_persona not found")
+
     # Thread row: always created (audit point: cross-Enterprise consult
     # was attempted, regardless of policy).
     if await store.get_consult(body.thread_id) is None:

--- a/server/backend/tests/test_x_enterprise_consult.py
+++ b/server/backend/tests/test_x_enterprise_consult.py
@@ -745,6 +745,31 @@ def test_x_enterprise_receiver_persona_in_wrong_enterprise_returns_404(
     assert _get_store().sync.get_consult(payload["thread_id"]) is None
 
 
+def test_x_enterprise_receiver_empty_persona_returns_422(client: TestClient) -> None:
+    """Empty-string to_persona is rejected at Pydantic parse time (HIGH on PR #112).
+
+    Without the schema-level ``min_length=1`` constraint on
+    ``ForwardRequestBody.to_persona``, the receiver's own
+    ``if body.to_persona:`` falsy guard would skip user lookup and
+    re-create the orphan-row bug for the degenerate empty-string input.
+    """
+    _seed_peering(offer_id="off_recv", from_ent="globex", to_ent="acme")
+    bearer = forward_sign.derive_peering_bearer(_FAKE_OFFER_SIG, _FAKE_ACCEPT_SIG)
+    payload = _x_enterprise_payload()
+    payload["to_persona"] = ""
+
+    r = client.post(
+        "/api/v1/consults/x-enterprise-forward-request",
+        headers=_x_enterprise_headers(bearer=bearer),
+        json=payload,
+    )
+    assert r.status_code == 422, r.text
+
+    # Defensive: no thread row, no message row landed.
+    assert _get_store().sync.get_consult(payload["thread_id"]) is None
+    assert _get_store().sync.list_consult_messages(payload["thread_id"]) == []
+
+
 def test_x_enterprise_receiver_valid_persona_succeeds(client: TestClient) -> None:
     """The happy-path mirror — explicit baseline that #98's validation
     didn't regress real users.

--- a/server/backend/tests/test_x_enterprise_consult.py
+++ b/server/backend/tests/test_x_enterprise_consult.py
@@ -682,3 +682,86 @@ def test_x_enterprise_receiver_inbox_visibility(client: TestClient) -> None:
     assert inbox.status_code == 200
     threads = inbox.json()["threads"]
     assert any(t["thread_id"] == "th_recv_1" for t in threads)
+
+
+# ---------------------------------------------------------------------------
+# Issue #98 — to_persona must exist on the receiving L2
+# ---------------------------------------------------------------------------
+#
+# Without this guard, a typo'd or stale persona name produces a thread +
+# message pair that nobody can ever read (the addressed user doesn't exist
+# on this L2, so the inbox surface never returns the row) — and the sender
+# gets a false-positive "delivered" 201 response. See issue #98.
+
+
+def test_x_enterprise_receiver_unknown_persona_returns_404(client: TestClient) -> None:
+    """to_persona that doesn't exist as a user on this L2 → 404, no rows written."""
+    _seed_peering(offer_id="off_recv", from_ent="globex", to_ent="acme")
+    bearer = forward_sign.derive_peering_bearer(_FAKE_OFFER_SIG, _FAKE_ACCEPT_SIG)
+    payload = _x_enterprise_payload()
+    payload["to_persona"] = "nonexistent_user"
+
+    r = client.post(
+        "/api/v1/consults/x-enterprise-forward-request",
+        headers=_x_enterprise_headers(bearer=bearer),
+        json=payload,
+    )
+    assert r.status_code == 404, r.text
+    assert r.json()["detail"] == "to_persona not found"
+
+    # Defensive: no thread row, no message row landed.
+    assert _get_store().sync.get_consult(payload["thread_id"]) is None
+    assert _get_store().sync.list_consult_messages(payload["thread_id"]) == []
+
+
+def test_x_enterprise_receiver_persona_in_wrong_enterprise_returns_404(
+    client: TestClient,
+) -> None:
+    """A username that exists but belongs to a different enterprise/group is not addressable."""
+    _seed_peering(offer_id="off_recv", from_ent="globex", to_ent="acme")
+    bearer = forward_sign.derive_peering_bearer(_FAKE_OFFER_SIG, _FAKE_ACCEPT_SIG)
+
+    # Seed a user with the right username but wrong tenancy. The receiver
+    # L2 is acme/engineering — this user is on rival/somewhere.
+    store = _get_store()
+    pw = bcrypt.hashpw(b"pw", bcrypt.gensalt()).decode()
+    store.sync.create_user("foreigner", pw)
+    with store._engine.begin() as _c:
+        _c.exec_driver_sql(
+            "UPDATE users SET enterprise_id = ?, group_id = ? WHERE username = ?",
+            ("rival", "somewhere", "foreigner"),
+        )
+
+    payload = _x_enterprise_payload()
+    payload["to_persona"] = "foreigner"
+
+    r = client.post(
+        "/api/v1/consults/x-enterprise-forward-request",
+        headers=_x_enterprise_headers(bearer=bearer),
+        json=payload,
+    )
+    assert r.status_code == 404, r.text
+    assert r.json()["detail"] == "to_persona not found"
+    assert _get_store().sync.get_consult(payload["thread_id"]) is None
+
+
+def test_x_enterprise_receiver_valid_persona_succeeds(client: TestClient) -> None:
+    """The happy-path mirror — explicit baseline that #98's validation
+    didn't regress real users.
+
+    The fixture seeds ALICE on acme/engineering (the receiving L2's
+    tenancy). The default _x_enterprise_payload() addresses ALICE, so
+    this should still 201 + create the thread, even with the new check.
+    """
+    _seed_peering(offer_id="off_recv", from_ent="globex", to_ent="acme")
+    bearer = forward_sign.derive_peering_bearer(_FAKE_OFFER_SIG, _FAKE_ACCEPT_SIG)
+
+    r = client.post(
+        "/api/v1/consults/x-enterprise-forward-request",
+        headers=_x_enterprise_headers(bearer=bearer),
+        json=_x_enterprise_payload(),
+    )
+    assert r.status_code == 201, r.text
+    thread = _get_store().sync.get_consult("th_recv_1")
+    assert thread is not None
+    assert thread["to_persona"] == ALICE


### PR DESCRIPTION
## Summary

Cross-Enterprise consult forwards (`POST /consults/x-enterprise-forward-request`, `consults.py:929`) previously created thread + message rows for **any** `to_persona`, regardless of whether such a user existed on the receiving L2. Threads landed in limbo: no inbox surface returned them (the addressed user didn't exist) but the sender got a `201 {"status": "mirrored"}` response — silent black hole, easy data loss via typos. Discovery context is in #98 (surfaced verifying Bran's onboarding consult to a non-existent `david` persona on `8th-layer/engineering`).

## Fix

In `x_enterprise_forward_consult_request`, after `_require_x_enterprise_auth` and **before** any `create_consult` / `append_consult_message` writes, validate that `body.to_persona`:

1. Resolves to a real user on this L2 (via `store.get_user(username)`).
2. Has `enterprise_id` matching this L2's `aigrp_mod.enterprise()`.
3. Has `group_id` matching this L2's `aigrp_mod.group()`.

If any check fails → `HTTPException(404, "to_persona not found")`. No rows written.

The `if body.to_persona:` guard preserves the team-lead-flagged edge case: if a future Group-only address shape lands (with empty `to_persona`), the validation is skipped — current schema requires non-empty so this is forward-compat only.

## Test plan

- [x] `tests/test_x_enterprise_consult.py::test_x_enterprise_receiver_unknown_persona_returns_404` — unknown username → 404 + zero rows
- [x] `tests/test_x_enterprise_consult.py::test_x_enterprise_receiver_persona_in_wrong_enterprise_returns_404` — username exists but wrong tenancy → 404
- [x] `tests/test_x_enterprise_consult.py::test_x_enterprise_receiver_valid_persona_succeeds` — happy-path baseline (no regression for real users)
- [x] Full backend suite: `uv run pytest -x -q` → **575 passed, 5 skipped** (pre-existing skips, no new failures)
- [x] Existing 27 tests in `test_x_enterprise_consult.py` all still pass alongside the 3 new ones

## Out of scope (filed separately if needed)

- Metric `consult.x_enterprise_forward.persona_not_found` mentioned in the issue — emitting metrics is not wired into this path yet; deferred until the metrics layer is in place.
- Admin "orphan threads" view (issue's alternative path) — not pursued; the 404 approach is the operator-decision per the team-lead brief.
- Same-Enterprise `/forward-request` (line 694) has the same shape risk but is out of scope per the brief; can file as a follow-up if confirmed.

closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)