### PR TITLE
feat(108-stage-2): instrumentation + #89 tenancy fix + #103 pending_review + activity read

### DIFF
--- a/server/backend/alembic/versions/0011_activity_log.py
+++ b/server/backend/alembic/versions/0011_activity_log.py
@@ -1,0 +1,198 @@
+r"""Activity log of record — corporate IP capture for the L2 (#108).
+
+Revision ID: 0011_activity_log
+Revises: 0010_reflect_submissions
+Create Date: 2026-05-06
+
+Phase 1 of #108: schema only. Stage 2 (instrumentation-engineer) wires
+existing handlers to write rows; Stage 2 also ships the read endpoint at
+``GET /api/v1/activity``. This migration creates the substrate.
+
+The L2 is the **activity log of record** for a team's agents — every
+``cq.query`` call, every KU lifecycle event, every crosstalk message,
+every cross-Enterprise consult. The table is append-only and tenanted:
+
+* All rows carry ``tenant_enterprise`` (NOT NULL). ``tenant_group`` is
+  nullable because some system events (e.g. cross-tenant peering scans)
+  don't have a single owning group.
+* ``persona`` and ``human`` are nullable so background/system events
+  (cron sweeps, automated reflect runs) can still log without faking
+  an actor.
+* ``payload`` and ``result_summary`` are JSON-as-text — same convention
+  as every other store column (SQLite has no JSON type; PostgreSQL gets
+  upgraded to ``jsonb`` in a future migration when the runtime moves
+  off SQLite).
+* ``event_type`` is constrained to the locked enum below by a CHECK
+  constraint — same shape as ``reflect_submissions.state``. Adding a
+  new event type requires a follow-up migration that drops + recreates
+  the table on SQLite (``ALTER TABLE ... DROP CHECK`` is not supported)
+  via Alembic's batch-recreate mode.
+
+Locked event-type enum (#108 Schema sketch):
+
+    query, propose, confirm, flag,
+    review_start, review_resolve,
+    crosstalk_send, crosstalk_reply, crosstalk_close,
+    consult_open, consult_reply, consult_close
+
+Indexes (per #108 acceptance):
+
+* ``idx_activity_log_tenant_ts`` — ``(tenant_enterprise, tenant_group,
+  ts)``: drives the dashboard "what is our team doing" queries and the
+  retention sweeper's per-tenant scan.
+* ``idx_activity_log_persona_ts`` — ``(persona, ts)``: drives the
+  per-persona drill-down ("activity by human").
+* ``idx_activity_log_event_type_ts`` — ``(event_type, ts)``: drives
+  filtering by event class on the read endpoint.
+* ``idx_activity_log_thread`` — ``(thread_or_chain_id)``: correlates
+  events into workflows (consult thread, crosstalk chain, review
+  cycle).
+
+Indexes are declared with columns in ascending order for portability.
+SQLite uses the same b-tree for ``ORDER BY ts DESC`` queries; the read
+endpoint sets ``ORDER BY ts DESC`` and the planner picks up the index
+for backward iteration.
+
+# Retention
+
+Default retention is **90 days**, configurable per Enterprise via
+``activity_retention_config(enterprise_id, retention_days, updated_at)``.
+Absence of a row means "use default 90 days" — operators only need to
+write a row to override.
+
+Cleanup runs out-of-band:
+
+* In-server: a periodic asyncio task in ``app.py`` startup wakes daily
+  and calls ``store.purge_activity_older_than(...)`` per Enterprise
+  (Stage 2 of #108 wires this — schema only here).
+* Lambda alternative: an EventBridge cron hits an admin endpoint that
+  invokes the same store helper. Same SQL, different scheduler.
+
+Cleanup is intentionally **not** triggered by the migration. Schema
+changes never delete rows.
+
+# Append-only invariant
+
+Application code never UPDATEs or DELETEs except via the retention
+sweeper, which deletes rows older than the per-Enterprise window. The
+schema does not enforce this — it's a code-level invariant, validated
+in ``test_activity_log.py``. PostgreSQL will eventually grow a
+trigger to forbid UPDATEs; SQLite has no equivalent so the invariant
+stays code-only.
+
+# Idempotency
+
+The ``_table_exists`` guard mirrors every other migration in this
+chain (#305 baseline, #67 reflect, #99 reputation). A re-run is a
+no-op. Downgrade drops both tables — used by tests; not for prod.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0011_activity_log"
+down_revision: str | Sequence[str] | None = "0010_reflect_submissions"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# Locked enum — must stay in sync with cq_server.activity.EVENT_TYPES.
+# Adding a new value requires a new migration that uses Alembic batch
+# recreate to swap the CHECK constraint.
+_EVENT_TYPES = (
+    "query",
+    "propose",
+    "confirm",
+    "flag",
+    "review_start",
+    "review_resolve",
+    "crosstalk_send",
+    "crosstalk_reply",
+    "crosstalk_close",
+    "consult_open",
+    "consult_reply",
+    "consult_close",
+)
+
+
+def _table_exists(bind: sa.engine.Connection, table_name: str) -> bool:
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def _check_clause() -> str:
+    quoted = ", ".join(f"'{e}'" for e in _EVENT_TYPES)
+    return f"event_type IN ({quoted})"
+
+
+def upgrade() -> None:
+    """Create the ``activity_log`` + ``activity_retention_config`` tables."""
+    bind = op.get_bind()
+
+    if not _table_exists(bind, "activity_log"):
+        op.create_table(
+            "activity_log",
+            sa.Column("id", sa.Text(), primary_key=True),  # act_<26-char-ULID>
+            sa.Column("ts", sa.Text(), nullable=False),  # ISO-8601 with Z suffix
+            sa.Column("tenant_enterprise", sa.Text(), nullable=False),
+            sa.Column("tenant_group", sa.Text(), nullable=True),
+            sa.Column("persona", sa.Text(), nullable=True),
+            sa.Column("human", sa.Text(), nullable=True),
+            sa.Column("event_type", sa.Text(), nullable=False),
+            sa.Column("payload", sa.Text(), nullable=False, server_default=sa.text("'{}'")),
+            sa.Column("result_summary", sa.Text(), nullable=True),
+            sa.Column("thread_or_chain_id", sa.Text(), nullable=True),
+            sa.CheckConstraint(_check_clause(), name="ck_activity_log_event_type"),
+        )
+        op.create_index(
+            "idx_activity_log_tenant_ts",
+            "activity_log",
+            ["tenant_enterprise", "tenant_group", "ts"],
+        )
+        op.create_index(
+            "idx_activity_log_persona_ts",
+            "activity_log",
+            ["persona", "ts"],
+        )
+        op.create_index(
+            "idx_activity_log_event_type_ts",
+            "activity_log",
+            ["event_type", "ts"],
+        )
+        op.create_index(
+            "idx_activity_log_thread",
+            "activity_log",
+            ["thread_or_chain_id"],
+        )
+
+    if not _table_exists(bind, "activity_retention_config"):
+        op.create_table(
+            "activity_retention_config",
+            sa.Column("enterprise_id", sa.Text(), primary_key=True),
+            sa.Column(
+                "retention_days",
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text("90"),
+            ),
+            sa.Column("updated_at", sa.Text(), nullable=False),
+            sa.CheckConstraint(
+                "retention_days > 0",
+                name="ck_activity_retention_days_positive",
+            ),
+        )
+
+
+def downgrade() -> None:
+    """Drop activity-log tables. Used by tests; not for production."""
+    bind = op.get_bind()
+    if _table_exists(bind, "activity_retention_config"):
+        op.drop_table("activity_retention_config")
+    if _table_exists(bind, "activity_log"):
+        op.drop_index("idx_activity_log_thread", table_name="activity_log")
+        op.drop_index("idx_activity_log_event_type_ts", table_name="activity_log")
+        op.drop_index("idx_activity_log_persona_ts", table_name="activity_log")
+        op.drop_index("idx_activity_log_tenant_ts", table_name="activity_log")
+        op.drop_table("activity_log")

--- a/server/backend/alembic/versions/0012_pending_review_tier.py
+++ b/server/backend/alembic/versions/0012_pending_review_tier.py
@@ -1,0 +1,113 @@
+"""Pending-review tier columns on knowledge_units (#103).
+
+Revision ID: 0012_pending_review_tier
+Revises: 0011_activity_log
+Create Date: 2026-05-06
+
+Adds the substrate for the L2-queued hard-finding review surface from
+#103. ``/cq:reflect`` produces VIBE√-flagged candidates that need human
+judgment before tier-promotion (sanitization concerns: credentials in
+summary, PII in detail, etc.). Pre-fix, those candidates were either
+silently dropped or pushed to private — both losing data and bypassing
+the security review the VIBE√ classifier flagged. This migration ships
+the columns and the state-machine values; ``cq_server.review`` and a
+new ``GET /review/pending-review`` route layer use them.
+
+State model (#103):
+
+* Hard findings are submitted with ``status='pending_review'`` plus a
+  reason string and a per-tenant TTL on ``pending_review_expires_at``.
+* ``POST /review/{id}/approve`` transitions ``pending_review →
+  approved`` (existing approve handler — same shape as the normal
+  pending-queue approve).
+* ``POST /review/{id}/reject`` transitions ``pending_review →
+  dropped`` — the dropped status is *terminal* and distinct from
+  ``rejected`` so we can distinguish "operator saw it and said no"
+  from "lost data" if a downstream sweeper ever needs to.
+* TTL sweeper transitions ``pending_review → dropped`` when
+  ``pending_review_expires_at < now`` and no human has reviewed.
+
+Why ``status``, not a new ``tier``: the cq SDK's ``Tier`` enum is
+pinned from PyPI (cq-sdk~=0.9.1). Adding a new tier value would
+require an SDK release; the ``status`` column is already L2-server-
+local and was designed for exactly this kind of lifecycle marker.
+KUs proposed via the hard-finding queue still land at ``tier=private``
+on the storage axis; the lifecycle axis is ``status``.
+
+# Schema additions
+
+* ``pending_review_reason TEXT NULL`` — free-form reason from the
+  reflect classifier ("credential-shaped substring", "PII detected",
+  etc.). NULL on rows that aren't pending-review.
+* ``pending_review_expires_at TEXT NULL`` — ISO-8601 with Z suffix.
+  When ``status='pending_review'`` AND ``expires_at < now``, the TTL
+  sweeper drops the row.
+
+No CHECK constraint on the status column — adding one would need
+batch-recreate, and the existing review code paths already use string
+comparison rather than enum membership. Documentation and the
+``/review/*`` handlers gate the value space.
+
+# Idempotency
+
+Standard column-existence guard pattern. Re-runs are no-ops. Downgrade
+drops both columns; only used by tests.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0012_pending_review_tier"
+down_revision: str | Sequence[str] | None = "0011_activity_log"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _table_exists(bind: sa.engine.Connection, table_name: str) -> bool:
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def _column_names(bind: sa.engine.Connection, table_name: str) -> set[str]:
+    inspector = sa.inspect(bind)
+    if table_name not in inspector.get_table_names():
+        return set()
+    return {col["name"] for col in inspector.get_columns(table_name)}
+
+
+def upgrade() -> None:
+    """Add pending_review_reason + pending_review_expires_at to knowledge_units."""
+    bind = op.get_bind()
+    if not _table_exists(bind, "knowledge_units"):
+        # The table is created by 0001_baseline; this migration runs on
+        # a stamped DB that already has it. Defensive: skip rather than
+        # error if the chain is somehow incomplete (matches the
+        # idempotency guard in 0001_phase6_step1).
+        return
+
+    existing = _column_names(bind, "knowledge_units")
+    with op.batch_alter_table("knowledge_units") as batch:
+        if "pending_review_reason" not in existing:
+            batch.add_column(
+                sa.Column("pending_review_reason", sa.Text(), nullable=True)
+            )
+        if "pending_review_expires_at" not in existing:
+            batch.add_column(
+                sa.Column("pending_review_expires_at", sa.Text(), nullable=True)
+            )
+
+
+def downgrade() -> None:
+    """Drop pending_review columns. Used by tests; not for production."""
+    bind = op.get_bind()
+    if not _table_exists(bind, "knowledge_units"):
+        return
+
+    existing = _column_names(bind, "knowledge_units")
+    with op.batch_alter_table("knowledge_units") as batch:
+        if "pending_review_expires_at" in existing:
+            batch.drop_column("pending_review_expires_at")
+        if "pending_review_reason" in existing:
+            batch.drop_column("pending_review_reason")

--- a/server/backend/alembic/versions/0013_backfill_default_enterprise_kus.py
+++ b/server/backend/alembic/versions/0013_backfill_default_enterprise_kus.py
@@ -1,0 +1,171 @@
+"""Backfill default-enterprise KUs to their proposer's tenancy (#121 finding 3).
+
+Revision ID: 0013_backfill_default_enterprise_kus
+Revises: 0012_pending_review_tier
+Create Date: 2026-05-07
+
+The #89 fix landed in 819729b, but it only protects new INSERTs via
+``INSERT_UNIT_WITH_TENANCY``. Every KU proposed before the fix shipped
+sits in ``enterprise_id='default-enterprise'`` /
+``group_id='default-group'`` regardless of which tenant the proposer
+actually belongs to. On a deployment that's been live since before the
+fix, those rows are mis-tenanted: cross-tenant queries can see them,
+the proposer's real tenant can't see them, and tenant-scoped admin
+endpoints (``/review/queue``, ``/review/stats``) silently exclude
+them from the right tenant's view.
+
+This migration scans every KU still at ``default-enterprise``, parses
+``created_by`` out of the JSON ``data`` blob, looks up that user's
+current tenancy, and rewrites the row's tenancy columns to match.
+Idempotent — re-runs are no-ops because the WHERE clause excludes
+rows that have already been backfilled.
+
+# What gets touched
+
+Only rows where:
+
+* ``enterprise_id = 'default-enterprise'`` AND ``group_id = 'default-group'``
+  — both columns must still be at the schema-level default. If either
+  has been customized, we leave the row alone (defensive: that row may
+  have been intentionally placed in default-enterprise, e.g. system-
+  proposed fixture data).
+* ``data->>'created_by'`` resolves to a known user with non-default
+  tenancy. KUs with no ``created_by``, an empty string, or a username
+  that doesn't exist in the users table are left at default-enterprise
+  — we have no signal to reassign them, and the safe default is "stay
+  put" rather than guess.
+
+# Why JSON parse over a join
+
+``knowledge_units.data`` is the ``KnowledgeUnit`` Pydantic dump as a
+TEXT blob. SQLite doesn't expose ``->>`` as a JSON operator pre-3.38;
+PostgreSQL does. To stay portable we parse in Python rather than push
+JSON extraction into SQL — slower, but a one-shot migration so the
+extra round-trips don't matter and the SQL stays portable.
+
+# Idempotency
+
+Standard pattern: re-runs of the upgrade scan zero rows because the
+WHERE clause excludes already-backfilled records. Downgrade is a
+no-op — there's no way to recover the original ``default-enterprise``
+state for the rows we touched (and we shouldn't want to: those rows
+were mis-tenanted in the first place).
+
+# Operator note
+
+If you're running this against a deployment with thousands of legacy
+KUs, the migration runs in O(n) Python time, not O(n) SQL time. For
+deployments below ~10k rows it'll complete in seconds; above that,
+plan a maintenance window. The rewrite uses one UPDATE per row rather
+than a single CASE expression because the per-row enterprise_id is
+data-dependent.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0013_backfill_default_enterprise_kus"
+down_revision: str | Sequence[str] | None = "0012_pending_review_tier"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _table_exists(bind: sa.engine.Connection, table_name: str) -> bool:
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def upgrade() -> None:
+    """Reassign legacy default-enterprise KUs to their proposer's tenancy."""
+    bind = op.get_bind()
+    # Defensive: the chain might be partial (test-only branches stamp
+    # one migration without running the rest). If knowledge_units or
+    # users isn't present, there's nothing to backfill.
+    if not _table_exists(bind, "knowledge_units"):
+        return
+    if not _table_exists(bind, "users"):
+        return
+
+    # Step 1: pull every still-default-enterprise KU id + data blob.
+    # We need data because that's where ``created_by`` lives.
+    candidates = bind.exec_driver_sql(
+        "SELECT id, data FROM knowledge_units "
+        "WHERE enterprise_id = 'default-enterprise' "
+        "AND group_id = 'default-group'"
+    ).fetchall()
+    if not candidates:
+        return
+
+    # Step 2: index users by username so the per-row lookup is O(1).
+    # Skip users at default tenancy themselves — they don't help us
+    # disambiguate (reassigning one default-enterprise row to another
+    # is a no-op, and we shouldn't pretend to "fix" it).
+    user_rows = bind.exec_driver_sql(
+        "SELECT username, enterprise_id, group_id FROM users "
+        "WHERE enterprise_id != 'default-enterprise' "
+        "OR group_id != 'default-group'"
+    ).fetchall()
+    user_map: dict[str, tuple[str, str]] = {
+        row[0]: (row[1], row[2]) for row in user_rows
+    }
+    if not user_map:
+        # No users with non-default tenancy => no signal to backfill on.
+        return
+
+    # Step 3: walk the candidates, parse created_by, rewrite tenancy.
+    update_sql = sa.text(
+        "UPDATE knowledge_units "
+        "SET enterprise_id = :enterprise_id, group_id = :group_id "
+        "WHERE id = :id "
+        "AND enterprise_id = 'default-enterprise' "
+        "AND group_id = 'default-group'"
+    )
+    backfilled = 0
+    for unit_id, data_blob in candidates:
+        try:
+            data = json.loads(data_blob)
+        except (TypeError, ValueError):
+            # Malformed JSON — log via Alembic's stderr and skip.
+            # We never raise: a single bad row must not abort the
+            # whole migration. The row stays at default-enterprise;
+            # operators can repair it manually.
+            continue
+        created_by = data.get("created_by") if isinstance(data, dict) else None
+        if not created_by or not isinstance(created_by, str):
+            continue
+        scope = user_map.get(created_by)
+        if scope is None:
+            continue
+        bind.execute(
+            update_sql,
+            {
+                "enterprise_id": scope[0],
+                "group_id": scope[1],
+                "id": unit_id,
+            },
+        )
+        backfilled += 1
+
+    # Surface the count in alembic output for the operator's audit log.
+    # Alembic captures stdout when running migrations.
+    print(  # noqa: T201 — migration audit signal, not application logging
+        f"[0013] backfilled {backfilled} of {len(candidates)} "
+        f"default-enterprise KUs to their proposer's tenancy"
+    )
+
+
+def downgrade() -> None:
+    """No-op: backfilled rows stay at their corrected tenancy.
+
+    Rolling back this migration would mean re-tenanting correctly-
+    placed rows back to default-enterprise — that's the bug, not a
+    feature. If you need to undo this migration for some reason,
+    write a follow-up data migration with explicit selection criteria
+    rather than reverting in bulk.
+    """
+    pass

--- a/server/backend/src/cq_server/activity.py
+++ b/server/backend/src/cq_server/activity.py
@@ -1,0 +1,92 @@
+"""Activity log of record — shared module for #108 Stage 1 substrate.
+
+Stage 1 (this PR) ships the schema + a minimal store helper that
+Stage 2 (instrumentation) calls from FastAPI ``BackgroundTask`` writes
+on every query / propose / confirm / flag / review / consult /
+crosstalk handler. Stage 2 also adds the ``GET /api/v1/activity``
+read endpoint.
+
+Single source of truth for:
+
+* The locked event-type enum (mirrors the CHECK constraint in
+  ``alembic/versions/0011_activity_log.py``).
+* The ``act_<ULID>`` row-id generator.
+* The ``Z``-suffix ISO-8601 timestamp helper used on the wire and in
+  the row.
+* The default 90-day retention constant.
+
+Nothing here imports the store. Store-bound logic lives on
+``SqliteStore.append_activity`` / ``purge_activity_older_than``.
+"""
+
+from __future__ import annotations
+
+import secrets
+import time
+from datetime import UTC, datetime
+
+__all__ = [
+    "DEFAULT_RETENTION_DAYS",
+    "EVENT_TYPES",
+    "generate_activity_id",
+    "now_iso_z",
+]
+
+
+# Locked enum — must stay in sync with the CHECK constraint in
+# ``alembic/versions/0011_activity_log.py`` and with the schema
+# sketch in issue #108. Adding a new value requires a new Alembic
+# migration that swaps the constraint via batch-recreate.
+EVENT_TYPES: frozenset[str] = frozenset(
+    {
+        "query",
+        "propose",
+        "confirm",
+        "flag",
+        "review_start",
+        "review_resolve",
+        "crosstalk_send",
+        "crosstalk_reply",
+        "crosstalk_close",
+        "consult_open",
+        "consult_reply",
+        "consult_close",
+    }
+)
+
+
+# Default retention window. Per-enterprise overrides live in
+# ``activity_retention_config(enterprise_id, retention_days, ...)``.
+# Absence of a row means "use this default".
+DEFAULT_RETENTION_DAYS: int = 90
+
+
+_CROCKFORD_BASE32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+
+def generate_activity_id() -> str:
+    """Produce an ``act_<26-char-ULID>`` id.
+
+    Lexicographically sortable on insert order: 10-char Crockford-base32
+    timestamp (millis since epoch) + 16 chars of cryptographic
+    randomness. Same shape ``python-ulid`` produces; inlined to avoid
+    a dependency for one helper, mirroring ``reflect._generate_submission_id``.
+    """
+    millis = int(time.time() * 1000)
+    ts_chars: list[str] = []
+    for _ in range(10):
+        ts_chars.append(_CROCKFORD_BASE32[millis & 0x1F])
+        millis >>= 5
+    ts_part = "".join(reversed(ts_chars))
+    rand_part = "".join(secrets.choice(_CROCKFORD_BASE32) for _ in range(16))
+    return f"act_{ts_part}{rand_part}"
+
+
+def now_iso_z() -> str:
+    """Return the current UTC time as an ISO-8601 string with ``Z`` suffix.
+
+    Same convention as ``cq_server.reflect._iso``: emit ``Z`` rather
+    than ``+00:00`` so wire payloads, log rows, and dashboard renders
+    all agree on a single timestamp shape.
+    """
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")

--- a/server/backend/src/cq_server/activity_logger.py
+++ b/server/backend/src/cq_server/activity_logger.py
@@ -1,0 +1,152 @@
+"""Non-blocking activity-log writer for #108 Stage 2 instrumentation.
+
+Stage 2 wraps Stage 1's substrate (``cq_server.activity`` +
+``store.append_activity``) into a *single* helper every write-path
+handler can hand to FastAPI's ``BackgroundTasks``. The helper:
+
+* Resolves the caller's tenancy (``enterprise_id`` / ``group_id``) from
+  the user row at task-execution time. Doing the resolution inside the
+  background task — not inside the request handler — keeps the response
+  path off the database for the audit write. Cost: one extra
+  ``SELECT users WHERE username = ?`` per logged event. That cost is
+  bounded; on the order of microseconds, and the request has already
+  been sent.
+* Swallows every failure path. The audit log is fire-and-forget by
+  design (#108: "if the activity log write fails, the response still
+  succeeds — log a warning, don't error"). Schema-engineer's
+  ``store.append_activity`` raises ``ValueError`` on unknown event_type
+  and ``IntegrityError`` on CHECK violation; both are caught here.
+* Mirrors the system-event shape from the schema sketch — when the
+  caller is None / the user row vanished, ``persona`` and ``human``
+  fall through as ``None`` and the row records under
+  ``aigrp.enterprise()`` / ``aigrp.group()`` (this L2's own identity)
+  rather than failing.
+
+The helper is intentionally a free function rather than a method on
+``SqliteStore``: it composes Store + activity-id generation + tenancy
+resolution, none of which are store-internal concerns.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from . import aigrp
+from .activity import EVENT_TYPES, generate_activity_id, now_iso_z
+
+if TYPE_CHECKING:
+    from .store._sqlite import SqliteStore
+
+__all__ = [
+    "log_activity",
+    "summary_first_60",
+]
+
+logger = logging.getLogger(__name__)
+
+
+def summary_first_60(text_value: str | None) -> str:
+    """Return at most the first 60 chars of ``text_value``.
+
+    Used to clamp KU summaries before they land in ``payload`` —
+    enforces the #108 schema sketch's ``summary_first_60_chars`` shape
+    and keeps the audit row from holding the entire KU body (which
+    already lives in ``knowledge_units.data``).
+    """
+    if not text_value:
+        return ""
+    return text_value[:60]
+
+
+async def log_activity(
+    store: SqliteStore,
+    *,
+    username: str | None,
+    event_type: str,
+    payload: dict[str, Any] | None = None,
+    result_summary: dict[str, Any] | None = None,
+    thread_or_chain_id: str | None = None,
+) -> None:
+    """Append one ``activity_log`` row; swallow any failure.
+
+    Designed to be scheduled via ``background_tasks.add_task(...)`` from
+    every write-path handler. The response is already sent by the time
+    this runs; any exception here is logged at WARNING level and never
+    propagates back to the client.
+
+    ``username`` may be ``None`` for system-emitted events (e.g. the
+    retention sweeper, AIGRP convergence hooks). When set, the user row
+    drives the row's ``tenant_enterprise`` / ``tenant_group`` /
+    ``persona``. When unset, the row is filed under this L2's own
+    Enterprise/Group with ``persona=None`` and ``human=None``.
+
+    ``event_type`` must be one of ``cq_server.activity.EVENT_TYPES``;
+    a typo here would otherwise hit the CHECK constraint at write time.
+    Validating in Python turns it into a logged warning rather than an
+    SQL exception silently swallowed by the background runner.
+    """
+    if event_type not in EVENT_TYPES:
+        logger.warning(
+            "activity log: refusing to append unknown event_type %r "
+            "(expected one of %s)",
+            event_type,
+            sorted(EVENT_TYPES),
+        )
+        return
+
+    try:
+        tenant_enterprise: str
+        tenant_group: str | None
+        persona: str | None
+        if username is None:
+            tenant_enterprise = aigrp.enterprise()
+            tenant_group = aigrp.group()
+            persona = None
+        else:
+            user = await store.get_user(username)
+            if user is None:
+                # The user row vanished between the auth check and the
+                # background-task run (deletion race). Fall back to
+                # this L2's own identity so the event is still
+                # recorded; persona is the username string the auth
+                # layer accepted.
+                tenant_enterprise = aigrp.enterprise()
+                tenant_group = aigrp.group()
+                persona = username
+            else:
+                tenant_enterprise = str(
+                    user.get("enterprise_id") or aigrp.enterprise()
+                )
+                # ``group_id`` is column-NOT-NULL on the users table per
+                # migration 0001_phase6_step1, but defensive cast keeps
+                # the helper safe if a future schema makes it nullable.
+                grp = user.get("group_id")
+                tenant_group = str(grp) if grp is not None else None
+                persona = username
+
+        await store.append_activity(
+            activity_id=generate_activity_id(),
+            ts=now_iso_z(),
+            tenant_enterprise=tenant_enterprise,
+            tenant_group=tenant_group,
+            persona=persona,
+            # ``human`` is the operator-mapped human identity. The
+            # human-to-persona mapping landed in #98 plans but isn't
+            # wired into the user row yet; leaving NULL until that
+            # mapping ships keeps this row truthful rather than fake-
+            # filling with the username.
+            human=None,
+            event_type=event_type,
+            payload=payload,
+            result_summary=result_summary,
+            thread_or_chain_id=thread_or_chain_id,
+        )
+    except Exception:  # noqa: BLE001 — fire-and-forget by design
+        logger.warning(
+            "activity log append failed: event_type=%s persona=%s thread=%s",
+            event_type,
+            username,
+            thread_or_chain_id,
+            exc_info=True,
+        )

--- a/server/backend/src/cq_server/activity_routes.py
+++ b/server/backend/src/cq_server/activity_routes.py
@@ -1,0 +1,217 @@
+"""Activity-log read endpoint (#108 Stage 2 — Workstream D).
+
+Stage 1 shipped the schema + write helper. Stage 2 wires every existing
+write-path handler to append rows; *this* module is the read side —
+``GET /api/v1/activity`` with admin-or-self auth scoping and cursor
+pagination.
+
+Auth model:
+
+* Admin callers can read any persona's events within their Enterprise.
+  Use ``persona=<name>`` to filter; omit it to see everyone.
+* Non-admin callers can only see events tagged with their own persona
+  (the username from their auth claims). Any persona query parameter
+  they send is forced to their own username before the store query —
+  no enumeration oracle, no cross-persona leak.
+
+Tenancy is mandatory: the route layer always pins
+``tenant_enterprise`` to the caller's Enterprise. Cross-Enterprise
+visibility is impossible by construction; foreign-Enterprise consults
+already log on both ends per the consult logging policy.
+
+Cursor:
+
+* Each response includes ``next_cursor`` when a full page returned;
+  callers re-send it as ``cursor=<value>`` for the next page.
+* Encoded as ``<ts>|<id>`` — opaque to the client, just round-trip it.
+* Decoder accepts the historical empty value as "no cursor".
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from .activity import EVENT_TYPES
+from .auth import get_current_user
+from .deps import get_store
+from .store._sqlite import SqliteStore
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/activity", tags=["activity"])
+
+_CURSOR_SEP = "|"
+# Hard ceiling protects the read endpoint from a caller asking for ten
+# million rows in one page; mirrors the ``le=500`` bound on /consents.
+_LIMIT_MAX = 500
+
+
+class ActivityRow(BaseModel):
+    """Public wire shape for one ``activity_log`` row."""
+
+    id: str
+    ts: str
+    tenant_enterprise: str
+    tenant_group: str | None
+    persona: str | None
+    human: str | None
+    event_type: str
+    payload: dict[str, Any]
+    result_summary: dict[str, Any] | None
+    thread_or_chain_id: str | None
+
+
+class ActivityListResponse(BaseModel):
+    """Paginated list of activity rows + opaque cursor for the next page."""
+
+    items: list[ActivityRow]
+    count: int
+    next_cursor: str | None
+
+
+def _encode_cursor(ts: str, id_: str) -> str:
+    return f"{ts}{_CURSOR_SEP}{id_}"
+
+
+def _decode_cursor(cursor: str | None) -> tuple[str, str] | None:
+    """Parse a ``ts|id`` cursor back into the store-helper tuple shape.
+
+    Returns None when ``cursor`` is None / empty. Raises 400 when the
+    cursor is malformed — a malformed cursor is a client bug, not a
+    "no more results" signal.
+    """
+    if not cursor:
+        return None
+    if _CURSOR_SEP not in cursor:
+        raise HTTPException(
+            status_code=400,
+            detail=f"malformed cursor {cursor!r}; expected '<ts>{_CURSOR_SEP}<id>'",
+        )
+    ts, id_ = cursor.split(_CURSOR_SEP, 1)
+    if not ts or not id_:
+        raise HTTPException(status_code=400, detail="cursor parts must be non-empty")
+    return ts, id_
+
+
+def _normalise_iso(value: str | None, *, field_name: str) -> str | None:
+    """Validate that ``value`` parses as ISO-8601; return it as-is.
+
+    The store column stores ISO-8601 strings rather than timestamps,
+    and SQLite compares them lexicographically — which works because
+    ISO-8601 with a fixed timezone offset is monotone in lexicographic
+    order. We accept the value verbatim once it parses; do NOT
+    canonicalise to UTC because that would shift the comparison
+    boundary by a timezone offset and miss rows.
+    """
+    if value is None:
+        return None
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=f"{field_name} is not a valid ISO-8601 timestamp: {value!r}",
+        ) from exc
+    return value
+
+
+@router.get("")
+async def list_activity(
+    persona: str | None = Query(default=None),
+    since: str | None = Query(default=None, description="ISO-8601 lower bound (inclusive)"),
+    until: str | None = Query(default=None, description="ISO-8601 upper bound (exclusive)"),
+    event_type: str | None = Query(default=None),
+    limit: int = Query(default=50, gt=0, le=_LIMIT_MAX),
+    cursor: str | None = Query(default=None),
+    username: str = Depends(get_current_user),
+    store: SqliteStore = Depends(get_store),
+) -> ActivityListResponse:
+    """Read activity-log rows with admin-or-self auth scoping.
+
+    Authorization tiers:
+
+    * **Admin caller** — ``persona`` query param applied as-is; omit it
+      to see every persona within the caller's Enterprise.
+    * **Non-admin caller** — ``persona`` is forced to the caller's
+      own username regardless of what they sent. A non-admin who
+      asked for ``persona=alice`` while authenticated as Bob will see
+      Bob's events only. Silent override (rather than a 403) — the
+      route can't tell whether the caller meant to spoof or just
+      misunderstood the contract; either way the right answer is
+      "your own activity".
+
+    Cursor pagination on ``(ts DESC, id DESC)``. ``next_cursor`` is
+    populated when the page returned exactly ``limit`` rows — the
+    last row's ``ts|id`` becomes the next page's anchor. A null
+    ``next_cursor`` means "no more rows".
+
+    422 on malformed timestamps; 400 on malformed cursor; 401 on auth
+    failure (raised by the chained ``get_current_user`` dep).
+    """
+    user = await store.get_user(username)
+    if user is None:
+        # Auth accepted the bearer but the user row vanished. Same shape
+        # as the ``propose_unit`` defensive 401.
+        raise HTTPException(status_code=401, detail="User not found")
+    enterprise_id = user["enterprise_id"]
+    role = user.get("role") or "user"
+
+    # Scope the persona filter:
+    #   - admin: pass through whatever they sent (including None for
+    #     "all personas in this Enterprise")
+    #   - non-admin: pin to their own username regardless of input
+    if role == "admin":
+        effective_persona = persona
+    else:
+        effective_persona = username
+        if persona is not None and persona != username:
+            logger.info(
+                "activity: non-admin %s asked for persona=%s; forced to self",
+                username,
+                persona,
+            )
+
+    if event_type is not None and event_type not in EVENT_TYPES:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"unknown event_type {event_type!r}; "
+                f"expected one of {sorted(EVENT_TYPES)}"
+            ),
+        )
+
+    since_iso = _normalise_iso(since, field_name="since")
+    until_iso = _normalise_iso(until, field_name="until")
+    cursor_tuple = _decode_cursor(cursor)
+
+    rows = await store.list_activity(
+        tenant_enterprise=enterprise_id,
+        persona=effective_persona,
+        since_iso=since_iso,
+        until_iso=until_iso,
+        event_type=event_type,
+        limit=limit,
+        cursor=cursor_tuple,
+    )
+
+    items = [ActivityRow(**row) for row in rows]
+    next_cursor = (
+        _encode_cursor(items[-1].ts, items[-1].id)
+        if len(items) == limit and items
+        else None
+    )
+    # Defensive: if `len(items) == limit` but we know there aren't more
+    # rows, the next call returns empty and the second-to-last cursor
+    # naturally terminates. Cheap one extra round-trip on the boundary
+    # vs the cost of a count(*) query on every page.
+
+    return ActivityListResponse(
+        items=items,
+        count=len(items),
+        next_cursor=next_cursor,
+    )

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -17,12 +17,14 @@ from cq.models import (
     Tier,
     create_knowledge_unit,
 )
-from fastapi import APIRouter, Depends, FastAPI, HTTPException, Query, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, FastAPI, HTTPException, Query, Request
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 from starlette.responses import FileResponse
 
 from . import aigrp
+from .activity_logger import log_activity, summary_first_60
+from .activity_routes import router as activity_router
 from .auth import require_admin
 from .auth import router as auth_router
 from .consults import router as consults_router
@@ -351,6 +353,7 @@ api_router.include_router(network_router)
 api_router.include_router(consults_router)
 api_router.include_router(reputation_router)
 api_router.include_router(reflect_router, prefix="/reflect", tags=["reflect"])
+api_router.include_router(activity_router)
 
 
 @api_router.get("/health")
@@ -1409,6 +1412,7 @@ async def query_semantic(
 
 @api_router.get("/query")
 async def query_units(
+    background_tasks: BackgroundTasks,
     domains: Annotated[list[str], Query()],
     languages: Annotated[list[str] | None, Query()] = None,
     frameworks: Annotated[list[str] | None, Query()] = None,
@@ -1423,12 +1427,17 @@ async def query_units(
     request never carries scope. Results are restricted to the caller's
     Enterprise (own Group plus cross-group-allowed KUs); cross-Enterprise
     discovery flows through ``/aigrp/forward-query`` (consent + audit).
+
+    Activity log (#108): every query schedules a non-blocking
+    ``activity_log`` row with the query parameters in ``payload`` and
+    the matched KU ids in ``result_summary``. Failure of the log write
+    never affects the response.
     """
     store = _get_store()
     user = await store.get_user(username)
     if user is None:
         raise HTTPException(status_code=401, detail="User not found")
-    return await store.query(
+    results = await store.query(
         domains,
         languages=languages,
         frameworks=frameworks,
@@ -1437,19 +1446,67 @@ async def query_units(
         enterprise_id=user["enterprise_id"],
         group_id=user["group_id"],
     )
+    background_tasks.add_task(
+        log_activity,
+        store,
+        username=username,
+        event_type="query",
+        payload={
+            "domains": list(domains),
+            "languages": list(languages) if languages else [],
+            "frameworks": list(frameworks) if frameworks else [],
+            "pattern": pattern or "",
+            "limit": limit,
+        },
+        result_summary={
+            "ku_ids": [u.id for u in results],
+            "cache_hit": False,  # L2 has no client-side cache; reserved
+        },
+    )
+    return results
 
 
 @api_router.post("/propose", status_code=201)
 async def propose_unit(
     request: ProposeRequest,
+    background_tasks: BackgroundTasks,
     username: str = Depends(require_api_key),
 ) -> KnowledgeUnit:
     """Submit a new knowledge unit.
 
-    ``created_by`` is always set to the authenticated caller's username; any
-    value supplied by the client is discarded.
+    ``created_by`` is always set to the authenticated caller's username;
+    any value supplied by the client is discarded.
+
+    Tenancy (#89): the new KU's ``enterprise_id`` / ``group_id`` come
+    directly from the authenticated caller's user row — never from the
+    request body and never from the schema-level ``default-enterprise``
+    fallback. Pre-fix every KU proposed via the API landed in
+    ``default-enterprise`` regardless of the L2's configured Enterprise,
+    breaking tenant isolation; this resolution closes that gap.
+
+    Activity log (#108): a non-blocking ``activity_log`` row is
+    appended after the response is sent.
     """
     store = _get_store()
+    user = await store.get_user(username)
+    if user is None:
+        # The auth layer accepted the bearer token but the user row is
+        # gone (revocation race / cleanup). 401 is the right shape —
+        # ``require_api_key`` already 401'd if the key was invalid, so a
+        # caller hitting this branch has a half-deleted user.
+        raise HTTPException(status_code=401, detail="User not found")
+    enterprise_id = user["enterprise_id"]
+    group_id = user["group_id"]
+    if not enterprise_id or not group_id:
+        # Defensive: the migration backfills these to non-empty defaults
+        # and the column is NOT NULL, so this should never trigger. If
+        # it does, the user row is malformed; fail loudly rather than
+        # silently writing a KU into ``default-enterprise``.
+        raise HTTPException(
+            status_code=500,
+            detail="User row missing tenancy claims; refusing to proceed",
+        )
+
     normalized = normalize_domains(request.domains)
     if not normalized:
         raise HTTPException(status_code=422, detail="At least one non-empty domain is required")
@@ -1472,34 +1529,85 @@ async def propose_unit(
     )
     if embed_payload is not None:
         embedding_bytes, embedding_model = embed_payload
-        await store.insert(unit)
+        await store.insert(
+            unit,
+            enterprise_id=enterprise_id,
+            group_id=group_id,
+        )
         await store.set_embedding(unit.id, embedding_bytes, embedding_model)
     else:
-        await store.insert(unit)
+        await store.insert(
+            unit,
+            enterprise_id=enterprise_id,
+            group_id=group_id,
+        )
+
+    background_tasks.add_task(
+        log_activity,
+        store,
+        username=username,
+        event_type="propose",
+        payload={
+            "ku_id": unit.id,
+            "summary_first_60_chars": summary_first_60(request.insight.summary),
+            "domains": list(normalized),
+        },
+    )
     return unit
 
 
 @api_router.post("/confirm/{unit_id}")
-async def confirm_unit(unit_id: str, _username: str = Depends(require_api_key)) -> KnowledgeUnit:
-    """Confirm a knowledge unit, boosting its confidence."""
+async def confirm_unit(
+    unit_id: str,
+    background_tasks: BackgroundTasks,
+    username: str = Depends(require_api_key),
+) -> KnowledgeUnit:
+    """Confirm a knowledge unit, boosting its confidence.
+
+    Activity log (#108): non-blocking ``confirm`` row.
+    """
     store = _get_store()
     unit = await store.get(unit_id)
     if unit is None:
         raise HTTPException(status_code=404, detail="Knowledge unit not found")
     confirmed = apply_confirmation(unit)
     await store.update(confirmed)
+    background_tasks.add_task(
+        log_activity,
+        store,
+        username=username,
+        event_type="confirm",
+        payload={"ku_id": unit_id},
+    )
     return confirmed
 
 
 @api_router.post("/flag/{unit_id}")
-async def flag_unit(unit_id: str, request: FlagRequest, _username: str = Depends(require_api_key)) -> KnowledgeUnit:
-    """Flag a knowledge unit, reducing its confidence."""
+async def flag_unit(
+    unit_id: str,
+    request: FlagRequest,
+    background_tasks: BackgroundTasks,
+    username: str = Depends(require_api_key),
+) -> KnowledgeUnit:
+    """Flag a knowledge unit, reducing its confidence.
+
+    Activity log (#108): non-blocking ``flag`` row carries the flag
+    reason in ``payload`` so the dashboard can surface "what kinds of
+    things does the team flag most often".
+    """
     store = _get_store()
     unit = await store.get(unit_id)
     if unit is None:
         raise HTTPException(status_code=404, detail="Knowledge unit not found")
     flagged = apply_flag(unit, request.reason)
     await store.update(flagged)
+    background_tasks.add_task(
+        log_activity,
+        store,
+        username=username,
+        event_type="flag",
+        payload={"ku_id": unit_id, "reason": str(request.reason)},
+    )
     return flagged
 
 

--- a/server/backend/src/cq_server/consults.py
+++ b/server/backend/src/cq_server/consults.py
@@ -27,11 +27,12 @@ from typing import Any
 from uuid import uuid4
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from . import aigrp as aigrp_mod
 from . import forward_sign
+from .activity_logger import log_activity
 from .auth import get_current_user
 from .deps import get_store
 from .store._sqlite import SqliteStore
@@ -402,6 +403,7 @@ def _to_thread_out(row: dict[str, Any]) -> ConsultThreadOut:
 @router.post("/request", response_model=ConsultThreadOut, status_code=201)
 async def request_consult(
     body: ConsultRequest,
+    background_tasks: BackgroundTasks,
     store: SqliteStore = Depends(get_store),
     username: str = Depends(get_current_user),
 ) -> ConsultThreadOut:
@@ -515,6 +517,22 @@ async def request_consult(
 
     row = await store.get_consult(thread_id)
     assert row is not None  # just inserted
+
+    # Activity log (#108): consult opened. Both same-L2 and cross-L2
+    # paths log on the asker side; the recipient L2 logs separately
+    # when its forward-request handler fires (covered there).
+    background_tasks.add_task(
+        log_activity,
+        store,
+        username=username,
+        event_type="consult_open",
+        payload={
+            "thread_id": thread_id,
+            "to_l2_id": body.to_l2_id,
+            "to_persona": body.to_persona,
+        },
+        thread_or_chain_id=thread_id,
+    )
     return _to_thread_out(row)
 
 
@@ -522,6 +540,7 @@ async def request_consult(
 async def post_consult_message(
     thread_id: str,
     body: ConsultMessage,
+    background_tasks: BackgroundTasks,
     store: SqliteStore = Depends(get_store),
     username: str = Depends(get_current_user),
 ) -> ConsultMessageOut:
@@ -594,6 +613,17 @@ async def post_consult_message(
         # Kept side-note: cross-L2 unused var lint guard
         del other_persona
 
+    # Activity log (#108): consult reply. ``thread_or_chain_id``
+    # carries the consult thread id so dashboards can group
+    # send/reply/close events into a single workflow.
+    background_tasks.add_task(
+        log_activity,
+        store,
+        username=username,
+        event_type="consult_reply",
+        payload={"thread_id": thread_id, "message_id": msg_id},
+        thread_or_chain_id=thread_id,
+    )
     return ConsultMessageOut(
         message_id=msg_id,
         thread_id=thread_id,
@@ -630,10 +660,16 @@ async def get_consult_messages(
 async def close_consult(
     thread_id: str,
     body: CloseRequest,
+    background_tasks: BackgroundTasks,
     store: SqliteStore = Depends(get_store),
     username: str = Depends(get_current_user),
 ) -> ConsultThreadOut:
-    """Mark the thread closed. Either participant can close."""
+    """Mark the thread closed. Either participant can close.
+
+    Activity log (#108): non-blocking ``consult_close`` row carries
+    the close reason so dashboards can break down consult outcomes
+    (resolved vs abandoned vs out-of-scope etc.).
+    """
     self_l2_id, self_persona = await _self_identity(store, username)
     thread = await store.get_consult(thread_id)
     if thread is None:
@@ -670,6 +706,14 @@ async def close_consult(
                 "resolution_summary": body.resolution_summary,
             },
         )
+    background_tasks.add_task(
+        log_activity,
+        store,
+        username=username,
+        event_type="consult_close",
+        payload={"thread_id": thread_id, "reason": body.reason},
+        thread_or_chain_id=thread_id,
+    )
     return _to_thread_out(row)
 
 

--- a/server/backend/src/cq_server/migrations.py
+++ b/server/backend/src/cq_server/migrations.py
@@ -36,7 +36,7 @@ BASELINE_REVISION = "0001"
 # Phase 2 (task #100) — chain head after porting fork-delta tables to
 # Alembic. Update this string when adding a new migration so test
 # assertions and ops scripts stay in sync with the actual chain head.
-HEAD_REVISION = "0010_reflect_submissions"
+HEAD_REVISION = "0011_activity_log"
 
 
 def _find_alembic_ini() -> Path:

--- a/server/backend/src/cq_server/migrations.py
+++ b/server/backend/src/cq_server/migrations.py
@@ -36,7 +36,7 @@ BASELINE_REVISION = "0001"
 # Phase 2 (task #100) — chain head after porting fork-delta tables to
 # Alembic. Update this string when adding a new migration so test
 # assertions and ops scripts stay in sync with the actual chain head.
-HEAD_REVISION = "0011_activity_log"
+HEAD_REVISION = "0012_pending_review_tier"
 
 
 def _find_alembic_ini() -> Path:

--- a/server/backend/src/cq_server/migrations.py
+++ b/server/backend/src/cq_server/migrations.py
@@ -36,7 +36,7 @@ BASELINE_REVISION = "0001"
 # Phase 2 (task #100) — chain head after porting fork-delta tables to
 # Alembic. Update this string when adding a new migration so test
 # assertions and ops scripts stay in sync with the actual chain head.
-HEAD_REVISION = "0012_pending_review_tier"
+HEAD_REVISION = "0013_backfill_default_enterprise_kus"
 
 
 def _find_alembic_ini() -> Path:

--- a/server/backend/src/cq_server/review.py
+++ b/server/backend/src/cq_server/review.py
@@ -173,7 +173,19 @@ async def approve_unit(
     # resolved and 409s.
     if status["status"] not in ("pending", "pending_review"):
         raise HTTPException(status_code=409, detail=f"Knowledge unit already {status['status']}")
-    await store.set_review_status(unit_id, "approved", username, enterprise_id=enterprise_id)
+    # Optimistic concurrency: ``set_review_status`` returns False when
+    # another admin transitioned the row between our SELECT above and
+    # our UPDATE — the WHERE clause's terminal-state guard refuses the
+    # second write. Re-read and 409 with the winning admin's outcome.
+    won = await store.set_review_status(
+        unit_id, "approved", username, enterprise_id=enterprise_id
+    )
+    if not won:
+        current = await store.get_review_status(unit_id, enterprise_id=enterprise_id)
+        terminal = current["status"] if current else "resolved"
+        raise HTTPException(
+            status_code=409, detail=f"Knowledge unit already {terminal}"
+        )
     updated = await store.get_review_status(unit_id, enterprise_id=enterprise_id)
     assert updated is not None  # Unit exists; we just wrote to it.
     await _hook_ku_event(store, unit_id, "approve", enterprise_id, username)
@@ -217,7 +229,18 @@ async def reject_unit(
         raise HTTPException(status_code=409, detail=f"Knowledge unit already {status['status']}")
 
     target_status = "dropped" if status["status"] == "pending_review" else "rejected"
-    await store.set_review_status(unit_id, target_status, username, enterprise_id=enterprise_id)
+    # Optimistic concurrency: see ``approve_unit`` for the rationale —
+    # if another admin won the race we 409 with the terminal status
+    # rather than silently overwriting their decision.
+    won = await store.set_review_status(
+        unit_id, target_status, username, enterprise_id=enterprise_id
+    )
+    if not won:
+        current = await store.get_review_status(unit_id, enterprise_id=enterprise_id)
+        terminal = current["status"] if current else "resolved"
+        raise HTTPException(
+            status_code=409, detail=f"Knowledge unit already {terminal}"
+        )
     updated = await store.get_review_status(unit_id, enterprise_id=enterprise_id)
     assert updated is not None  # Unit exists; we just wrote to it.
     await _hook_ku_event(store, unit_id, "reject", enterprise_id, username)

--- a/server/backend/src/cq_server/review.py
+++ b/server/backend/src/cq_server/review.py
@@ -6,9 +6,10 @@ the request, matching the pattern used by /peers/heartbeat.
 """
 
 from cq.models import KnowledgeUnit
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from pydantic import BaseModel
 
+from .activity_logger import log_activity
 from .auth import require_admin
 from .deps import get_store
 from .store._sqlite import SqliteStore
@@ -153,41 +154,148 @@ async def _hook_ku_event(store: "SqliteStore", unit_id: str, verb: str, enterpri
 @router.post("/{unit_id}/approve")
 async def approve_unit(
     unit_id: str,
+    background_tasks: BackgroundTasks,
     username: str = Depends(require_admin),
     store: SqliteStore = Depends(get_store),
 ) -> ReviewDecisionResponse:
-    """Approve a pending KU in the admin's Enterprise."""
+    """Approve a pending KU in the admin's Enterprise.
+
+    Activity log (#108): non-blocking ``review_resolve`` row with
+    ``decision='approve'``.
+    """
     enterprise_id = await _admin_enterprise(username, store)
     status = await store.get_review_status(unit_id, enterprise_id=enterprise_id)
     if status is None:
         raise HTTPException(status_code=404, detail="Knowledge unit not found")
-    if status["status"] != "pending":
+    # ``pending_review`` (#103) is a parallel review state — admin can
+    # approve from either ``pending`` (the historical default) or
+    # ``pending_review`` (hard-finding queue). Anything else is already
+    # resolved and 409s.
+    if status["status"] not in ("pending", "pending_review"):
         raise HTTPException(status_code=409, detail=f"Knowledge unit already {status['status']}")
     await store.set_review_status(unit_id, "approved", username, enterprise_id=enterprise_id)
     updated = await store.get_review_status(unit_id, enterprise_id=enterprise_id)
     assert updated is not None  # Unit exists; we just wrote to it.
     await _hook_ku_event(store, unit_id, "approve", enterprise_id, username)
+    background_tasks.add_task(
+        log_activity,
+        store,
+        username=username,
+        event_type="review_resolve",
+        payload={"ku_id": unit_id, "decision": "approve"},
+        thread_or_chain_id=unit_id,
+    )
     return _build_decision(unit_id, updated)
 
 
 @router.post("/{unit_id}/reject")
 async def reject_unit(
     unit_id: str,
+    background_tasks: BackgroundTasks,
     username: str = Depends(require_admin),
     store: SqliteStore = Depends(get_store),
+    reason: str | None = None,
 ) -> ReviewDecisionResponse:
-    """Reject a pending KU in the admin's Enterprise."""
+    """Reject a pending KU in the admin's Enterprise.
+
+    Activity log (#108): non-blocking ``review_resolve`` row with
+    ``decision='reject'`` and the optional reject reason.
+
+    Pending-review tier (#103): when the KU's current status is
+    ``pending_review``, the rejection transitions it to ``dropped``
+    rather than ``rejected``. ``dropped`` is the terminal state for
+    hard-finding rejection (operator saw the candidate and said no);
+    distinguishing it from ``rejected`` lets dashboards render the
+    two cohorts separately and lets future tooling sweep dropped rows
+    on a stricter retention than rejected rows.
+    """
     enterprise_id = await _admin_enterprise(username, store)
     status = await store.get_review_status(unit_id, enterprise_id=enterprise_id)
     if status is None:
         raise HTTPException(status_code=404, detail="Knowledge unit not found")
-    if status["status"] != "pending":
+    if status["status"] not in ("pending", "pending_review"):
         raise HTTPException(status_code=409, detail=f"Knowledge unit already {status['status']}")
-    await store.set_review_status(unit_id, "rejected", username, enterprise_id=enterprise_id)
+
+    target_status = "dropped" if status["status"] == "pending_review" else "rejected"
+    await store.set_review_status(unit_id, target_status, username, enterprise_id=enterprise_id)
     updated = await store.get_review_status(unit_id, enterprise_id=enterprise_id)
     assert updated is not None  # Unit exists; we just wrote to it.
     await _hook_ku_event(store, unit_id, "reject", enterprise_id, username)
+    payload: dict[str, str] = {
+        "ku_id": unit_id,
+        "decision": "reject",
+        "resulting_status": target_status,
+    }
+    if reason:
+        payload["reason"] = reason
+    background_tasks.add_task(
+        log_activity,
+        store,
+        username=username,
+        event_type="review_resolve",
+        payload=payload,
+        thread_or_chain_id=unit_id,
+    )
     return _build_decision(unit_id, updated)
+
+
+# --- Pending-review tier (#103) ---------------------------------------------
+
+
+class PendingReviewItem(BaseModel):
+    """One KU in the pending-review queue with its #103 metadata."""
+
+    knowledge_unit: KnowledgeUnit
+    status: str
+    pending_review_reason: str | None
+    pending_review_expires_at: str | None
+
+
+class PendingReviewQueueResponse(BaseModel):
+    """Paginated pending-review queue response."""
+
+    items: list[PendingReviewItem]
+    total: int
+    offset: int
+    limit: int
+
+
+@router.get("/pending-review")
+async def pending_review_queue(
+    limit: int = 20,
+    offset: int = 0,
+    username: str = Depends(require_admin),
+    store: SqliteStore = Depends(get_store),
+) -> PendingReviewQueueResponse:
+    """Return KUs in the pending-review queue (#103).
+
+    Distinct from ``GET /review/queue`` (which returns ``status='pending'``
+    rows from the standard propose flow). Hard findings extracted by
+    reflect's VIBE√ classifier land here with ``status='pending_review'``,
+    a reason string, and a per-Enterprise TTL.
+
+    Sorted by ``pending_review_expires_at ASC`` so the admin sees the
+    closest-to-expiring rows first — the actionable ones.
+    """
+    enterprise_id = await _admin_enterprise(username, store)
+    items = await store.list_pending_review(
+        enterprise_id=enterprise_id, limit=limit, offset=offset
+    )
+    total = await store.count_pending_review(enterprise_id=enterprise_id)
+    return PendingReviewQueueResponse(
+        items=[
+            PendingReviewItem(
+                knowledge_unit=item["knowledge_unit"],
+                status=item["status"],
+                pending_review_reason=item["pending_review_reason"],
+                pending_review_expires_at=item["pending_review_expires_at"],
+            )
+            for item in items
+        ],
+        total=total,
+        offset=offset,
+        limit=limit,
+    )
 
 
 @router.delete("/{unit_id}", status_code=204)

--- a/server/backend/src/cq_server/review.py
+++ b/server/backend/src/cq_server/review.py
@@ -129,6 +129,35 @@ async def review_queue(
     )
 
 
+async def _sweep_pending_review_ttl(store: "SqliteStore", enterprise_id: str) -> None:
+    """Best-effort TTL sweeper invoked from the read path (#121 finding 2).
+
+    The startup-loop wiring is still deferred (see ``expire_pending_reviews``
+    docstring); until that ships, every read of ``GET /review/pending-review``
+    queues a sweep so expired rows transition to ``status='dropped'``
+    before they accumulate. The read query itself filters by ``expires_at``
+    so the response is correct even if this sweep is dropped — the sweep
+    only ensures the on-disk state eventually catches up.
+
+    Failures are swallowed: a flaky sweep must never break the read.
+    """
+    import logging
+    from datetime import UTC
+    from datetime import datetime as _dt
+
+    try:
+        now_iso = _dt.now(UTC).isoformat()
+        await store.expire_pending_reviews(
+            enterprise_id=enterprise_id, now_iso=now_iso
+        )
+    except Exception as exc:  # noqa: BLE001 — best-effort by design
+        logging.getLogger(__name__).warning(
+            "pending_review TTL sweep failed for enterprise=%s: %s",
+            enterprise_id,
+            exc,
+        )
+
+
 async def _hook_ku_event(store: "SqliteStore", unit_id: str, verb: str, enterprise_id: str, by: str) -> None:
     """Reputation hook for KU lifecycle transitions (#108 sub-task 5).
 
@@ -285,6 +314,7 @@ class PendingReviewQueueResponse(BaseModel):
 
 @router.get("/pending-review")
 async def pending_review_queue(
+    background_tasks: BackgroundTasks,
     limit: int = 20,
     offset: int = 0,
     username: str = Depends(require_admin),
@@ -299,12 +329,24 @@ async def pending_review_queue(
 
     Sorted by ``pending_review_expires_at ASC`` so the admin sees the
     closest-to-expiring rows first — the actionable ones.
+
+    TTL enforcement (#121 finding 2): the read query already filters
+    ``expires_at > now`` so callers never see stale candidates even
+    when the sweeper hasn't fired yet. We *also* schedule a background
+    sweep so the on-disk transition to ``status='dropped'`` happens
+    promptly — the read response is correct without waiting for it.
+    Sweep failures are logged inside the helper and never block the
+    response (best-effort, same pattern as the activity-log writes).
     """
     enterprise_id = await _admin_enterprise(username, store)
     items = await store.list_pending_review(
         enterprise_id=enterprise_id, limit=limit, offset=offset
     )
     total = await store.count_pending_review(enterprise_id=enterprise_id)
+    # Best-effort TTL sweep — runs after the response is sent so the
+    # eventual on-disk transition lines up with the activity log
+    # without slowing the read path.
+    background_tasks.add_task(_sweep_pending_review_ttl, store, enterprise_id)
     return PendingReviewQueueResponse(
         items=[
             PendingReviewItem(

--- a/server/backend/src/cq_server/store/_queries.py
+++ b/server/backend/src/cq_server/store/_queries.py
@@ -77,8 +77,23 @@ SELECT_REVIEW_STATUS_BY_ID: TextClause = text(
     "SELECT status, reviewed_by, reviewed_at FROM knowledge_units WHERE id = :id"
 )
 
+# Optimistic-concurrency guard: the WHERE clause requires the row to
+# still be in a pending-shaped state. When two admins race (one
+# approves, one rejects) only the first UPDATE finds the row in the
+# expected state; the second sees ``rowcount == 0`` and the route
+# layer turns that into a 409 ``already <status>`` response. Without
+# this guard, both UPDATEs commit and the last writer wins silently
+# — losing the audit trail of the first decision and producing a
+# ``reviewed_by`` value that disagrees with the activity log.
+#
+# ``status NOT IN ('approved','rejected','dropped')`` rather than
+# ``IN ('pending','pending_review')`` so future intermediate states
+# (e.g. an in-review hold) inherit the same race-protection without
+# needing a query edit. The terminal-state list is the small, stable
+# axis; the pending-state list is the open-ended one.
 UPDATE_REVIEW_STATUS: TextClause = text(
-    "UPDATE knowledge_units SET status = :status, reviewed_by = :reviewed_by, reviewed_at = :reviewed_at WHERE id = :id"
+    "UPDATE knowledge_units SET status = :status, reviewed_by = :reviewed_by, reviewed_at = :reviewed_at "
+    "WHERE id = :id AND status NOT IN ('approved', 'rejected', 'dropped')"
 )
 
 UPDATE_UNIT_DATA: TextClause = text("UPDATE knowledge_units SET data = :data, tier = :tier WHERE id = :id")

--- a/server/backend/src/cq_server/store/_queries.py
+++ b/server/backend/src/cq_server/store/_queries.py
@@ -215,3 +215,40 @@ UPDATE_KEY_REVOKE: TextClause = text(
 )
 
 UPDATE_KEY_LAST_USED: TextClause = text("UPDATE api_keys SET last_used_at = :now WHERE id = :key_id")
+
+# --- activity_log (#108) ----------------------------------------------------
+
+# Append-only insert. Stage-1 substrate; Stage-2 instrumentation calls
+# this from FastAPI ``BackgroundTask`` writes (non-blocking — failures
+# are logged, not raised, so the response path never breaks because
+# the audit log is unavailable).
+INSERT_ACTIVITY_LOG: TextClause = text(
+    "INSERT INTO activity_log "
+    "(id, ts, tenant_enterprise, tenant_group, persona, human, "
+    " event_type, payload, result_summary, thread_or_chain_id) "
+    "VALUES (:id, :ts, :tenant_enterprise, :tenant_group, :persona, :human, "
+    " :event_type, :payload, :result_summary, :thread_or_chain_id)"
+)
+
+# Per-Enterprise retention config (90-day default; absence of a row
+# means "use the default", so the cleanup helper LEFT JOINs against
+# this table rather than INNER JOINing).
+SELECT_ACTIVITY_RETENTION_DAYS: TextClause = text(
+    "SELECT retention_days FROM activity_retention_config WHERE enterprise_id = :enterprise_id"
+)
+
+UPSERT_ACTIVITY_RETENTION_DAYS: TextClause = text(
+    "INSERT INTO activity_retention_config (enterprise_id, retention_days, updated_at) "
+    "VALUES (:enterprise_id, :retention_days, :updated_at) "
+    "ON CONFLICT(enterprise_id) DO UPDATE SET "
+    "retention_days = excluded.retention_days, "
+    "updated_at = excluded.updated_at"
+)
+
+# Retention sweep — delete rows older than ``cutoff_iso`` for one
+# Enterprise. Scoped per-tenant so a slow large-tenant sweep doesn't
+# block writes on every other tenant. Uses ``idx_activity_log_tenant_ts``.
+DELETE_ACTIVITY_OLDER_THAN: TextClause = text(
+    "DELETE FROM activity_log "
+    "WHERE tenant_enterprise = :tenant_enterprise AND ts < :cutoff_iso"
+)

--- a/server/backend/src/cq_server/store/_queries.py
+++ b/server/backend/src/cq_server/store/_queries.py
@@ -46,6 +46,25 @@ INSERT_UNIT: TextClause = text(
     "INSERT INTO knowledge_units (id, data, created_at, tier) VALUES (:id, :data, :created_at, :tier)"
 )
 
+# Closes #89 — explicit ``enterprise_id`` / ``group_id`` columns. Pre-fix
+# every KU insert went through ``INSERT_UNIT`` (above), which omits
+# the tenancy columns and falls back to the schema-level
+# ``server_default`` of ``default-enterprise`` / ``default-group``.
+# The bug surfaced during the moscowmul3 onboarding (#89): every KU
+# proposed via the API landed in ``default-enterprise`` regardless of
+# the L2's configured Enterprise. Code paths that carry auth claims
+# (the ``POST /propose`` handler, the pending-review submitter) now use
+# ``INSERT_UNIT_WITH_TENANCY`` to write the caller's enterprise/group
+# directly. Callers that don't carry scope (legacy fixture tests, the
+# migration-smoke path) keep using ``INSERT_UNIT`` and rely on the
+# server defaults — same behaviour as before #89, plus a clear marker
+# for which call sites need an explicit tenancy decision.
+INSERT_UNIT_WITH_TENANCY: TextClause = text(
+    "INSERT INTO knowledge_units "
+    "(id, data, created_at, tier, enterprise_id, group_id) "
+    "VALUES (:id, :data, :created_at, :tier, :enterprise_id, :group_id)"
+)
+
 INSERT_UNIT_DOMAIN: TextClause = text("INSERT INTO knowledge_unit_domains (unit_id, domain) VALUES (:unit_id, :domain)")
 
 DELETE_UNIT_DOMAINS: TextClause = text("DELETE FROM knowledge_unit_domains WHERE unit_id = :unit_id")

--- a/server/backend/src/cq_server/store/_sqlite.py
+++ b/server/backend/src/cq_server/store/_sqlite.py
@@ -322,8 +322,18 @@ class SqliteStore:
         reviewed_by: str,
         *,
         enterprise_id: str | None = None,
-    ) -> None:
-        await self._run_sync(self._set_review_status_sync, unit_id, status, reviewed_by)
+    ) -> bool:
+        """Transition a KU's review status with optimistic concurrency.
+
+        Returns ``True`` when the UPDATE matched a row (the caller won
+        the race) and ``False`` when the row was already in a terminal
+        state (another admin resolved it concurrently). Raises
+        ``KeyError`` only when the unit_id doesn't exist at all — the
+        race-loss case (row exists but is already terminal) is the
+        ``False`` branch, distinguished so route handlers can return
+        409 instead of 404.
+        """
+        return await self._run_sync(self._set_review_status_sync, unit_id, status, reviewed_by)
 
     # --- pending_review tier (#103) -------------------------------------
     #
@@ -1679,15 +1689,42 @@ class SqliteStore:
             raise RuntimeError("SqliteStore is closed")
         return await asyncio.to_thread(fn, *args, **kwargs)
 
-    def _set_review_status_sync(self, unit_id: str, status: str, reviewed_by: str) -> None:
+    def _set_review_status_sync(self, unit_id: str, status: str, reviewed_by: str) -> bool:
+        """Issue the guarded UPDATE; tell ``KeyError`` (no row) apart from race-loss.
+
+        ``UPDATE_REVIEW_STATUS`` ANDs the WHERE clause on
+        ``status NOT IN ('approved','rejected','dropped')``. Two paths
+        produce ``rowcount == 0``:
+
+        * The unit_id doesn't exist — raise ``KeyError`` (legacy
+          behaviour, preserved for callers that 404 on missing).
+        * The unit_id exists but is already terminal — return ``False``
+          so the caller can 409 instead of overwriting the prior
+          decision.
+
+        We disambiguate with a follow-up SELECT inside the same
+        transaction so the answer reflects the same snapshot the UPDATE
+        saw. SQLite's default isolation is serialisable on a single
+        write connection, so no extra locking is needed.
+        """
         reviewed_at = datetime.now(UTC).isoformat()
         with self._engine.begin() as conn:
             cursor = conn.execute(
                 UPDATE_REVIEW_STATUS,
                 {"id": unit_id, "status": status, "reviewed_by": reviewed_by, "reviewed_at": reviewed_at},
             )
-            if cursor.rowcount == 0:
+            if cursor.rowcount > 0:
+                return True
+            # Distinguish missing-row from race-loss with a SELECT in
+            # the same transaction. If the row is gone, raise KeyError
+            # (404 in the caller); if it's terminal, return False (409).
+            row = conn.exec_driver_sql(
+                "SELECT 1 FROM knowledge_units WHERE id = ?",
+                (unit_id,),
+            ).fetchone()
+            if row is None:
                 raise KeyError(f"Knowledge unit not found: {unit_id}")
+            return False
 
     # --- pending_review tier (#103) sync impls ---------------------------
 

--- a/server/backend/src/cq_server/store/_sqlite.py
+++ b/server/backend/src/cq_server/store/_sqlite.py
@@ -1762,15 +1762,34 @@ class SqliteStore:
     def _list_pending_review_sync(
         self, *, enterprise_id: str, limit: int = 20, offset: int = 0
     ) -> list[dict[str, Any]]:
+        """List pending-review rows that have NOT yet hit their TTL.
+
+        Read-time TTL filter (#121 finding 2): the sweeper transitions
+        ``pending_review → dropped`` eventually, but until it fires
+        every read could surface stale candidates whose
+        ``pending_review_expires_at`` has already passed. We add an
+        ``expires_at > now`` guard inline so the response can never
+        contain rows the operator should no longer see, regardless of
+        sweeper timing. Rows where ``expires_at IS NULL`` continue to
+        appear (defensive: a NULL TTL means "never expires", same shape
+        as ``expire_pending_reviews``'s ``IS NOT NULL`` filter).
+
+        ``ORDER BY pending_review_expires_at ASC`` is preserved so the
+        admin still sees closest-to-expiring rows first within the
+        non-expired set.
+        """
+        now_iso = datetime.now(UTC).isoformat()
         with self._engine.connect() as conn:
             rows = conn.exec_driver_sql(
                 "SELECT data, status, reviewed_by, reviewed_at, "
                 "pending_review_reason, pending_review_expires_at "
                 "FROM knowledge_units "
                 "WHERE status = 'pending_review' AND enterprise_id = ? "
+                "AND (pending_review_expires_at IS NULL "
+                "     OR pending_review_expires_at > ?) "
                 "ORDER BY pending_review_expires_at ASC "
                 "LIMIT ? OFFSET ?",
-                (enterprise_id, limit, offset),
+                (enterprise_id, now_iso, limit, offset),
             ).fetchall()
         return [
             {
@@ -1785,12 +1804,22 @@ class SqliteStore:
         ]
 
     def _count_pending_review_sync(self, *, enterprise_id: str) -> int:
+        """Count pending-review rows whose TTL has not yet passed.
+
+        Mirror of ``_list_pending_review_sync``'s read-time filter
+        (#121 finding 2) — count and list must agree on which rows
+        are visible, otherwise dashboard pagination breaks ("total: 5"
+        with only 3 items rendered).
+        """
+        now_iso = datetime.now(UTC).isoformat()
         with self._engine.connect() as conn:
             return int(
                 conn.exec_driver_sql(
                     "SELECT COUNT(*) FROM knowledge_units "
-                    "WHERE status = 'pending_review' AND enterprise_id = ?",
-                    (enterprise_id,),
+                    "WHERE status = 'pending_review' AND enterprise_id = ? "
+                    "AND (pending_review_expires_at IS NULL "
+                    "     OR pending_review_expires_at > ?)",
+                    (enterprise_id, now_iso),
                 ).scalar() or 0
             )
 

--- a/server/backend/src/cq_server/store/_sqlite.py
+++ b/server/backend/src/cq_server/store/_sqlite.py
@@ -807,6 +807,103 @@ class SqliteStore:
             consent_id=consent_id,
         )
 
+    # --- activity_log (#108) ---------------------------------------------
+    #
+    # Append-only audit-of-record. Stage-1 substrate (this PR) ships the
+    # write path + retention helpers; Stage-2 wires every existing
+    # handler (query / propose / confirm / flag / review / consult /
+    # crosstalk) to call ``append_activity`` from a FastAPI
+    # ``BackgroundTask``. Failures inside the helper are *not* swallowed
+    # here — the caller wraps the call in its own try/except so the
+    # response path stays green when the audit log is unavailable.
+
+    async def append_activity(
+        self,
+        *,
+        activity_id: str,
+        ts: str,
+        tenant_enterprise: str,
+        tenant_group: str | None,
+        persona: str | None,
+        human: str | None,
+        event_type: str,
+        payload: dict[str, Any] | None = None,
+        result_summary: dict[str, Any] | None = None,
+        thread_or_chain_id: str | None = None,
+    ) -> None:
+        """Append one row to ``activity_log``.
+
+        Args carry the schema sketch from #108 verbatim. ``payload`` and
+        ``result_summary`` are JSON-serialised here; the table column
+        type is TEXT (SQLite has no JSON type — see migration 0011 for
+        the full rationale). ``event_type`` is validated against
+        ``cq_server.activity.EVENT_TYPES`` before hitting the DB so we
+        get a clean ``ValueError`` rather than a CHECK-constraint
+        IntegrityError on the wire.
+        """
+        from ..activity import EVENT_TYPES
+
+        if event_type not in EVENT_TYPES:
+            raise ValueError(
+                f"unknown activity event_type {event_type!r}; "
+                f"expected one of {sorted(EVENT_TYPES)}"
+            )
+        await self._run_sync(
+            self._append_activity_sync,
+            activity_id=activity_id,
+            ts=ts,
+            tenant_enterprise=tenant_enterprise,
+            tenant_group=tenant_group,
+            persona=persona,
+            human=human,
+            event_type=event_type,
+            payload=payload,
+            result_summary=result_summary,
+            thread_or_chain_id=thread_or_chain_id,
+        )
+
+    async def get_activity_retention_days(
+        self, *, enterprise_id: str
+    ) -> int:
+        """Return the configured retention window for an Enterprise.
+
+        Falls back to ``DEFAULT_RETENTION_DAYS`` (90) when no override
+        row exists. Stage-2 cron uses this to compute the per-tenant
+        cutoff before calling ``purge_activity_older_than``.
+        """
+        return await self._run_sync(
+            self._get_activity_retention_days_sync,
+            enterprise_id=enterprise_id,
+        )
+
+    async def set_activity_retention_days(
+        self, *, enterprise_id: str, retention_days: int
+    ) -> None:
+        """Upsert the retention window for one Enterprise."""
+        if retention_days <= 0:
+            raise ValueError("retention_days must be positive")
+        await self._run_sync(
+            self._set_activity_retention_days_sync,
+            enterprise_id=enterprise_id,
+            retention_days=retention_days,
+        )
+
+    async def purge_activity_older_than(
+        self, *, tenant_enterprise: str, cutoff_iso: str
+    ) -> int:
+        """Delete activity rows for one tenant older than ``cutoff_iso``.
+
+        Returns the number of deleted rows so the cron can log
+        observability metrics. Scoped per-Enterprise so a slow
+        large-tenant sweep doesn't lock writes for every other tenant
+        on the same L2.
+        """
+        return await self._run_sync(
+            self._purge_activity_older_than_sync,
+            tenant_enterprise=tenant_enterprise,
+            cutoff_iso=cutoff_iso,
+        )
+
     # --- reflect_submissions (#67) ---------------------------------------
     #
     # Persistence layer for the batch-reflect contract. The router layer
@@ -2451,6 +2548,91 @@ class SqliteStore:
                 )
             ).fetchall()
         return {r[0] for r in rows if r[0]}
+
+    # --- activity_log (#108) sync impls ----------------------------------
+
+    def _append_activity_sync(
+        self,
+        *,
+        activity_id: str,
+        ts: str,
+        tenant_enterprise: str,
+        tenant_group: str | None,
+        persona: str | None,
+        human: str | None,
+        event_type: str,
+        payload: dict[str, Any] | None,
+        result_summary: dict[str, Any] | None,
+        thread_or_chain_id: str | None,
+    ) -> None:
+        from ._queries import INSERT_ACTIVITY_LOG
+
+        payload_json = json.dumps(payload if payload is not None else {})
+        result_json = (
+            None if result_summary is None else json.dumps(result_summary)
+        )
+        with self._engine.begin() as conn:
+            conn.execute(
+                INSERT_ACTIVITY_LOG,
+                {
+                    "id": activity_id,
+                    "ts": ts,
+                    "tenant_enterprise": tenant_enterprise,
+                    "tenant_group": tenant_group,
+                    "persona": persona,
+                    "human": human,
+                    "event_type": event_type,
+                    "payload": payload_json,
+                    "result_summary": result_json,
+                    "thread_or_chain_id": thread_or_chain_id,
+                },
+            )
+
+    def _get_activity_retention_days_sync(
+        self, *, enterprise_id: str
+    ) -> int:
+        from ..activity import DEFAULT_RETENTION_DAYS
+        from ._queries import SELECT_ACTIVITY_RETENTION_DAYS
+
+        with self._engine.connect() as conn:
+            row = conn.execute(
+                SELECT_ACTIVITY_RETENTION_DAYS,
+                {"enterprise_id": enterprise_id},
+            ).fetchone()
+        if row is None:
+            return DEFAULT_RETENTION_DAYS
+        return int(row[0])
+
+    def _set_activity_retention_days_sync(
+        self, *, enterprise_id: str, retention_days: int
+    ) -> None:
+        from ._queries import UPSERT_ACTIVITY_RETENTION_DAYS
+
+        updated_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        with self._engine.begin() as conn:
+            conn.execute(
+                UPSERT_ACTIVITY_RETENTION_DAYS,
+                {
+                    "enterprise_id": enterprise_id,
+                    "retention_days": retention_days,
+                    "updated_at": updated_at,
+                },
+            )
+
+    def _purge_activity_older_than_sync(
+        self, *, tenant_enterprise: str, cutoff_iso: str
+    ) -> int:
+        from ._queries import DELETE_ACTIVITY_OLDER_THAN
+
+        with self._engine.begin() as conn:
+            cursor = conn.execute(
+                DELETE_ACTIVITY_OLDER_THAN,
+                {
+                    "tenant_enterprise": tenant_enterprise,
+                    "cutoff_iso": cutoff_iso,
+                },
+            )
+            return int(cursor.rowcount or 0)
 
     # --- reflect_submissions (#67) sync impls ----------------------------
 

--- a/server/backend/src/cq_server/store/_sqlite.py
+++ b/server/backend/src/cq_server/store/_sqlite.py
@@ -222,8 +222,28 @@ class SqliteStore:
         *,
         embedding: bytes | None = None,
         embedding_model: str | None = None,
+        enterprise_id: str | None = None,
+        group_id: str | None = None,
     ) -> None:
-        await self._run_sync(self._insert_sync, unit)
+        """Insert a KU; optionally pin its tenancy.
+
+        ``enterprise_id`` / ``group_id`` are the auth-claim values from
+        the propose request. When set, they are written into the row
+        directly — closes #89 (KUs landing in ``default-enterprise``
+        regardless of the caller's actual scope). When unset (legacy
+        fixture / migration-smoke-test path), the schema-level
+        ``server_default`` populates the columns instead.
+
+        The two-variant approach keeps the legacy test surface
+        (``store.sync.insert(unit)`` with no kwargs) green while making
+        every API path honour real tenancy.
+        """
+        await self._run_sync(
+            self._insert_sync,
+            unit,
+            enterprise_id=enterprise_id,
+            group_id=group_id,
+        )
         if embedding is not None and embedding_model is not None:
             await self.set_embedding(unit.id, embedding, embedding_model)
 
@@ -304,6 +324,79 @@ class SqliteStore:
         enterprise_id: str | None = None,
     ) -> None:
         await self._run_sync(self._set_review_status_sync, unit_id, status, reviewed_by)
+
+    # --- pending_review tier (#103) -------------------------------------
+    #
+    # Hard-finding queue: KUs flagged by reflect's VIBE√ classifier as
+    # needing human approval before tier-promotion. ``submit_pending_review``
+    # is the entry point (called from /reflect/submit?queue_hard_findings=true
+    # in a follow-up); ``list_pending_review`` drives the admin queue UI;
+    # ``expire_pending_reviews`` is the TTL sweeper. Reuses the existing
+    # ``status`` column rather than adding a new tier (cq SDK Tier enum is
+    # PyPI-pinned; see migration 0012 for the rationale).
+
+    async def submit_pending_review(
+        self,
+        unit: KnowledgeUnit,
+        *,
+        reason: str,
+        expires_at: str,
+        enterprise_id: str,
+        group_id: str,
+    ) -> None:
+        """Insert a KU at ``status='pending_review'`` with reason + TTL.
+
+        Same code path as ``insert``, then a follow-up UPDATE sets
+        ``status='pending_review'`` plus the two pending_review columns.
+        Doing it as INSERT-then-UPDATE rather than a custom INSERT keeps
+        the standard insert path (with quality guards, domain rows, and
+        embedding stub) intact.
+        """
+        await self._run_sync(
+            self._submit_pending_review_sync,
+            unit,
+            reason=reason,
+            expires_at=expires_at,
+            enterprise_id=enterprise_id,
+            group_id=group_id,
+        )
+
+    async def list_pending_review(
+        self,
+        *,
+        enterprise_id: str,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """Return KUs in pending_review state for the admin queue."""
+        return await self._run_sync(
+            self._list_pending_review_sync,
+            enterprise_id=enterprise_id,
+            limit=limit,
+            offset=offset,
+        )
+
+    async def count_pending_review(self, *, enterprise_id: str) -> int:
+        """Return the size of the pending_review queue for one tenant."""
+        return await self._run_sync(
+            self._count_pending_review_sync, enterprise_id=enterprise_id
+        )
+
+    async def expire_pending_reviews(
+        self, *, enterprise_id: str, now_iso: str
+    ) -> list[str]:
+        """Sweep expired pending_review rows for one tenant.
+
+        Transitions every row with ``status='pending_review'`` AND
+        ``pending_review_expires_at < now_iso`` to ``status='dropped'``.
+        Returns the list of unit_ids transitioned so the caller can log
+        the per-row drops to the activity log.
+        """
+        return await self._run_sync(
+            self._expire_pending_reviews_sync,
+            enterprise_id=enterprise_id,
+            now_iso=now_iso,
+        )
 
     async def touch_api_key_last_used(self, key_id: str) -> None:
         await self._run_sync(self._touch_api_key_last_used_sync, key_id)
@@ -904,6 +997,40 @@ class SqliteStore:
             cutoff_iso=cutoff_iso,
         )
 
+    async def list_activity(
+        self,
+        *,
+        tenant_enterprise: str,
+        persona: str | None = None,
+        since_iso: str | None = None,
+        until_iso: str | None = None,
+        event_type: str | None = None,
+        limit: int = 50,
+        cursor: tuple[str, str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Read rows from ``activity_log`` with filter + cursor pagination.
+
+        Powers ``GET /api/v1/activity`` (Stage 2 of #108). All filters
+        compose with AND. ``cursor`` is a ``(ts, id)`` tuple from the
+        last row of the previous page — the next page reads strictly
+        before that point on the ``(ts DESC, id DESC)`` ordering. Pure
+        keyset pagination; no offset arithmetic.
+
+        Tenancy is mandatory (``tenant_enterprise`` is required, never
+        nullable on this read path) so the route layer can never
+        accidentally return cross-tenant rows.
+        """
+        return await self._run_sync(
+            self._list_activity_sync,
+            tenant_enterprise=tenant_enterprise,
+            persona=persona,
+            since_iso=since_iso,
+            until_iso=until_iso,
+            event_type=event_type,
+            limit=limit,
+            cursor=cursor,
+        )
+
     # --- reflect_submissions (#67) ---------------------------------------
     #
     # Persistence layer for the batch-reflect contract. The router layer
@@ -1260,9 +1387,22 @@ class SqliteStore:
         *,
         embedding: bytes | None = None,
         embedding_model: str | None = None,
+        enterprise_id: str | None = None,
+        group_id: str | None = None,
     ) -> None:
         # embedding kwargs: persist via UPDATE after the INSERT.
         # Acceptance is silent here; the actual write happens via _set_embedding_sync.
+        #
+        # ``enterprise_id`` / ``group_id`` are the auth-claim values from
+        # the propose handler (closes #89). When both are provided we
+        # use ``INSERT_UNIT_WITH_TENANCY`` to write them explicitly; when
+        # either is None the legacy ``INSERT_UNIT`` runs and the schema's
+        # ``server_default`` (``default-enterprise`` / ``default-group``)
+        # fills the column. The two-variant split keeps legacy fixture
+        # callers (``store.sync.insert(unit)`` with no kwargs) green
+        # without forcing every test to manufacture a tenant.
+        from ._queries import INSERT_UNIT_WITH_TENANCY
+
         domains = normalize_domains(unit.domains)
         if not domains:
             raise ValueError("At least one non-empty domain is required")
@@ -1275,15 +1415,28 @@ class SqliteStore:
         )
         try:
             with self._engine.begin() as conn:
-                conn.execute(
-                    INSERT_UNIT,
-                    {
-                        "id": unit.id,
-                        "data": unit.model_dump_json(),
-                        "created_at": created_at,
-                        "tier": unit.tier.value,
-                    },
-                )
+                if enterprise_id is not None and group_id is not None:
+                    conn.execute(
+                        INSERT_UNIT_WITH_TENANCY,
+                        {
+                            "id": unit.id,
+                            "data": unit.model_dump_json(),
+                            "created_at": created_at,
+                            "tier": unit.tier.value,
+                            "enterprise_id": enterprise_id,
+                            "group_id": group_id,
+                        },
+                    )
+                else:
+                    conn.execute(
+                        INSERT_UNIT,
+                        {
+                            "id": unit.id,
+                            "data": unit.model_dump_json(),
+                            "created_at": created_at,
+                            "tier": unit.tier.value,
+                        },
+                    )
                 for d in domains:
                     conn.execute(INSERT_UNIT_DOMAIN, {"unit_id": unit.id, "domain": d})
                 if embedding is not None and embedding_model is not None:
@@ -1535,6 +1688,109 @@ class SqliteStore:
             )
             if cursor.rowcount == 0:
                 raise KeyError(f"Knowledge unit not found: {unit_id}")
+
+    # --- pending_review tier (#103) sync impls ---------------------------
+
+    def _submit_pending_review_sync(
+        self,
+        unit: KnowledgeUnit,
+        *,
+        reason: str,
+        expires_at: str,
+        enterprise_id: str,
+        group_id: str,
+    ) -> None:
+        """Insert a KU and immediately move it into pending_review state.
+
+        Two writes in one transaction: the standard INSERT (re-uses the
+        ``_insert_sync`` body for tier=private + tenancy + domain rows),
+        then an UPDATE that flips status to pending_review and stamps
+        the reason + expires_at columns.
+        """
+        # Re-use the canonical insert path so domain rows / quality
+        # guards / tenancy fields all flow through the same sync method.
+        self._insert_sync(unit, enterprise_id=enterprise_id, group_id=group_id)
+        with self._engine.begin() as conn:
+            conn.execute(
+                text(
+                    "UPDATE knowledge_units SET "
+                    "status = 'pending_review', "
+                    "pending_review_reason = :reason, "
+                    "pending_review_expires_at = :expires_at "
+                    "WHERE id = :id"
+                ),
+                {"reason": reason, "expires_at": expires_at, "id": unit.id},
+            )
+
+    def _list_pending_review_sync(
+        self, *, enterprise_id: str, limit: int = 20, offset: int = 0
+    ) -> list[dict[str, Any]]:
+        with self._engine.connect() as conn:
+            rows = conn.exec_driver_sql(
+                "SELECT data, status, reviewed_by, reviewed_at, "
+                "pending_review_reason, pending_review_expires_at "
+                "FROM knowledge_units "
+                "WHERE status = 'pending_review' AND enterprise_id = ? "
+                "ORDER BY pending_review_expires_at ASC "
+                "LIMIT ? OFFSET ?",
+                (enterprise_id, limit, offset),
+            ).fetchall()
+        return [
+            {
+                "knowledge_unit": KnowledgeUnit.model_validate_json(row[0]),
+                "status": row[1] or "pending_review",
+                "reviewed_by": row[2],
+                "reviewed_at": row[3],
+                "pending_review_reason": row[4],
+                "pending_review_expires_at": row[5],
+            }
+            for row in rows
+        ]
+
+    def _count_pending_review_sync(self, *, enterprise_id: str) -> int:
+        with self._engine.connect() as conn:
+            return int(
+                conn.exec_driver_sql(
+                    "SELECT COUNT(*) FROM knowledge_units "
+                    "WHERE status = 'pending_review' AND enterprise_id = ?",
+                    (enterprise_id,),
+                ).scalar() or 0
+            )
+
+    def _expire_pending_reviews_sync(
+        self, *, enterprise_id: str, now_iso: str
+    ) -> list[str]:
+        """Two-step sweep: SELECT the row ids first, then UPDATE.
+
+        We return the ids so the caller can emit one ``review_resolve``
+        activity-log row per drop. Doing it as a single UPDATE…
+        RETURNING would be cleaner on PostgreSQL but SQLite's RETURNING
+        landed in 3.35; we run on whatever the host has, so split the
+        round-trip explicitly.
+        """
+        with self._engine.begin() as conn:
+            rows = conn.exec_driver_sql(
+                "SELECT id FROM knowledge_units "
+                "WHERE status = 'pending_review' AND enterprise_id = ? "
+                "AND pending_review_expires_at IS NOT NULL "
+                "AND pending_review_expires_at < ?",
+                (enterprise_id, now_iso),
+            ).fetchall()
+            ids = [row[0] for row in rows]
+            if ids:
+                placeholders = ",".join("?" * len(ids))
+                # Mark as dropped + stamp reviewed_by sentinel so the
+                # admin UI can render "TTL-expired" in the audit history.
+                reviewed_at = datetime.now(UTC).isoformat()
+                conn.exec_driver_sql(
+                    f"UPDATE knowledge_units SET "
+                    f"status = 'dropped', "
+                    f"reviewed_by = 'ttl_expired_sweeper', "
+                    f"reviewed_at = ? "
+                    f"WHERE id IN ({placeholders})",
+                    (reviewed_at, *ids),
+                )
+        return ids
 
     def _touch_api_key_last_used_sync(self, key_id: str) -> None:
         now = datetime.now(UTC).isoformat()
@@ -2633,6 +2889,94 @@ class SqliteStore:
                 },
             )
             return int(cursor.rowcount or 0)
+
+    def _list_activity_sync(
+        self,
+        *,
+        tenant_enterprise: str,
+        persona: str | None,
+        since_iso: str | None,
+        until_iso: str | None,
+        event_type: str | None,
+        limit: int,
+        cursor: tuple[str, str] | None,
+    ) -> list[dict[str, Any]]:
+        """Build the WHERE clause dynamically based on which filters are set.
+
+        The base index is ``idx_activity_log_tenant_ts (tenant_enterprise,
+        tenant_group, ts)``; the leading column pin makes every filter
+        combination index-friendly. Persona filter switches over to
+        ``idx_activity_log_persona_ts`` when set. Event-type filter
+        switches over to ``idx_activity_log_event_type_ts``.
+
+        Cursor: when set, restrict to rows strictly before ``(ts, id)``
+        on the descending order — equivalent to "give me the next page
+        beneath the last row of the previous page". The id tie-breaker
+        is necessary because two rows can share a ts (sub-millisecond
+        background-task scheduling).
+        """
+        clauses = ["tenant_enterprise = :tenant_enterprise"]
+        params: dict[str, Any] = {"tenant_enterprise": tenant_enterprise, "limit": limit}
+        if persona is not None:
+            clauses.append("persona = :persona")
+            params["persona"] = persona
+        if since_iso is not None:
+            clauses.append("ts >= :since_iso")
+            params["since_iso"] = since_iso
+        if until_iso is not None:
+            clauses.append("ts < :until_iso")
+            params["until_iso"] = until_iso
+        if event_type is not None:
+            clauses.append("event_type = :event_type")
+            params["event_type"] = event_type
+        if cursor is not None:
+            cursor_ts, cursor_id = cursor
+            # (ts, id) < (cursor_ts, cursor_id) tuple comparison — split
+            # into the lexicographic SQL form so SQLite's planner can
+            # use the indexes correctly.
+            clauses.append("(ts < :cursor_ts OR (ts = :cursor_ts AND id < :cursor_id))")
+            params["cursor_ts"] = cursor_ts
+            params["cursor_id"] = cursor_id
+
+        sql = (
+            "SELECT id, ts, tenant_enterprise, tenant_group, persona, human, "
+            "event_type, payload, result_summary, thread_or_chain_id "
+            "FROM activity_log "
+            f"WHERE {' AND '.join(clauses)} "
+            "ORDER BY ts DESC, id DESC "
+            "LIMIT :limit"
+        )
+        with self._engine.connect() as conn:
+            rows = conn.execute(text(sql), params).fetchall()
+        results: list[dict[str, Any]] = []
+        for row in rows:
+            payload_raw = row[7]
+            result_raw = row[8]
+            try:
+                payload = json.loads(payload_raw) if payload_raw else {}
+            except (TypeError, ValueError):
+                payload = {}
+            try:
+                result_summary = (
+                    json.loads(result_raw) if result_raw is not None else None
+                )
+            except (TypeError, ValueError):
+                result_summary = None
+            results.append(
+                {
+                    "id": row[0],
+                    "ts": row[1],
+                    "tenant_enterprise": row[2],
+                    "tenant_group": row[3],
+                    "persona": row[4],
+                    "human": row[5],
+                    "event_type": row[6],
+                    "payload": payload,
+                    "result_summary": result_summary,
+                    "thread_or_chain_id": row[9],
+                }
+            )
+        return results
 
     # --- reflect_submissions (#67) sync impls ----------------------------
 

--- a/server/backend/tests/test_activity_log_instrumentation.py
+++ b/server/backend/tests/test_activity_log_instrumentation.py
@@ -1,0 +1,383 @@
+"""Activity-log instrumentation — #108 Stage 2 Workstream A.
+
+Pins that every write-path handler emits exactly the right
+``activity_log`` row(s) via FastAPI ``BackgroundTasks``. Failure of
+the audit write must never affect the response (covered by a separate
+suite below — we monkey-patch ``store.append_activity`` to raise and
+assert the response is still 2xx).
+
+Coverage:
+
+* ``GET /query`` → ``query`` event with payload + result_summary
+* ``POST /propose`` → ``propose`` event with summary_first_60_chars
+* ``POST /confirm/{id}`` → ``confirm`` event with ku_id
+* ``POST /flag/{id}`` → ``flag`` event with reason
+* ``POST /review/{id}/approve`` → ``review_resolve`` decision=approve
+* ``POST /review/{id}/reject`` → ``review_resolve`` decision=reject
+* ``POST /consults/request`` → ``consult_open`` with thread_id
+* ``POST /consults/{id}/messages`` → ``consult_reply``
+* ``POST /consults/{id}/close`` → ``consult_close`` with reason
+* All rows carry the caller's ``persona`` and ``tenant_enterprise``
+  resolved from the user row (never the schema default).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cq_server.app import _get_store, app
+from cq_server.auth import hash_password
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "activity.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    with TestClient(app) as c:
+        yield c
+
+
+def _seed_user(
+    *,
+    username: str,
+    password: str,
+    enterprise_id: str = "acme",
+    group_id: str = "engineering",
+    role: str = "user",
+) -> None:
+    store = _get_store()
+    store.sync.create_user(username, hash_password(password))
+    if role != "user":
+        store.sync.set_user_role(username, role)
+    with store._engine.begin() as conn:
+        conn.exec_driver_sql(
+            "UPDATE users SET enterprise_id = ?, group_id = ? WHERE username = ?",
+            (enterprise_id, group_id, username),
+        )
+
+
+def _login_jwt(client: TestClient, username: str, password: str) -> str:
+    resp = client.post("/auth/login", json={"username": username, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _mint_api_key(client: TestClient, jwt_token: str) -> str:
+    resp = client.post(
+        "/auth/api-keys",
+        headers={"Authorization": f"Bearer {jwt_token}"},
+        json={"name": "activity-test", "ttl": "30d"},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["token"]
+
+
+def _activity_rows(db_path: Path) -> list[dict]:
+    """Read all activity_log rows directly off-disk, ordered by ts."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        rows = conn.execute(
+            "SELECT id, ts, tenant_enterprise, tenant_group, persona, human, "
+            "event_type, payload, result_summary, thread_or_chain_id "
+            "FROM activity_log ORDER BY ts"
+        ).fetchall()
+    finally:
+        conn.close()
+    return [
+        {
+            "id": r[0],
+            "ts": r[1],
+            "tenant_enterprise": r[2],
+            "tenant_group": r[3],
+            "persona": r[4],
+            "human": r[5],
+            "event_type": r[6],
+            "payload": r[7],
+            "result_summary": r[8],
+            "thread_or_chain_id": r[9],
+        }
+        for r in rows
+    ]
+
+
+def _propose_one(client: TestClient, api_key: str) -> str:
+    resp = client.post(
+        "/propose",
+        json={
+            "domains": ["test-fleet"],
+            "insight": {
+                "summary": "Activity instrumentation pin",
+                "detail": "Asserts a propose event is logged with the caller's persona.",
+                "action": "Read tests/test_activity_log_instrumentation.py for the full coverage map.",
+            },
+        },
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+# ---------------------------------------------------------------------------
+# Per-handler row shape
+# ---------------------------------------------------------------------------
+
+
+class TestProposeLogs:
+    def test_propose_writes_activity_row(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        _seed_user(username="proposer", password="pw")
+        api_key = _mint_api_key(client, _login_jwt(client, "proposer", "pw"))
+        ku_id = _propose_one(client, api_key)
+
+        rows = _activity_rows(tmp_path / "activity.db")
+        propose_rows = [r for r in rows if r["event_type"] == "propose"]
+        assert len(propose_rows) == 1
+        row = propose_rows[0]
+        assert row["persona"] == "proposer"
+        assert row["tenant_enterprise"] == "acme"
+        assert row["tenant_group"] == "engineering"
+        assert ku_id in row["payload"]
+        # summary_first_60_chars is the schema sketch shape — assert
+        # it's present, not just substring-match the full summary.
+        import json as _json
+
+        payload = _json.loads(row["payload"])
+        assert payload["ku_id"] == ku_id
+        assert "summary_first_60_chars" in payload
+        assert payload["summary_first_60_chars"] == "Activity instrumentation pin"
+        assert payload["domains"] == ["test-fleet"]
+
+
+class TestQueryLogs:
+    def test_query_writes_activity_row_with_result_summary(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        _seed_user(username="querier", password="pw")
+        api_key = _mint_api_key(client, _login_jwt(client, "querier", "pw"))
+        ku_id = _propose_one(client, api_key)
+        # Approve so the KU is queryable.
+        store = _get_store()
+        store.sync.set_review_status(ku_id, "approved", "querier")
+
+        resp = client.get(
+            "/query?domains=test-fleet&limit=5",
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+        assert resp.status_code == 200, resp.text
+
+        rows = _activity_rows(tmp_path / "activity.db")
+        query_rows = [r for r in rows if r["event_type"] == "query"]
+        assert len(query_rows) == 1
+        row = query_rows[0]
+        assert row["persona"] == "querier"
+
+        import json as _json
+
+        payload = _json.loads(row["payload"])
+        assert payload["domains"] == ["test-fleet"]
+        assert payload["limit"] == 5
+        result = _json.loads(row["result_summary"])
+        # The KU we just approved should be in the result list.
+        assert ku_id in result["ku_ids"]
+        assert result["cache_hit"] is False
+
+
+class TestConfirmFlagLogs:
+    def test_confirm_writes_activity_row(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        _seed_user(username="confirmer", password="pw")
+        api_key = _mint_api_key(client, _login_jwt(client, "confirmer", "pw"))
+        ku_id = _propose_one(client, api_key)
+        # confirm/flag both reach into ``store.get`` which filters by
+        # status='approved'. Approve out-of-band so the handler 200s.
+        _get_store().sync.set_review_status(ku_id, "approved", "confirmer")
+
+        resp = client.post(
+            f"/confirm/{ku_id}",
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+        assert resp.status_code == 200, resp.text
+
+        rows = _activity_rows(tmp_path / "activity.db")
+        confirm_rows = [r for r in rows if r["event_type"] == "confirm"]
+        assert len(confirm_rows) == 1
+        import json as _json
+
+        assert _json.loads(confirm_rows[0]["payload"])["ku_id"] == ku_id
+
+    def test_flag_writes_activity_row_with_reason(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        _seed_user(username="flagger", password="pw")
+        api_key = _mint_api_key(client, _login_jwt(client, "flagger", "pw"))
+        ku_id = _propose_one(client, api_key)
+        _get_store().sync.set_review_status(ku_id, "approved", "flagger")
+
+        resp = client.post(
+            f"/flag/{ku_id}",
+            json={"reason": "stale"},
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+        assert resp.status_code == 200, resp.text
+
+        rows = _activity_rows(tmp_path / "activity.db")
+        flag_rows = [r for r in rows if r["event_type"] == "flag"]
+        assert len(flag_rows) == 1
+        import json as _json
+
+        payload = _json.loads(flag_rows[0]["payload"])
+        assert payload["ku_id"] == ku_id
+        # FlagReason is a StrEnum; the helper stringifies it via str().
+        assert "stale" in payload["reason"]
+
+
+class TestReviewLogs:
+    def test_approve_writes_review_resolve_row(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        _seed_user(username="proposer2", password="pw")
+        _seed_user(username="admin1", password="pw", role="admin")
+
+        proposer_key = _mint_api_key(client, _login_jwt(client, "proposer2", "pw"))
+        admin_jwt = _login_jwt(client, "admin1", "pw")
+        ku_id = _propose_one(client, proposer_key)
+
+        resp = client.post(
+            f"/review/{ku_id}/approve",
+            headers={"Authorization": f"Bearer {admin_jwt}"},
+        )
+        assert resp.status_code == 200, resp.text
+
+        rows = _activity_rows(tmp_path / "activity.db")
+        rr = [r for r in rows if r["event_type"] == "review_resolve"]
+        assert len(rr) == 1
+        import json as _json
+
+        payload = _json.loads(rr[0]["payload"])
+        assert payload["decision"] == "approve"
+        assert payload["ku_id"] == ku_id
+        assert rr[0]["thread_or_chain_id"] == ku_id  # correlates to the KU
+        assert rr[0]["persona"] == "admin1"
+
+    def test_reject_writes_review_resolve_row(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        _seed_user(username="proposer3", password="pw")
+        _seed_user(username="admin2", password="pw", role="admin")
+
+        proposer_key = _mint_api_key(client, _login_jwt(client, "proposer3", "pw"))
+        admin_jwt = _login_jwt(client, "admin2", "pw")
+        ku_id = _propose_one(client, proposer_key)
+
+        resp = client.post(
+            f"/review/{ku_id}/reject",
+            headers={"Authorization": f"Bearer {admin_jwt}"},
+        )
+        assert resp.status_code == 200, resp.text
+
+        rows = _activity_rows(tmp_path / "activity.db")
+        rr = [r for r in rows if r["event_type"] == "review_resolve"]
+        assert len(rr) == 1
+        import json as _json
+
+        payload = _json.loads(rr[0]["payload"])
+        assert payload["decision"] == "reject"
+
+
+class TestConsultLogs:
+    def test_consult_lifecycle_writes_open_reply_close(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        _seed_user(username="alice2", password="pw")
+        _seed_user(username="bob2", password="pw")
+        alice_jwt = _login_jwt(client, "alice2", "pw")
+        bob_jwt = _login_jwt(client, "bob2", "pw")
+
+        # Open
+        resp = client.post(
+            "/api/v1/consults/request",
+            headers={"Authorization": f"Bearer {alice_jwt}"},
+            json={
+                "to_l2_id": "acme/engineering",
+                "to_persona": "bob2",
+                "subject": "test",
+                "content": "hello",
+            },
+        )
+        assert resp.status_code == 201, resp.text
+        thread_id = resp.json()["thread_id"]
+
+        # Reply (Bob to Alice)
+        resp = client.post(
+            f"/api/v1/consults/{thread_id}/messages",
+            headers={"Authorization": f"Bearer {bob_jwt}"},
+            json={"content": "hi back"},
+        )
+        assert resp.status_code == 201, resp.text
+
+        # Close
+        resp = client.post(
+            f"/api/v1/consults/{thread_id}/close",
+            headers={"Authorization": f"Bearer {alice_jwt}"},
+            json={"reason": "resolved"},
+        )
+        assert resp.status_code == 200, resp.text
+
+        rows = _activity_rows(tmp_path / "activity.db")
+        consult_rows = [r for r in rows if r["event_type"].startswith("consult_")]
+        events = sorted(r["event_type"] for r in consult_rows)
+        assert events == ["consult_close", "consult_open", "consult_reply"]
+
+        # Every consult row carries thread_id for workflow correlation.
+        for r in consult_rows:
+            assert r["thread_or_chain_id"] == thread_id
+
+
+# ---------------------------------------------------------------------------
+# Failure-mode pins — handler must succeed even when activity log fails.
+# ---------------------------------------------------------------------------
+
+
+class TestActivityLogFailureNeverBreaksResponse:
+    def test_propose_succeeds_when_append_activity_raises(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """The audit log is fire-and-forget by design (#108).
+
+        Patch ``store.append_activity`` to raise on every call. The
+        propose handler still returns 201 because the audit write runs
+        after the response is sealed via BackgroundTasks; the
+        ``log_activity`` helper swallows the exception with a logged
+        warning.
+        """
+        _seed_user(username="resilient", password="pw")
+        api_key = _mint_api_key(client, _login_jwt(client, "resilient", "pw"))
+
+        store = _get_store()
+        original = store.append_activity
+
+        async def _raises(*args: object, **kwargs: object) -> None:
+            raise RuntimeError("simulated DB failure during audit append")
+
+        monkeypatch.setattr(store, "append_activity", _raises)
+        try:
+            ku_id = _propose_one(client, api_key)
+            assert ku_id  # propose response succeeded
+
+            # No activity rows written (the patched method raised
+            # instead of inserting).
+            rows = _activity_rows(tmp_path / "activity.db")
+            assert all(r["event_type"] != "propose" for r in rows)
+        finally:
+            monkeypatch.setattr(store, "append_activity", original)

--- a/server/backend/tests/test_activity_read_endpoint.py
+++ b/server/backend/tests/test_activity_read_endpoint.py
@@ -1,0 +1,342 @@
+"""``GET /api/v1/activity`` — #108 Stage 2 Workstream D.
+
+Pins:
+
+* Authentication is mandatory; both JWT and API key are accepted via
+  ``get_current_user``.
+* Tenancy: the route always pins ``tenant_enterprise`` to the caller's
+  Enterprise. No cross-Enterprise leak path.
+* Admin scope: admin callers can read any persona within their
+  Enterprise; ``persona=`` filter is honoured as-sent.
+* Self scope: non-admin callers always see only their own persona's
+  events. A non-admin who sends ``persona=alice`` while authenticated
+  as Bob sees Bob's events — not 403, silent override.
+* Filters compose: ``event_type``, ``since``, ``until``, ``persona``
+  AND together. Malformed values 422 (timestamps) or 400 (cursor).
+* Cursor pagination yields strict (ts DESC, id DESC) ordering and
+  ``next_cursor`` terminates correctly.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cq_server.activity import generate_activity_id, now_iso_z
+from cq_server.app import _get_store, app
+from cq_server.auth import hash_password
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "activity-read.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    with TestClient(app) as c:
+        yield c
+
+
+def _seed_user(
+    *,
+    username: str,
+    password: str,
+    enterprise_id: str = "acme",
+    group_id: str = "engineering",
+    role: str = "user",
+) -> None:
+    s = _get_store()
+    s.sync.create_user(username, hash_password(password))
+    if role != "user":
+        s.sync.set_user_role(username, role)
+    with s._engine.begin() as conn:
+        conn.exec_driver_sql(
+            "UPDATE users SET enterprise_id = ?, group_id = ? WHERE username = ?",
+            (enterprise_id, group_id, username),
+        )
+
+
+def _login_jwt(client: TestClient, username: str, password: str) -> str:
+    resp = client.post("/auth/login", json={"username": username, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+async def _seed_activity_row(
+    *,
+    persona: str,
+    enterprise: str = "acme",
+    group: str = "engineering",
+    event_type: str = "query",
+    ts: str | None = None,
+    payload: dict | None = None,
+    thread_or_chain_id: str | None = None,
+) -> str:
+    """Drive store.append_activity directly. Bypasses the request path."""
+    s = _get_store()
+    activity_id = generate_activity_id()
+    await s.append_activity(
+        activity_id=activity_id,
+        ts=ts or now_iso_z(),
+        tenant_enterprise=enterprise,
+        tenant_group=group,
+        persona=persona,
+        human=None,
+        event_type=event_type,
+        payload=payload or {},
+        result_summary=None,
+        thread_or_chain_id=thread_or_chain_id,
+    )
+    return activity_id
+
+
+# ---------------------------------------------------------------------------
+# Auth + tenancy scoping
+# ---------------------------------------------------------------------------
+
+
+class TestAuthAndScoping:
+    def test_unauthenticated_returns_401(self, client: TestClient) -> None:
+        resp = client.get("/api/v1/activity")
+        assert resp.status_code == 401
+
+    def test_admin_sees_every_persona_in_their_enterprise(
+        self, client: TestClient
+    ) -> None:
+        import asyncio
+
+        _seed_user(username="alice3", password="pw")
+        _seed_user(username="bob3", password="pw")
+        _seed_user(username="admin3", password="pw", role="admin")
+
+        async def _seed() -> None:
+            await _seed_activity_row(persona="alice3", event_type="query")
+            await _seed_activity_row(persona="bob3", event_type="query")
+
+        asyncio.run(_seed())
+
+        token = _login_jwt(client, "admin3", "pw")
+        resp = client.get(
+            "/api/v1/activity",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        personas = sorted(item["persona"] for item in body["items"])
+        assert personas == ["alice3", "bob3"]
+
+    def test_non_admin_sees_only_their_own_persona(self, client: TestClient) -> None:
+        """Critical scoping pin: a non-admin caller asking for
+        ``persona=alice4`` while authenticated as bob4 sees bob4's
+        events — silent override, no 403, no leak."""
+        import asyncio
+
+        _seed_user(username="alice4", password="pw")
+        _seed_user(username="bob4", password="pw")
+
+        async def _seed() -> None:
+            await _seed_activity_row(persona="alice4", event_type="query")
+            await _seed_activity_row(persona="bob4", event_type="query")
+
+        asyncio.run(_seed())
+
+        token = _login_jwt(client, "bob4", "pw")
+        # Bob asks for Alice's events; the route forces persona=bob4.
+        resp = client.get(
+            "/api/v1/activity?persona=alice4",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200, resp.text
+        items = resp.json()["items"]
+        assert all(item["persona"] == "bob4" for item in items), items
+
+    def test_cross_enterprise_rows_not_visible(self, client: TestClient) -> None:
+        """An admin in acme cannot see moscowmul3 rows even when they
+        ask. Tenancy is mandatory and pinned by the route layer."""
+        import asyncio
+
+        _seed_user(username="acme_admin", password="pw", role="admin")
+
+        async def _seed() -> None:
+            await _seed_activity_row(persona="alice5", enterprise="acme")
+            await _seed_activity_row(persona="rival", enterprise="moscowmul3")
+
+        asyncio.run(_seed())
+
+        token = _login_jwt(client, "acme_admin", "pw")
+        resp = client.get(
+            "/api/v1/activity",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200, resp.text
+        personas = [item["persona"] for item in resp.json()["items"]]
+        assert "rival" not in personas
+        assert "alice5" in personas
+
+
+# ---------------------------------------------------------------------------
+# Filters
+# ---------------------------------------------------------------------------
+
+
+class TestFilters:
+    def test_event_type_filter(self, client: TestClient) -> None:
+        import asyncio
+
+        _seed_user(username="filter_admin", password="pw", role="admin")
+
+        async def _seed() -> None:
+            await _seed_activity_row(persona="x", event_type="query")
+            await _seed_activity_row(persona="x", event_type="propose")
+            await _seed_activity_row(persona="x", event_type="confirm")
+
+        asyncio.run(_seed())
+
+        token = _login_jwt(client, "filter_admin", "pw")
+        resp = client.get(
+            "/api/v1/activity?event_type=propose",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200, resp.text
+        rows = resp.json()["items"]
+        assert all(r["event_type"] == "propose" for r in rows)
+
+    def test_event_type_unknown_value_422s(self, client: TestClient) -> None:
+        _seed_user(username="filter_x", password="pw")
+        token = _login_jwt(client, "filter_x", "pw")
+        resp = client.get(
+            "/api/v1/activity?event_type=not_a_real_event",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 422
+        assert "event_type" in resp.json()["detail"].lower() or "expected" in resp.json()["detail"].lower()
+
+    def test_since_until_window(self, client: TestClient) -> None:
+        import asyncio
+
+        _seed_user(username="window_admin", password="pw", role="admin")
+
+        # Three rows at three different timestamps.
+        old = (datetime.now(UTC) - timedelta(days=10)).isoformat().replace("+00:00", "Z")
+        mid = (datetime.now(UTC) - timedelta(days=5)).isoformat().replace("+00:00", "Z")
+        new = (datetime.now(UTC) - timedelta(days=1)).isoformat().replace("+00:00", "Z")
+
+        async def _seed() -> None:
+            await _seed_activity_row(persona="t", event_type="query", ts=old)
+            await _seed_activity_row(persona="t", event_type="query", ts=mid)
+            await _seed_activity_row(persona="t", event_type="query", ts=new)
+
+        asyncio.run(_seed())
+
+        token = _login_jwt(client, "window_admin", "pw")
+        # Window covers only the mid row (since=before-mid, until=before-new).
+        since = (datetime.now(UTC) - timedelta(days=7)).isoformat().replace("+00:00", "Z")
+        until = (datetime.now(UTC) - timedelta(days=2)).isoformat().replace("+00:00", "Z")
+        resp = client.get(
+            f"/api/v1/activity?since={since}&until={until}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200, resp.text
+        rows = resp.json()["items"]
+        assert len(rows) == 1
+        assert rows[0]["ts"] == mid
+
+    def test_malformed_timestamp_422s(self, client: TestClient) -> None:
+        _seed_user(username="ts", password="pw")
+        token = _login_jwt(client, "ts", "pw")
+        resp = client.get(
+            "/api/v1/activity?since=not-a-timestamp",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Cursor pagination
+# ---------------------------------------------------------------------------
+
+
+class TestCursorPagination:
+    def test_cursor_advances_through_rows(self, client: TestClient) -> None:
+        import asyncio
+
+        _seed_user(username="cur_admin", password="pw", role="admin")
+
+        # Five rows, monotone-increasing ts.
+        async def _seed() -> None:
+            base = datetime.now(UTC)
+            for i in range(5):
+                ts = (base + timedelta(seconds=i)).isoformat().replace("+00:00", "Z")
+                await _seed_activity_row(persona="curs", event_type="query", ts=ts)
+
+        asyncio.run(_seed())
+
+        token = _login_jwt(client, "cur_admin", "pw")
+        resp = client.get(
+            "/api/v1/activity?limit=2",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert len(body["items"]) == 2
+        first_page_tss = [it["ts"] for it in body["items"]]
+        assert body["next_cursor"] is not None
+
+        resp2 = client.get(
+            f"/api/v1/activity?limit=2&cursor={body['next_cursor']}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp2.status_code == 200
+        page2 = resp2.json()
+        page2_tss = [it["ts"] for it in page2["items"]]
+        # No overlap with page 1; descending order.
+        assert not set(first_page_tss) & set(page2_tss)
+        assert all(p2 < p1 for p1 in first_page_tss for p2 in page2_tss)
+
+    def test_malformed_cursor_400s(self, client: TestClient) -> None:
+        _seed_user(username="cm", password="pw")
+        token = _login_jwt(client, "cm", "pw")
+        resp = client.get(
+            "/api/v1/activity?cursor=not-a-cursor",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# API-key auth — the same endpoint accepts cqa.v1.* tokens (issue #99 fix).
+# ---------------------------------------------------------------------------
+
+
+class TestApiKeyAuth:
+    def test_endpoint_accepts_api_key(self, client: TestClient) -> None:
+        import asyncio
+
+        _seed_user(username="ak_user", password="pw")
+
+        async def _seed() -> None:
+            await _seed_activity_row(persona="ak_user", event_type="query")
+
+        asyncio.run(_seed())
+
+        jwt = _login_jwt(client, "ak_user", "pw")
+        resp = client.post(
+            "/auth/api-keys",
+            headers={"Authorization": f"Bearer {jwt}"},
+            json={"name": "x", "ttl": "30d"},
+        )
+        assert resp.status_code == 201, resp.text
+        api_key = resp.json()["token"]
+        assert api_key.startswith("cqa.v1.")
+
+        resp = client.get(
+            "/api/v1/activity",
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+        assert resp.status_code == 200, resp.text
+        # Non-admin scope: only their own persona.
+        rows = resp.json()["items"]
+        assert all(r["persona"] == "ak_user" for r in rows)

--- a/server/backend/tests/test_default_enterprise_backfill.py
+++ b/server/backend/tests/test_default_enterprise_backfill.py
@@ -1,0 +1,420 @@
+"""Backfill migration 0013 — legacy default-enterprise KUs (#121 finding 3).
+
+The #89 tenancy fix only protects new INSERTs. KUs proposed before
+that fix shipped sit in ``enterprise_id='default-enterprise'`` /
+``group_id='default-group'`` regardless of which tenant the proposer
+actually belongs to. Migration 0013 reassigns those rows by parsing
+``created_by`` out of the JSON ``data`` blob and looking up the
+proposer's tenancy in ``users``.
+
+These tests pin the migration's behaviour:
+
+1. Eligible legacy rows (default-enterprise + known-non-default
+   proposer) get reassigned to the proposer's actual tenancy.
+2. Rows with no ``created_by``, an empty ``created_by``, or a
+   ``created_by`` that doesn't resolve to a user — left alone.
+3. Rows whose proposer is also at default tenancy — left alone (no
+   useful signal to use for reassignment).
+4. Rows already at non-default tenancy (i.e. proposed *after* the
+   #89 fix) — left alone. The migration is restricted to the bug's
+   blast radius.
+5. Re-running the upgrade is a no-op (idempotent).
+
+Tests use the public ``run_migrations`` entrypoint plus direct
+sqlite3 inspection — same shape as the other 001x migration tests in
+this directory.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from cq_server.migrations import HEAD_REVISION, run_migrations
+
+
+def _seed_legacy_ku(
+    conn: sqlite3.Connection,
+    *,
+    unit_id: str,
+    created_by: str,
+    enterprise_id: str = "default-enterprise",
+    group_id: str = "default-group",
+) -> None:
+    """Insert a KU directly into knowledge_units, bypassing the store.
+
+    Mimics the pre-#89 shape: tenancy columns at default, a populated
+    ``data`` JSON with the proposer's username under ``created_by``.
+    """
+    data = {
+        "id": unit_id,
+        "domains": ["test-fleet"],
+        "insight": {
+            "summary": "legacy KU for backfill probe",
+            "detail": "Inserted with default tenancy to simulate pre-#89.",
+            "action": "Migration 0013 should reassign based on created_by.",
+        },
+        "tier": "private",
+        "created_by": created_by,
+        "evidence": {"confirmations": 0, "flags": []},
+    }
+    conn.execute(
+        "INSERT INTO knowledge_units "
+        "(id, data, created_at, tier, status, enterprise_id, group_id) "
+        "VALUES (?, ?, ?, 'private', 'pending', ?, ?)",
+        (
+            unit_id,
+            json.dumps(data),
+            datetime.now(UTC).isoformat(),
+            enterprise_id,
+            group_id,
+        ),
+    )
+
+
+def _seed_user(
+    conn: sqlite3.Connection,
+    *,
+    username: str,
+    enterprise_id: str,
+    group_id: str,
+) -> None:
+    conn.execute(
+        "INSERT INTO users "
+        "(username, password_hash, created_at, enterprise_id, group_id) "
+        "VALUES (?, '$2b$12$placeholder', ?, ?, ?)",
+        (username, datetime.now(UTC).isoformat(), enterprise_id, group_id),
+    )
+
+
+def _read_tenancy(conn: sqlite3.Connection, unit_id: str) -> tuple[str, str]:
+    row = conn.execute(
+        "SELECT enterprise_id, group_id FROM knowledge_units WHERE id = ?",
+        (unit_id,),
+    ).fetchone()
+    assert row is not None
+    return row[0], row[1]
+
+
+@pytest.fixture()
+def db(tmp_path: Path) -> Path:
+    """Bring a DB up through 0012 (one short of the backfill migration).
+
+    All tests then seed legacy + user rows and step the chain forward
+    one revision so we can observe the backfill in isolation.
+    """
+    path = tmp_path / "backfill.db"
+    repo_root = Path(__file__).resolve().parents[1]
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "HOME": str(Path.home()),
+        "CQ_DB_PATH": str(path),
+    }
+    up = subprocess.run(
+        ["uv", "run", "alembic", "upgrade", "0012_pending_review_tier"],
+        cwd=str(repo_root),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert up.returncode == 0, f"upgrade-to-0012 failed: {up.stderr}\n{up.stdout}"
+    return path
+
+
+def _step_to_0013(db_path: Path) -> subprocess.CompletedProcess[str]:
+    repo_root = Path(__file__).resolve().parents[1]
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "HOME": str(Path.home()),
+        "CQ_DB_PATH": str(db_path),
+    }
+    return subprocess.run(
+        ["uv", "run", "alembic", "upgrade", "0013_backfill_default_enterprise_kus"],
+        cwd=str(repo_root),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Headline behaviour: eligible row reassigned to proposer tenancy.
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyRowReassignment:
+    def test_default_enterprise_row_with_known_proposer_gets_reassigned(
+        self, db: Path
+    ) -> None:
+        conn = sqlite3.connect(str(db))
+        try:
+            _seed_user(
+                conn,
+                username="bran",
+                enterprise_id="moscowmul3",
+                group_id="engineering",
+            )
+            _seed_legacy_ku(conn, unit_id="legacy-1", created_by="bran")
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = _step_to_0013(db)
+        assert result.returncode == 0, result.stderr
+
+        conn = sqlite3.connect(str(db))
+        try:
+            ent, grp = _read_tenancy(conn, "legacy-1")
+        finally:
+            conn.close()
+        assert ent == "moscowmul3"
+        assert grp == "engineering"
+
+    def test_two_proposers_two_enterprises_each_row_lands_correctly(
+        self, db: Path
+    ) -> None:
+        """Pin per-row resolution. Two legacy KUs from two proposers
+        in two enterprises — each row gets its own proposer's tenancy,
+        not the wrong one (no thread-local cache, no cross-row leak).
+        """
+        conn = sqlite3.connect(str(db))
+        try:
+            _seed_user(
+                conn,
+                username="alice",
+                enterprise_id="acme",
+                group_id="solutions",
+            )
+            _seed_user(
+                conn,
+                username="bob",
+                enterprise_id="moscowmul3",
+                group_id="engineering",
+            )
+            _seed_legacy_ku(conn, unit_id="ku-alice", created_by="alice")
+            _seed_legacy_ku(conn, unit_id="ku-bob", created_by="bob")
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = _step_to_0013(db)
+        assert result.returncode == 0, result.stderr
+
+        conn = sqlite3.connect(str(db))
+        try:
+            assert _read_tenancy(conn, "ku-alice") == ("acme", "solutions")
+            assert _read_tenancy(conn, "ku-bob") == ("moscowmul3", "engineering")
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Skip conditions — rows the migration must leave untouched.
+# ---------------------------------------------------------------------------
+
+
+class TestRowsLeftAlone:
+    def test_row_with_unknown_proposer_stays_default(self, db: Path) -> None:
+        """``created_by`` doesn't resolve to any user — no signal to
+        reassign on. Row stays at default-enterprise.
+        """
+        conn = sqlite3.connect(str(db))
+        try:
+            _seed_legacy_ku(conn, unit_id="ghost", created_by="never-existed")
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = _step_to_0013(db)
+        assert result.returncode == 0, result.stderr
+
+        conn = sqlite3.connect(str(db))
+        try:
+            assert _read_tenancy(conn, "ghost") == (
+                "default-enterprise",
+                "default-group",
+            )
+        finally:
+            conn.close()
+
+    def test_row_with_empty_created_by_stays_default(self, db: Path) -> None:
+        conn = sqlite3.connect(str(db))
+        try:
+            _seed_legacy_ku(conn, unit_id="empty-attr", created_by="")
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = _step_to_0013(db)
+        assert result.returncode == 0, result.stderr
+
+        conn = sqlite3.connect(str(db))
+        try:
+            assert _read_tenancy(conn, "empty-attr") == (
+                "default-enterprise",
+                "default-group",
+            )
+        finally:
+            conn.close()
+
+    def test_row_whose_proposer_is_also_default_stays_default(
+        self, db: Path
+    ) -> None:
+        """If the proposer is themselves at default tenancy, there's
+        no useful signal — the migration shouldn't pretend to "fix"
+        the row by re-tenanting it to default-enterprise (no-op).
+        """
+        conn = sqlite3.connect(str(db))
+        try:
+            _seed_user(
+                conn,
+                username="default_user",
+                enterprise_id="default-enterprise",
+                group_id="default-group",
+            )
+            _seed_legacy_ku(
+                conn, unit_id="dual-default", created_by="default_user"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = _step_to_0013(db)
+        assert result.returncode == 0, result.stderr
+
+        conn = sqlite3.connect(str(db))
+        try:
+            assert _read_tenancy(conn, "dual-default") == (
+                "default-enterprise",
+                "default-group",
+            )
+        finally:
+            conn.close()
+
+    def test_row_already_at_non_default_tenancy_is_not_overwritten(
+        self, db: Path
+    ) -> None:
+        """A row proposed *after* the #89 fix has the right tenancy
+        already — the migration must not touch it (the WHERE clause's
+        ``enterprise_id = 'default-enterprise'`` guard).
+        """
+        conn = sqlite3.connect(str(db))
+        try:
+            _seed_user(
+                conn,
+                username="alice",
+                enterprise_id="acme",
+                group_id="solutions",
+            )
+            # Already correctly-tenanted row — don't touch it.
+            _seed_legacy_ku(
+                conn,
+                unit_id="post-fix",
+                created_by="alice",
+                enterprise_id="acme",
+                group_id="solutions",
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = _step_to_0013(db)
+        assert result.returncode == 0, result.stderr
+
+        conn = sqlite3.connect(str(db))
+        try:
+            assert _read_tenancy(conn, "post-fix") == ("acme", "solutions")
+        finally:
+            conn.close()
+
+    def test_malformed_data_blob_is_skipped_not_aborted(self, db: Path) -> None:
+        """A single bad-JSON row must not abort the whole migration
+        — the row stays put, every other eligible row still backfills.
+        """
+        conn = sqlite3.connect(str(db))
+        try:
+            _seed_user(
+                conn,
+                username="alice",
+                enterprise_id="acme",
+                group_id="solutions",
+            )
+            # Good row — must still backfill.
+            _seed_legacy_ku(conn, unit_id="good", created_by="alice")
+            # Bad row — invalid JSON blob.
+            conn.execute(
+                "INSERT INTO knowledge_units "
+                "(id, data, created_at, tier, status, enterprise_id, group_id) "
+                "VALUES ('bad', 'not-json{', ?, 'private', 'pending', "
+                "'default-enterprise', 'default-group')",
+                (datetime.now(UTC).isoformat(),),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = _step_to_0013(db)
+        assert result.returncode == 0, result.stderr
+
+        conn = sqlite3.connect(str(db))
+        try:
+            assert _read_tenancy(conn, "good") == ("acme", "solutions")
+            # Bad row stays put — no crash, no migration abort.
+            assert _read_tenancy(conn, "bad") == (
+                "default-enterprise",
+                "default-group",
+            )
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Idempotency + chain integration.
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotencyAndChain:
+    def test_rerun_via_run_migrations_is_noop(self, db: Path) -> None:
+        """Running the chain twice through ``run_migrations`` (the ops
+        path, not the alembic CLI) leaves the data unchanged the
+        second time. Pre-fix this would re-process every row; post-
+        fix the WHERE clause sees zero candidates.
+        """
+        conn = sqlite3.connect(str(db))
+        try:
+            _seed_user(
+                conn,
+                username="alice",
+                enterprise_id="acme",
+                group_id="solutions",
+            )
+            _seed_legacy_ku(conn, unit_id="rerun", created_by="alice")
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Step forward via the ops entrypoint — this is what runs at
+        # server startup, not the alembic CLI.
+        run_migrations(f"sqlite:///{db}")
+        run_migrations(f"sqlite:///{db}")  # second call must be no-op.
+
+        conn = sqlite3.connect(str(db))
+        try:
+            assert _read_tenancy(conn, "rerun") == ("acme", "solutions")
+        finally:
+            conn.close()
+
+    def test_head_revision_is_0013(self) -> None:
+        """If a future migration lands without bumping HEAD_REVISION,
+        ``run_migrations`` silently misses the new revision on stamped
+        DBs. Pin the constant so the chain head is the source of truth.
+        """
+        assert HEAD_REVISION == "0013_backfill_default_enterprise_kus"

--- a/server/backend/tests/test_migration_0011_activity_log.py
+++ b/server/backend/tests/test_migration_0011_activity_log.py
@@ -512,7 +512,10 @@ class TestHeadRevisionAndHistory:
         is the source of truth for ops scripts and stamp logic."""
         from cq_server.migrations import HEAD_REVISION
 
-        assert HEAD_REVISION == "0011_activity_log"
+        # Bumped by 0012_pending_review_tier (#103). Stage 1 of #108
+        # set this to 0011_activity_log; Stage 2 (this PR) chains
+        # 0012_pending_review_tier on top.
+        assert HEAD_REVISION == "0012_pending_review_tier"
 
     @pytest.mark.parametrize("invalid_dir", [None])
     def test_alembic_history_includes_0011(self, invalid_dir: object) -> None:

--- a/server/backend/tests/test_migration_0011_activity_log.py
+++ b/server/backend/tests/test_migration_0011_activity_log.py
@@ -512,10 +512,11 @@ class TestHeadRevisionAndHistory:
         is the source of truth for ops scripts and stamp logic."""
         from cq_server.migrations import HEAD_REVISION
 
-        # Bumped by 0012_pending_review_tier (#103). Stage 1 of #108
-        # set this to 0011_activity_log; Stage 2 (this PR) chains
-        # 0012_pending_review_tier on top.
-        assert HEAD_REVISION == "0012_pending_review_tier"
+        # Bumped by 0013_backfill_default_enterprise_kus (#121
+        # finding 3, post-merge cleanup of #89 tenancy fix). Earlier
+        # bumps: 0011 (#108 Stage 1), 0012 (#103). Each new migration
+        # MUST move this constant.
+        assert HEAD_REVISION == "0013_backfill_default_enterprise_kus"
 
     @pytest.mark.parametrize("invalid_dir", [None])
     def test_alembic_history_includes_0011(self, invalid_dir: object) -> None:

--- a/server/backend/tests/test_migration_0011_activity_log.py
+++ b/server/backend/tests/test_migration_0011_activity_log.py
@@ -1,0 +1,534 @@
+"""Stage 1 of #108 — activity-log Alembic migration smoke-tests.
+
+Mirrors the pattern in ``test_migration_0003_presence.py`` /
+``test_migration_0002_xgroup_consent.py``: every migration in this
+chain ships an upgrade-from-empty + upgrade-from-legacy + downgrade
+cycle test, and a history-linearity sanity test.
+
+Stage 1 is **schema only** — Stage 2 (instrumentation-engineer) wires
+existing handlers to write rows, and ships ``GET /api/v1/activity``.
+This file therefore covers:
+
+* ``activity_log`` + ``activity_retention_config`` create cleanly on
+  an empty DB and on a populated legacy DB.
+* The CHECK constraint on ``event_type`` rejects unknown values.
+* The ``DEFAULT 90`` and ``retention_days > 0`` constraints on
+  ``activity_retention_config`` work as advertised.
+* ``SqliteStore.append_activity`` round-trips a row through every
+  nullable / non-nullable column.
+* Retention config helpers fall back to 90 when no row exists, and
+  upsert correctly.
+* ``purge_activity_older_than`` deletes only rows older than the
+  cutoff and only for the named tenant.
+* The chain head moved to ``0011_activity_log`` (catches the easy
+  miss of forgetting to bump ``HEAD_REVISION``).
+* ``alembic history`` shows the new revision chained off
+  ``0010_reflect_submissions``.
+
+Tests intentionally do **not** assert on the route handlers (Stage 2)
+or on any read endpoint — those land in a separate PR.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _run_alembic(
+    db_path: Path, command: str, target: str
+) -> subprocess.CompletedProcess[str]:
+    repo_root = Path(__file__).resolve().parents[1]
+    return subprocess.run(
+        ["uv", "run", "alembic", command, target],
+        cwd=str(repo_root),
+        env={
+            "PATH": os.environ.get("PATH", ""),
+            "CQ_DB_PATH": str(db_path),
+            "HOME": str(Path.home()),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?", (name,)
+    ).fetchone()
+    return row is not None
+
+
+def _index_names(conn: sqlite3.Connection, table: str) -> set[str]:
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name = ?",
+        (table,),
+    ).fetchall()
+    return {r[0] for r in rows}
+
+
+def _column_names(conn: sqlite3.Connection, table: str) -> list[str]:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return [r[1] for r in rows]
+
+
+# --- 1. fresh DB upgrade/downgrade ----------------------------------------
+
+
+class TestUpgradeDowngradeEmpty:
+    def test_upgrade_creates_activity_log_with_indexes(self, tmp_path: Path) -> None:
+        db = tmp_path / "alembic_empty.db"
+        sqlite3.connect(str(db)).close()  # touch
+
+        up = _run_alembic(db, "upgrade", "head")
+        assert up.returncode == 0, f"upgrade failed:\n{up.stderr}\n{up.stdout}"
+
+        check = sqlite3.connect(str(db))
+        try:
+            assert _table_exists(check, "activity_log")
+            assert _table_exists(check, "activity_retention_config")
+
+            # Column shape mirrors the #108 schema sketch verbatim.
+            cols = _column_names(check, "activity_log")
+            assert cols == [
+                "id",
+                "ts",
+                "tenant_enterprise",
+                "tenant_group",
+                "persona",
+                "human",
+                "event_type",
+                "payload",
+                "result_summary",
+                "thread_or_chain_id",
+            ]
+
+            idx = _index_names(check, "activity_log")
+            assert "idx_activity_log_tenant_ts" in idx
+            assert "idx_activity_log_persona_ts" in idx
+            assert "idx_activity_log_event_type_ts" in idx
+            assert "idx_activity_log_thread" in idx
+
+            # Retention config has the 90-day default.
+            row = check.execute(
+                "SELECT dflt_value FROM pragma_table_info('activity_retention_config') "
+                "WHERE name = 'retention_days'"
+            ).fetchone()
+            assert row is not None
+            assert row[0] == "90"
+        finally:
+            check.close()
+
+        down = _run_alembic(db, "downgrade", "0010_reflect_submissions")
+        assert down.returncode == 0, f"downgrade failed:\n{down.stderr}\n{down.stdout}"
+
+        check = sqlite3.connect(str(db))
+        try:
+            assert not _table_exists(check, "activity_log")
+            assert not _table_exists(check, "activity_retention_config")
+        finally:
+            check.close()
+
+
+# --- 2. legacy DB upgrade -------------------------------------------------
+
+
+class TestUpgradeOnLegacyDb:
+    """Pre-Alembic prod DB has knowledge_units but no alembic_version.
+
+    The runtime path (run_migrations) stamps at baseline first; without
+    the stamp, ``upgrade head`` errors trying to re-CREATE existing
+    tables. This test exercises the full chain on a populated legacy
+    fixture and asserts the activity-log tables land cleanly without
+    touching pre-existing rows.
+    """
+
+    def test_upgrade_creates_tables_without_disturbing_legacy_rows(
+        self, tmp_path: Path
+    ) -> None:
+        db = tmp_path / "alembic_legacy.db"
+        conn = sqlite3.connect(str(db))
+        conn.executescript(
+            """
+            CREATE TABLE knowledge_units (id TEXT PRIMARY KEY, data TEXT NOT NULL);
+            CREATE TABLE users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                username TEXT NOT NULL UNIQUE,
+                password_hash TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            );
+            INSERT INTO knowledge_units (id, data) VALUES ('legacy_ku', '{}');
+            INSERT INTO users (username, password_hash, created_at)
+                VALUES ('legacy_user', 'hash', '2024-01-01T00:00:00+00:00');
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        from cq_server.migrations import run_migrations
+        run_migrations(f"sqlite:///{db}")
+
+        check = sqlite3.connect(str(db))
+        try:
+            assert _table_exists(check, "activity_log")
+            assert _table_exists(check, "activity_retention_config")
+            # Legacy row survived.
+            row = check.execute(
+                "SELECT id FROM knowledge_units WHERE id = 'legacy_ku'"
+            ).fetchone()
+            assert row is not None
+            assert row[0] == "legacy_ku"
+        finally:
+            check.close()
+
+
+# --- 3. CHECK constraints -------------------------------------------------
+
+
+class TestCheckConstraints:
+    """Direct SQL probes — covers the CHECK constraints declared in
+    the migration without going through SqliteStore (which validates
+    in Python *before* the constraint fires)."""
+
+    def test_event_type_rejects_unknown_value(self, tmp_path: Path) -> None:
+        db = tmp_path / "ck_event.db"
+        sqlite3.connect(str(db)).close()
+        up = _run_alembic(db, "upgrade", "head")
+        assert up.returncode == 0, up.stderr
+
+        conn = sqlite3.connect(str(db))
+        # Foreign keys are off by default in raw sqlite3 connections;
+        # CHECK constraints fire regardless. Confirm.
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO activity_log "
+                "(id, ts, tenant_enterprise, event_type, payload) "
+                "VALUES ('act_x', '2026-05-06T00:00:00Z', 'ent', 'not_a_real_event', '{}')"
+            )
+        conn.close()
+
+    def test_event_type_accepts_every_locked_enum_value(
+        self, tmp_path: Path
+    ) -> None:
+        db = tmp_path / "ck_event_ok.db"
+        sqlite3.connect(str(db)).close()
+        up = _run_alembic(db, "upgrade", "head")
+        assert up.returncode == 0, up.stderr
+
+        from cq_server.activity import EVENT_TYPES
+
+        conn = sqlite3.connect(str(db))
+        for i, et in enumerate(sorted(EVENT_TYPES)):
+            conn.execute(
+                "INSERT INTO activity_log "
+                "(id, ts, tenant_enterprise, event_type, payload) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (f"act_ok_{i:02d}", "2026-05-06T00:00:00Z", "ent", et, "{}"),
+            )
+        conn.commit()
+        # Every event-type round-tripped.
+        cnt = conn.execute("SELECT COUNT(*) FROM activity_log").fetchone()[0]
+        assert cnt == len(EVENT_TYPES)
+        conn.close()
+
+    def test_retention_days_must_be_positive(self, tmp_path: Path) -> None:
+        db = tmp_path / "ck_retention.db"
+        sqlite3.connect(str(db)).close()
+        up = _run_alembic(db, "upgrade", "head")
+        assert up.returncode == 0, up.stderr
+
+        conn = sqlite3.connect(str(db))
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO activity_retention_config "
+                "(enterprise_id, retention_days, updated_at) "
+                "VALUES ('ent', 0, '2026-05-06T00:00:00Z')"
+            )
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO activity_retention_config "
+                "(enterprise_id, retention_days, updated_at) "
+                "VALUES ('ent', -1, '2026-05-06T00:00:00Z')"
+            )
+        conn.close()
+
+
+# --- 4. Store helper round-trip -------------------------------------------
+
+
+class TestSqliteStoreActivityHelpers:
+    """End-to-end through the SqliteStore wrapper. Stage-2 callers
+    will go through the async surface; tests use the sync proxy for
+    brevity, same as every other helper test in this suite."""
+
+    async def test_append_activity_round_trip(self, tmp_path: Path) -> None:
+        from cq_server.activity import generate_activity_id, now_iso_z
+        from cq_server.store import SqliteStore
+
+        db = tmp_path / "store.db"
+        store = SqliteStore(db_path=db)
+        try:
+            aid = generate_activity_id()
+            ts = now_iso_z()
+            await store.append_activity(
+                activity_id=aid,
+                ts=ts,
+                tenant_enterprise="ent-1",
+                tenant_group="grp-A",
+                persona="alice@persona",
+                human="alice",
+                event_type="query",
+                payload={"domains": ["api"], "limit": 5},
+                result_summary={"ku_ids": ["ku_x"], "cache_hit": False},
+                thread_or_chain_id=None,
+            )
+
+            row = store.sync._engine.connect().execute(
+                __import__("sqlalchemy").text(
+                    "SELECT id, tenant_enterprise, tenant_group, persona, human, "
+                    "event_type, payload, result_summary, thread_or_chain_id "
+                    "FROM activity_log WHERE id = :id"
+                ),
+                {"id": aid},
+            ).fetchone()
+            assert row is not None
+            assert row[0] == aid
+            assert row[1] == "ent-1"
+            assert row[2] == "grp-A"
+            assert row[3] == "alice@persona"
+            assert row[4] == "alice"
+            assert row[5] == "query"
+            # JSON round-trip preserves shape.
+            import json as _json
+            assert _json.loads(row[6]) == {"domains": ["api"], "limit": 5}
+            assert _json.loads(row[7]) == {"ku_ids": ["ku_x"], "cache_hit": False}
+            assert row[8] is None
+        finally:
+            store.sync.close()
+
+    async def test_append_activity_rejects_unknown_event_type(
+        self, tmp_path: Path
+    ) -> None:
+        from cq_server.activity import generate_activity_id, now_iso_z
+        from cq_server.store import SqliteStore
+
+        db = tmp_path / "store_bad.db"
+        store = SqliteStore(db_path=db)
+        try:
+            with pytest.raises(ValueError, match="unknown activity event_type"):
+                await store.append_activity(
+                    activity_id=generate_activity_id(),
+                    ts=now_iso_z(),
+                    tenant_enterprise="ent",
+                    tenant_group=None,
+                    persona=None,
+                    human=None,
+                    event_type="bogus",
+                )
+        finally:
+            store.sync.close()
+
+    async def test_append_activity_allows_null_persona_and_group(
+        self, tmp_path: Path
+    ) -> None:
+        """System events log without a persona / group / human."""
+        from cq_server.activity import generate_activity_id, now_iso_z
+        from cq_server.store import SqliteStore
+
+        db = tmp_path / "store_null.db"
+        store = SqliteStore(db_path=db)
+        try:
+            aid = generate_activity_id()
+            await store.append_activity(
+                activity_id=aid,
+                ts=now_iso_z(),
+                tenant_enterprise="ent-sys",
+                tenant_group=None,
+                persona=None,
+                human=None,
+                event_type="review_start",
+                payload={"reason": "automatic_quality_gate"},
+            )
+            # Insert succeeded — assert by counting.
+            cnt = (
+                store.sync._engine.connect()
+                .execute(
+                    __import__("sqlalchemy").text(
+                        "SELECT COUNT(*) FROM activity_log WHERE id = :id"
+                    ),
+                    {"id": aid},
+                )
+                .scalar()
+            )
+            assert cnt == 1
+        finally:
+            store.sync.close()
+
+
+class TestRetentionConfigHelpers:
+    async def test_default_is_90_when_no_row(self, tmp_path: Path) -> None:
+        from cq_server.store import SqliteStore
+
+        db = tmp_path / "ret_default.db"
+        store = SqliteStore(db_path=db)
+        try:
+            assert (
+                await store.get_activity_retention_days(enterprise_id="any-ent")
+                == 90
+            )
+        finally:
+            store.sync.close()
+
+    async def test_set_then_get_round_trip(self, tmp_path: Path) -> None:
+        from cq_server.store import SqliteStore
+
+        db = tmp_path / "ret_set.db"
+        store = SqliteStore(db_path=db)
+        try:
+            await store.set_activity_retention_days(
+                enterprise_id="ent-1", retention_days=30
+            )
+            assert (
+                await store.get_activity_retention_days(enterprise_id="ent-1")
+                == 30
+            )
+            # Upsert overrides existing value.
+            await store.set_activity_retention_days(
+                enterprise_id="ent-1", retention_days=180
+            )
+            assert (
+                await store.get_activity_retention_days(enterprise_id="ent-1")
+                == 180
+            )
+            # Sibling enterprise still defaults.
+            assert (
+                await store.get_activity_retention_days(enterprise_id="ent-2")
+                == 90
+            )
+        finally:
+            store.sync.close()
+
+    async def test_set_rejects_non_positive(self, tmp_path: Path) -> None:
+        from cq_server.store import SqliteStore
+
+        db = tmp_path / "ret_bad.db"
+        store = SqliteStore(db_path=db)
+        try:
+            with pytest.raises(ValueError):
+                await store.set_activity_retention_days(
+                    enterprise_id="ent-1", retention_days=0
+                )
+            with pytest.raises(ValueError):
+                await store.set_activity_retention_days(
+                    enterprise_id="ent-1", retention_days=-7
+                )
+        finally:
+            store.sync.close()
+
+
+class TestPurgeOlderThan:
+    async def test_purge_deletes_only_old_rows_for_named_tenant(
+        self, tmp_path: Path
+    ) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        from cq_server.activity import generate_activity_id
+        from cq_server.store import SqliteStore
+
+        db = tmp_path / "purge.db"
+        store = SqliteStore(db_path=db)
+        try:
+            now = datetime.now(UTC)
+            old_ts = (now - timedelta(days=120)).isoformat().replace("+00:00", "Z")
+            recent_ts = (now - timedelta(days=10)).isoformat().replace("+00:00", "Z")
+            cutoff_iso = (now - timedelta(days=90)).isoformat().replace("+00:00", "Z")
+
+            # Three rows: one old + one recent for ent-1, one old for ent-2.
+            await store.append_activity(
+                activity_id=generate_activity_id(),
+                ts=old_ts,
+                tenant_enterprise="ent-1",
+                tenant_group=None,
+                persona=None,
+                human=None,
+                event_type="query",
+            )
+            await store.append_activity(
+                activity_id=generate_activity_id(),
+                ts=recent_ts,
+                tenant_enterprise="ent-1",
+                tenant_group=None,
+                persona=None,
+                human=None,
+                event_type="query",
+            )
+            await store.append_activity(
+                activity_id=generate_activity_id(),
+                ts=old_ts,
+                tenant_enterprise="ent-2",
+                tenant_group=None,
+                persona=None,
+                human=None,
+                event_type="query",
+            )
+
+            # Purge ent-1 only.
+            deleted = await store.purge_activity_older_than(
+                tenant_enterprise="ent-1", cutoff_iso=cutoff_iso
+            )
+            assert deleted == 1
+
+            # ent-1 still has the recent row; ent-2 still has its old row.
+            import sqlalchemy as _sa
+            with store.sync._engine.connect() as conn:
+                rows = conn.execute(
+                    _sa.text(
+                        "SELECT tenant_enterprise, ts FROM activity_log "
+                        "ORDER BY tenant_enterprise, ts"
+                    )
+                ).fetchall()
+            assert [(r[0], r[1]) for r in rows] == [
+                ("ent-1", recent_ts),
+                ("ent-2", old_ts),
+            ]
+        finally:
+            store.sync.close()
+
+
+# --- 5. chain head + history ---------------------------------------------
+
+
+class TestHeadRevisionAndHistory:
+    def test_head_revision_constant_was_bumped(self) -> None:
+        """If a future migration lands without bumping HEAD_REVISION,
+        ``test_migrations`` keeps asserting the old head, which the
+        test suite would still pass — but ``run_migrations`` would
+        silently miss the new revision on stamped DBs. The constant
+        is the source of truth for ops scripts and stamp logic."""
+        from cq_server.migrations import HEAD_REVISION
+
+        assert HEAD_REVISION == "0011_activity_log"
+
+    @pytest.mark.parametrize("invalid_dir", [None])
+    def test_alembic_history_includes_0011(self, invalid_dir: object) -> None:
+        repo_root = Path(__file__).resolve().parents[1]
+        result = subprocess.run(
+            ["uv", "run", "alembic", "history"],
+            cwd=str(repo_root),
+            env={
+                "PATH": os.environ.get("PATH", ""),
+                "HOME": str(Path.home()),
+                "CQ_DB_PATH": "/tmp/cq-alembic-history-check-0011.db",
+            },
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "0010_reflect_submissions" in result.stdout
+        assert "0011_activity_log" in result.stdout

--- a/server/backend/tests/test_migrations.py
+++ b/server/backend/tests/test_migrations.py
@@ -215,7 +215,8 @@ class TestFreshDatabase:
 
             # knowledge_units columns and order: baseline (0001) +
             # tenancy (0001_phase6_step1) + xgroup (0002_phase6_step2)
-            # + embedding (0007_embedding). Other phase-2 migrations
+            # + embedding (0007_embedding) + pending_review
+            # (0012_pending_review_tier). Other phase-2 migrations
             # don't touch this table.
             ku_cols = [c[0] for c in _columns(conn, "knowledge_units")]
             assert ku_cols == [
@@ -231,6 +232,8 @@ class TestFreshDatabase:
                 "cross_group_allowed",
                 "embedding",
                 "embedding_model",
+                "pending_review_reason",
+                "pending_review_expires_at",
             ]
 
             # Defaults on the columns that have them.

--- a/server/backend/tests/test_pending_review_concurrency.py
+++ b/server/backend/tests/test_pending_review_concurrency.py
@@ -1,0 +1,280 @@
+"""Optimistic-concurrency control on review-status transitions.
+
+Race surface (#121 review finding 1): two admins resolve the same KU
+at the same time — one approves, one rejects. Pre-fix, both UPDATEs
+landed and the last writer won silently, leaving an audit-log row
+that disagreed with the on-disk ``reviewed_by`` value.
+
+Fix shape: ``UPDATE_REVIEW_STATUS`` carries
+``WHERE id = :id AND status NOT IN ('approved','rejected','dropped')``.
+The first transition flips the row out of the pending family; the
+second SELECT-then-UPDATE finds zero matching rows, ``set_review_status``
+returns ``False``, and the FastAPI route returns 409.
+
+These tests pin three things:
+
+1. The store-level ``set_review_status`` returns ``True`` on the
+   winning transition and ``False`` on the racing one.
+2. The route-level ``approve`` / ``reject`` handlers turn the racing
+   ``False`` into a 409 with the winning admin's terminal status.
+3. Missing-row (KeyError) is preserved as distinct from race-loss
+   (False return). The route 404s on missing, 409s on race-loss.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from cq.models import Insight, create_knowledge_unit
+from fastapi.testclient import TestClient
+
+from cq_server.app import _get_store, app
+from cq_server.auth import hash_password
+from cq_server.migrations import run_migrations
+from cq_server.store import SqliteStore
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "race.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> Iterator[SqliteStore]:
+    db = tmp_path / "race.db"
+    run_migrations(f"sqlite:///{db}")
+    s = SqliteStore(db_path=db)
+    yield s
+    s.close_sync()
+
+
+def _make_unit(*, summary: str = "race candidate") -> object:
+    return create_knowledge_unit(
+        domains=["test-fleet"],
+        insight=Insight(
+            summary=summary,
+            detail="Probe the optimistic concurrency guard on review status.",
+            action="Two admins act on the same row; only one wins.",
+        ),
+    )
+
+
+def _seed_user(*, username: str, password: str, role: str = "user") -> None:
+    s = _get_store()
+    s.sync.create_user(username, hash_password(password))
+    if role != "user":
+        s.sync.set_user_role(username, role)
+    with s._engine.begin() as conn:
+        conn.exec_driver_sql(
+            "UPDATE users SET enterprise_id = ?, group_id = ? WHERE username = ?",
+            ("acme", "engineering", username),
+        )
+
+
+def _login_jwt(client: TestClient, username: str, password: str) -> str:
+    resp = client.post("/auth/login", json={"username": username, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+# ---------------------------------------------------------------------------
+# Store-level: set_review_status returns True on win, False on race-loss.
+# ---------------------------------------------------------------------------
+
+
+class TestSetReviewStatusReturnValue:
+    def test_first_transition_wins_returns_true(self, store: SqliteStore) -> None:
+        unit = _make_unit()
+        store.sync.insert(unit)
+        assert store.sync.set_review_status(unit.id, "approved", "first") is True
+        review = store.sync.get_review_status(unit.id)
+        assert review is not None
+        assert review["status"] == "approved"
+        assert review["reviewed_by"] == "first"
+
+    def test_second_transition_loses_returns_false(self, store: SqliteStore) -> None:
+        """Approve, then attempt reject. The reject UPDATE finds zero rows
+        because the WHERE clause excludes terminal states; the helper
+        returns False without overwriting the prior decision.
+        """
+        unit = _make_unit()
+        store.sync.insert(unit)
+        assert store.sync.set_review_status(unit.id, "approved", "first") is True
+        # Second writer races in — must not silently overwrite.
+        assert store.sync.set_review_status(unit.id, "rejected", "second") is False
+
+        review = store.sync.get_review_status(unit.id)
+        assert review is not None
+        # Still the first writer's decision — race-loss did not corrupt the
+        # audit trail. This is the bug the WHERE clause guards against.
+        assert review["status"] == "approved"
+        assert review["reviewed_by"] == "first"
+
+    def test_dropped_status_also_blocks_subsequent_writes(
+        self, store: SqliteStore
+    ) -> None:
+        """``dropped`` (the pending_review→reject terminal) must also
+        block further transitions. Pins that the WHERE clause's
+        terminal-state list covers all three values, not just
+        approved/rejected.
+        """
+        unit = _make_unit()
+        expires = (datetime.now(UTC) + timedelta(days=10)).isoformat()
+        store.sync.submit_pending_review(
+            unit,
+            reason="x",
+            expires_at=expires,
+            enterprise_id="acme",
+            group_id="engineering",
+        )
+        assert store.sync.set_review_status(unit.id, "dropped", "first") is True
+        assert store.sync.set_review_status(unit.id, "approved", "second") is False
+        review = store.sync.get_review_status(unit.id)
+        assert review is not None
+        assert review["status"] == "dropped"
+        assert review["reviewed_by"] == "first"
+
+    def test_missing_unit_still_raises_key_error(self, store: SqliteStore) -> None:
+        """Race-loss returns False; missing-row continues to raise
+        KeyError. The route layer uses this distinction to 404 on
+        missing and 409 on race-loss."""
+        with pytest.raises(KeyError, match="Knowledge unit not found"):
+            store.sync.set_review_status("does-not-exist", "approved", "x")
+
+
+# ---------------------------------------------------------------------------
+# Route-level: simulated race produces 409, not silent overwrite.
+# ---------------------------------------------------------------------------
+
+
+class TestRouteRaceProduces409:
+    def test_concurrent_approve_then_reject_returns_409(
+        self, client: TestClient
+    ) -> None:
+        """Two admins race on the same KU. The first /approve wins; the
+        second /reject must 409 with the terminal status, not silently
+        overwrite the audit row.
+        """
+        _seed_user(username="admin_a", password="pw", role="admin")
+        _seed_user(username="admin_b", password="pw", role="admin")
+        _seed_user(username="proposer", password="pw", role="user")
+
+        # Propose via the API so the row lands at status='pending'.
+        prop_jwt = _login_jwt(client, "proposer", "pw")
+        prop_key_resp = client.post(
+            "/auth/api-keys",
+            headers={"Authorization": f"Bearer {prop_jwt}"},
+            json={"name": "race", "ttl": "30d"},
+        )
+        prop_key = prop_key_resp.json()["token"]
+        propose = client.post(
+            "/propose",
+            json={
+                "domains": ["test-fleet"],
+                "insight": {
+                    "summary": "Race candidate KU for concurrency probe",
+                    "detail": "Two admins act on this row at the same time.",
+                    "action": "Verify only the first decision lands.",
+                },
+            },
+            headers={"Authorization": f"Bearer {prop_key}"},
+        )
+        assert propose.status_code == 201, propose.text
+        ku_id = propose.json()["id"]
+
+        a_jwt = _login_jwt(client, "admin_a", "pw")
+        b_jwt = _login_jwt(client, "admin_b", "pw")
+
+        # admin_a wins.
+        a_resp = client.post(
+            f"/review/{ku_id}/approve",
+            headers={"Authorization": f"Bearer {a_jwt}"},
+        )
+        assert a_resp.status_code == 200, a_resp.text
+        assert a_resp.json()["status"] == "approved"
+
+        # admin_b loses — 409 with the winning admin's terminal status
+        # surfaced in the detail string.
+        b_resp = client.post(
+            f"/review/{ku_id}/reject",
+            headers={"Authorization": f"Bearer {b_jwt}"},
+        )
+        assert b_resp.status_code == 409
+        assert "approved" in b_resp.json()["detail"]
+
+    def test_concurrent_reject_after_approve_does_not_corrupt_audit(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        """Pin the on-disk shape: after the racing reject 409s, the
+        ``reviewed_by`` row in the DB is still the winning admin's
+        username — not the loser's. This is the audit-corruption
+        regression the WHERE clause closes.
+        """
+        _seed_user(username="winner", password="pw", role="admin")
+        _seed_user(username="loser", password="pw", role="admin")
+        _seed_user(username="prop2", password="pw", role="user")
+        prop_jwt = _login_jwt(client, "prop2", "pw")
+        prop_key_resp = client.post(
+            "/auth/api-keys",
+            headers={"Authorization": f"Bearer {prop_jwt}"},
+            json={"name": "race2", "ttl": "30d"},
+        )
+        propose = client.post(
+            "/propose",
+            json={
+                "domains": ["test-fleet"],
+                "insight": {
+                    "summary": "Pin the on-disk audit row after race-loss",
+                    "detail": "After 409, the reviewed_by must match the winner.",
+                    "action": "Inspect the SQLite row directly.",
+                },
+            },
+            headers={
+                "Authorization": f"Bearer {prop_key_resp.json()['token']}"
+            },
+        )
+        assert propose.status_code == 201, propose.text
+        ku_id = propose.json()["id"]
+
+        winner_jwt = _login_jwt(client, "winner", "pw")
+        loser_jwt = _login_jwt(client, "loser", "pw")
+        client.post(
+            f"/review/{ku_id}/approve",
+            headers={"Authorization": f"Bearer {winner_jwt}"},
+        )
+        client.post(
+            f"/review/{ku_id}/reject",
+            headers={"Authorization": f"Bearer {loser_jwt}"},
+        )
+
+        # Inspect the on-disk row directly — bypass the store.
+        conn = sqlite3.connect(str(tmp_path / "race.db"))
+        try:
+            row = conn.execute(
+                "SELECT status, reviewed_by FROM knowledge_units WHERE id = ?",
+                (ku_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row == ("approved", "winner")
+
+    def test_404_preserved_when_unit_missing(self, client: TestClient) -> None:
+        """Race-loss is 409; missing-id is still 404. The two cases are
+        distinct in the store layer (KeyError vs False return) and
+        must remain distinct at the route layer.
+        """
+        _seed_user(username="admin404", password="pw", role="admin")
+        token = _login_jwt(client, "admin404", "pw")
+        resp = client.post(
+            "/review/does-not-exist/approve",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 404

--- a/server/backend/tests/test_pending_review_tier.py
+++ b/server/backend/tests/test_pending_review_tier.py
@@ -1,0 +1,431 @@
+"""Pending-review tier (#103) — store + route tests.
+
+State machine pinned by these tests:
+
+* ``submit_pending_review(unit, reason, expires_at, ...)`` lands the KU
+  with ``status='pending_review'`` plus the reason and TTL columns.
+* ``GET /review/pending-review`` lists rows in that state, sorted by
+  expiry ascending (closest-to-expiring first).
+* ``POST /review/{id}/approve`` transitions ``pending_review →
+  approved`` (same shape as the standard pending → approved flow).
+* ``POST /review/{id}/reject`` transitions ``pending_review →
+  dropped`` — distinct from the regular ``rejected`` state. The
+  distinct value lets dashboards render the two cohorts separately
+  and lets future tooling sweep dropped rows on a stricter retention.
+* ``expire_pending_reviews`` sweeps rows whose
+  ``pending_review_expires_at < now``, transitioning them to
+  ``status='dropped'`` and stamping
+  ``reviewed_by='ttl_expired_sweeper'``.
+
+Out of scope here: the ``/reflect/submit?queue_hard_findings=true``
+contract that produces these rows from the reflect classifier — that
+ships in the harness-agnostic-reflect work (#102 / #67). This file
+exercises the L2-side substrate that the reflect work will plug into.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from cq.models import Insight, create_knowledge_unit
+from fastapi.testclient import TestClient
+
+from cq_server.app import _get_store, app
+from cq_server.auth import hash_password
+from cq_server.migrations import run_migrations
+from cq_server.store import SqliteStore
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "pending.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> Iterator[SqliteStore]:
+    """Direct store fixture — no FastAPI lifespan, no API surface."""
+    db = tmp_path / "pending.db"
+    run_migrations(f"sqlite:///{db}")
+    s = SqliteStore(db_path=db)
+    yield s
+    s.close_sync()
+
+
+def _make_unit(*, summary: str = "Hard finding") -> object:
+    return create_knowledge_unit(
+        domains=["test-fleet"],
+        insight=Insight(
+            summary=summary,
+            detail="VIBE√ classifier flagged this candidate for sanitization review.",
+            action="Operator approves to promote, rejects to drop.",
+        ),
+    )
+
+
+def _seed_user(*, username: str, password: str, role: str = "user") -> None:
+    s = _get_store()
+    s.sync.create_user(username, hash_password(password))
+    if role != "user":
+        s.sync.set_user_role(username, role)
+    with s._engine.begin() as conn:
+        conn.exec_driver_sql(
+            "UPDATE users SET enterprise_id = ?, group_id = ? WHERE username = ?",
+            ("acme", "engineering", username),
+        )
+
+
+def _login_jwt(client: TestClient, username: str, password: str) -> str:
+    resp = client.post("/auth/login", json={"username": username, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+# ---------------------------------------------------------------------------
+# Store-level state machine
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitPendingReview:
+    def test_submission_lands_with_status_and_reason_columns(
+        self, store: SqliteStore, tmp_path: Path
+    ) -> None:
+        unit = _make_unit()
+        expires = (datetime.now(UTC) + timedelta(days=30)).isoformat()
+        store.sync.submit_pending_review(
+            unit,
+            reason="credential-shaped substring in summary",
+            expires_at=expires,
+            enterprise_id="acme",
+            group_id="engineering",
+        )
+
+        # On-disk inspection — the migration column-set must include
+        # both pending_review_* columns and the row's status must be
+        # 'pending_review' (not the default 'pending').
+        conn = sqlite3.connect(str(tmp_path / "pending.db"))
+        try:
+            row = conn.execute(
+                "SELECT status, pending_review_reason, "
+                "pending_review_expires_at, enterprise_id, group_id "
+                "FROM knowledge_units WHERE id = ?",
+                (unit.id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+        assert row[0] == "pending_review"
+        assert row[1] == "credential-shaped substring in summary"
+        assert row[2] == expires
+        # #89 fix carries through — submission honours auth claims.
+        assert row[3] == "acme"
+        assert row[4] == "engineering"
+
+
+class TestPendingReviewListAndCount:
+    def test_listing_orders_by_expires_ascending(
+        self, store: SqliteStore
+    ) -> None:
+        # Three pending-review rows with different expiries.
+        soon = (datetime.now(UTC) + timedelta(days=1)).isoformat()
+        mid = (datetime.now(UTC) + timedelta(days=15)).isoformat()
+        far = (datetime.now(UTC) + timedelta(days=29)).isoformat()
+        for expires, label in ((mid, "mid"), (far, "far"), (soon, "soon")):
+            unit = _make_unit(summary=label)
+            store.sync.submit_pending_review(
+                unit,
+                reason=f"{label}-test",
+                expires_at=expires,
+                enterprise_id="acme",
+                group_id="engineering",
+            )
+
+        items = store.sync.list_pending_review(enterprise_id="acme", limit=10, offset=0)
+        # Ordered by pending_review_expires_at ASC — soon, mid, far.
+        labels = [i["knowledge_unit"].insight.summary for i in items]
+        assert labels == ["soon", "mid", "far"]
+
+        assert store.sync.count_pending_review(enterprise_id="acme") == 3
+
+    def test_listing_scopes_by_enterprise(
+        self, store: SqliteStore
+    ) -> None:
+        """Cross-tenant: an acme pending-review row must NOT appear in
+        moscowmul3's queue. Pin against accidental cross-tenant leak."""
+        store.sync.submit_pending_review(
+            _make_unit(summary="acme-only"),
+            reason="x",
+            expires_at=(datetime.now(UTC) + timedelta(days=10)).isoformat(),
+            enterprise_id="acme",
+            group_id="engineering",
+        )
+        store.sync.submit_pending_review(
+            _make_unit(summary="moscow-only"),
+            reason="y",
+            expires_at=(datetime.now(UTC) + timedelta(days=10)).isoformat(),
+            enterprise_id="moscowmul3",
+            group_id="engineering",
+        )
+        acme_items = store.sync.list_pending_review(
+            enterprise_id="acme", limit=10, offset=0
+        )
+        moscow_items = store.sync.list_pending_review(
+            enterprise_id="moscowmul3", limit=10, offset=0
+        )
+        assert [i["knowledge_unit"].insight.summary for i in acme_items] == ["acme-only"]
+        assert [i["knowledge_unit"].insight.summary for i in moscow_items] == ["moscow-only"]
+
+
+class TestExpirePendingReviews:
+    def test_sweep_drops_only_expired_rows(self, store: SqliteStore) -> None:
+        future = (datetime.now(UTC) + timedelta(days=10)).isoformat()
+        past = (datetime.now(UTC) - timedelta(days=1)).isoformat()
+
+        keep = _make_unit(summary="not yet expired")
+        drop = _make_unit(summary="should be dropped")
+        store.sync.submit_pending_review(
+            keep,
+            reason="x",
+            expires_at=future,
+            enterprise_id="acme",
+            group_id="engineering",
+        )
+        store.sync.submit_pending_review(
+            drop,
+            reason="y",
+            expires_at=past,
+            enterprise_id="acme",
+            group_id="engineering",
+        )
+
+        now_iso = datetime.now(UTC).isoformat()
+        dropped = store.sync.expire_pending_reviews(
+            enterprise_id="acme", now_iso=now_iso
+        )
+        assert dropped == [drop.id]
+
+        # The non-expired row stays put; the expired row is now status=dropped.
+        items = store.sync.list_pending_review(enterprise_id="acme", limit=10, offset=0)
+        assert [i["knowledge_unit"].id for i in items] == [keep.id]
+
+        # And the dropped row's status moved on, with the sweeper sentinel
+        # in reviewed_by so the audit trail is honest.
+        review = store.sync.get_review_status(drop.id)
+        assert review is not None
+        assert review["status"] == "dropped"
+        assert review["reviewed_by"] == "ttl_expired_sweeper"
+
+
+# ---------------------------------------------------------------------------
+# Route layer
+# ---------------------------------------------------------------------------
+
+
+class TestPendingReviewRoute:
+    def test_pending_review_endpoint_lists_rows(self, client: TestClient) -> None:
+        _seed_user(username="reviewer", password="pw", role="admin")
+        # Submit one pending-review KU through the store (no /reflect
+        # contract surface yet; the route layer is what we're testing).
+        s = _get_store()
+        unit = _make_unit(summary="route-test")
+        future = (datetime.now(UTC) + timedelta(days=10)).isoformat()
+        s.sync.submit_pending_review(
+            unit,
+            reason="credential-shaped substring",
+            expires_at=future,
+            enterprise_id="acme",
+            group_id="engineering",
+        )
+        token = _login_jwt(client, "reviewer", "pw")
+
+        resp = client.get(
+            "/review/pending-review",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["total"] == 1
+        assert len(body["items"]) == 1
+        item = body["items"][0]
+        assert item["status"] == "pending_review"
+        assert item["pending_review_reason"] == "credential-shaped substring"
+        assert item["pending_review_expires_at"] == future
+
+    def test_pending_review_requires_admin(self, client: TestClient) -> None:
+        _seed_user(username="grunt", password="pw", role="user")
+        token = _login_jwt(client, "grunt", "pw")
+        resp = client.get(
+            "/review/pending-review",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 403  # require_admin gate
+
+    def test_approve_from_pending_review_transitions_to_approved(
+        self, client: TestClient
+    ) -> None:
+        _seed_user(username="admin_approve", password="pw", role="admin")
+        s = _get_store()
+        unit = _make_unit()
+        s.sync.submit_pending_review(
+            unit,
+            reason="x",
+            expires_at=(datetime.now(UTC) + timedelta(days=10)).isoformat(),
+            enterprise_id="acme",
+            group_id="engineering",
+        )
+        token = _login_jwt(client, "admin_approve", "pw")
+
+        resp = client.post(
+            f"/review/{unit.id}/approve",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == "approved"
+
+    def test_reject_from_pending_review_transitions_to_dropped_not_rejected(
+        self, client: TestClient
+    ) -> None:
+        """The lifecycle distinction (#103): operator rejection of a
+        pending_review row sets status='dropped', not 'rejected'.
+        Pins the spec line "pending_review → dropped (operator rejects)".
+        """
+        _seed_user(username="admin_reject", password="pw", role="admin")
+        s = _get_store()
+        unit = _make_unit()
+        s.sync.submit_pending_review(
+            unit,
+            reason="x",
+            expires_at=(datetime.now(UTC) + timedelta(days=10)).isoformat(),
+            enterprise_id="acme",
+            group_id="engineering",
+        )
+        token = _login_jwt(client, "admin_reject", "pw")
+
+        resp = client.post(
+            f"/review/{unit.id}/reject",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200, resp.text
+        # Critical assertion: dropped, not rejected.
+        assert resp.json()["status"] == "dropped"
+
+    def test_reject_from_regular_pending_still_uses_rejected(
+        self, client: TestClient
+    ) -> None:
+        """The dropped distinction is *only* for pending_review. A
+        regular ``status='pending'`` rejection still goes to
+        ``status='rejected'`` — unchanged from pre-#103 behaviour."""
+        _seed_user(username="admin_reg", password="pw", role="admin")
+        # Propose via the API path so the row lands at status='pending'
+        # (default), not pending_review.
+        _seed_user(username="proposer_reg", password="pw", role="user")
+        prop_jwt = _login_jwt(client, "proposer_reg", "pw")
+        prop_key_resp = client.post(
+            "/auth/api-keys",
+            headers={"Authorization": f"Bearer {prop_jwt}"},
+            json={"name": "x", "ttl": "30d"},
+        )
+        prop_key = prop_key_resp.json()["token"]
+        propose = client.post(
+            "/propose",
+            json={
+                "domains": ["test-fleet"],
+                "insight": {
+                    "summary": "Regular pending KU for the regression boundary",
+                    "detail": "Goes to status='rejected', not dropped, when an admin rejects.",
+                    "action": "Pins the boundary between #103 dropped and pre-existing rejected.",
+                },
+            },
+            headers={"Authorization": f"Bearer {prop_key}"},
+        )
+        assert propose.status_code == 201, propose.text
+        ku_id = propose.json()["id"]
+
+        admin_jwt = _login_jwt(client, "admin_reg", "pw")
+        resp = client.post(
+            f"/review/{ku_id}/reject",
+            headers={"Authorization": f"Bearer {admin_jwt}"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == "rejected"  # NOT dropped
+
+
+# ---------------------------------------------------------------------------
+# Migration round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestPendingReviewMigration:
+    def test_columns_present_after_upgrade(self, tmp_path: Path) -> None:
+        db = tmp_path / "migration.db"
+        run_migrations(f"sqlite:///{db}")
+
+        conn = sqlite3.connect(str(db))
+        try:
+            cols = {row[1] for row in conn.execute("PRAGMA table_info(knowledge_units)")}
+        finally:
+            conn.close()
+        assert "pending_review_reason" in cols
+        assert "pending_review_expires_at" in cols
+
+    def test_downgrade_drops_columns(self, tmp_path: Path) -> None:
+        """Round-trip: upgrade brings the columns; downgrade removes
+        them. Validates the migration is symmetric (used by tests, not
+        prod) — same shape as ``test_migration_0011_activity_log``'s
+        downgrade pin."""
+        import os
+        import subprocess
+
+        db = tmp_path / "downgrade.db"
+        sqlite3.connect(str(db)).close()  # touch
+        repo_root = Path(__file__).resolve().parents[1]
+        env = {
+            "PATH": os.environ.get("PATH", ""),
+            "HOME": str(Path.home()),
+            "CQ_DB_PATH": str(db),
+        }
+
+        up = subprocess.run(
+            ["uv", "run", "alembic", "upgrade", "0012_pending_review_tier"],
+            cwd=str(repo_root),
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert up.returncode == 0, f"upgrade failed: {up.stderr}\n{up.stdout}"
+
+        # Both columns now present.
+        conn = sqlite3.connect(str(db))
+        try:
+            cols_after_up = {row[1] for row in conn.execute("PRAGMA table_info(knowledge_units)")}
+        finally:
+            conn.close()
+        assert {"pending_review_reason", "pending_review_expires_at"} <= cols_after_up
+
+        # Downgrade ONE step (not all the way to base — that would
+        # blow away every previous migration too).
+        down = subprocess.run(
+            ["uv", "run", "alembic", "downgrade", "0011_activity_log"],
+            cwd=str(repo_root),
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert down.returncode == 0, f"downgrade failed: {down.stderr}\n{down.stdout}"
+
+        conn = sqlite3.connect(str(db))
+        try:
+            cols_after_down = {row[1] for row in conn.execute("PRAGMA table_info(knowledge_units)")}
+        finally:
+            conn.close()
+        assert "pending_review_reason" not in cols_after_down
+        assert "pending_review_expires_at" not in cols_after_down

--- a/server/backend/tests/test_pending_review_ttl.py
+++ b/server/backend/tests/test_pending_review_ttl.py
@@ -1,0 +1,278 @@
+"""Read-time TTL enforcement on pending_review queries.
+
+Read-time hazard (#121 review finding 2): the TTL sweeper transitions
+``pending_review → dropped`` once ``pending_review_expires_at < now``,
+but the sweeper's startup-loop wiring is deferred. Without a read-time
+filter, ``GET /review/pending-review`` (and the underlying
+``list_pending_review`` / ``count_pending_review`` helpers) could
+surface candidates that have already passed their TTL — admins would
+see and act on rows the spec says should already be dropped.
+
+Fix shape: the read queries AND
+``(pending_review_expires_at IS NULL OR pending_review_expires_at > now)``
+into the WHERE clause. The route also schedules a background sweep so
+the on-disk transition catches up — but the response is correct even
+when that sweep is delayed or dropped.
+
+These tests pin three things:
+
+1. ``list_pending_review`` and ``count_pending_review`` filter expired
+   rows out at read time, regardless of sweeper state.
+2. ``GET /review/pending-review`` mirrors the store-level filter.
+3. NULL TTL (defensive: a row with no expires_at) continues to appear
+   — same shape as the sweeper's ``IS NOT NULL`` filter.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from cq.models import Insight, create_knowledge_unit
+from fastapi.testclient import TestClient
+
+from cq_server.app import _get_store, app
+from cq_server.auth import hash_password
+from cq_server.migrations import run_migrations
+from cq_server.store import SqliteStore
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "ttl.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> Iterator[SqliteStore]:
+    db = tmp_path / "ttl.db"
+    run_migrations(f"sqlite:///{db}")
+    s = SqliteStore(db_path=db)
+    yield s
+    s.close_sync()
+
+
+def _make_unit(*, summary: str = "ttl candidate") -> object:
+    return create_knowledge_unit(
+        domains=["test-fleet"],
+        insight=Insight(
+            summary=summary,
+            detail="Probe read-time TTL enforcement on pending_review.",
+            action="Expired rows must not surface even when sweeper is idle.",
+        ),
+    )
+
+
+def _seed_user(*, username: str, password: str, role: str = "user") -> None:
+    s = _get_store()
+    s.sync.create_user(username, hash_password(password))
+    if role != "user":
+        s.sync.set_user_role(username, role)
+    with s._engine.begin() as conn:
+        conn.exec_driver_sql(
+            "UPDATE users SET enterprise_id = ?, group_id = ? WHERE username = ?",
+            ("acme", "engineering", username),
+        )
+
+
+def _login_jwt(client: TestClient, username: str, password: str) -> str:
+    resp = client.post("/auth/login", json={"username": username, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+# ---------------------------------------------------------------------------
+# Store-level: read filters expired rows.
+# ---------------------------------------------------------------------------
+
+
+class TestListFiltersExpiredRows:
+    def test_expired_row_invisible_in_list_even_before_sweep(
+        self, store: SqliteStore
+    ) -> None:
+        """Submit a row whose TTL has already passed at insert time
+        (sweeper has not run). The list query must not include it.
+        Pre-fix the row appeared in the result; the read filter closes
+        that gap.
+        """
+        past = (datetime.now(UTC) - timedelta(seconds=30)).isoformat()
+        future = (datetime.now(UTC) + timedelta(days=10)).isoformat()
+        expired = _make_unit(summary="expired")
+        fresh = _make_unit(summary="fresh")
+        store.sync.submit_pending_review(
+            expired,
+            reason="should not surface",
+            expires_at=past,
+            enterprise_id="acme",
+            group_id="engineering",
+        )
+        store.sync.submit_pending_review(
+            fresh,
+            reason="should surface",
+            expires_at=future,
+            enterprise_id="acme",
+            group_id="engineering",
+        )
+
+        # The sweeper has NOT run yet; the on-disk status of the
+        # expired row is still 'pending_review'. The read filter is
+        # what keeps it out of the response.
+        items = store.sync.list_pending_review(
+            enterprise_id="acme", limit=10, offset=0
+        )
+        summaries = [i["knowledge_unit"].insight.summary for i in items]
+        assert summaries == ["fresh"], (
+            f"#121 finding 2: expired pending_review row leaked into "
+            f"list. Got {summaries!r}; expected only ['fresh']."
+        )
+
+    def test_count_matches_list_under_ttl_filter(
+        self, store: SqliteStore
+    ) -> None:
+        """count_pending_review must agree with list_pending_review on
+        which rows are visible — otherwise dashboard pagination breaks
+        (total: 5 with only 3 items rendered).
+        """
+        past = (datetime.now(UTC) - timedelta(seconds=10)).isoformat()
+        future = (datetime.now(UTC) + timedelta(days=5)).isoformat()
+        for label, expires in (
+            ("expired1", past),
+            ("expired2", past),
+            ("fresh1", future),
+        ):
+            store.sync.submit_pending_review(
+                _make_unit(summary=label),
+                reason="x",
+                expires_at=expires,
+                enterprise_id="acme",
+                group_id="engineering",
+            )
+
+        listed = store.sync.list_pending_review(
+            enterprise_id="acme", limit=10, offset=0
+        )
+        counted = store.sync.count_pending_review(enterprise_id="acme")
+        assert len(listed) == counted == 1
+
+    def test_null_expires_at_continues_to_appear(
+        self, store: SqliteStore, tmp_path: Path
+    ) -> None:
+        """Defensive: a row with NULL ``pending_review_expires_at``
+        means "no TTL configured". The read filter uses
+        ``IS NULL OR > now`` so those rows still appear — same shape
+        as the sweeper's ``IS NOT NULL`` guard.
+
+        We can't construct this through the public API
+        (``submit_pending_review`` requires expires_at) so we patch
+        the on-disk row directly.
+        """
+        unit = _make_unit(summary="null-ttl")
+        future = (datetime.now(UTC) + timedelta(days=10)).isoformat()
+        store.sync.submit_pending_review(
+            unit,
+            reason="x",
+            expires_at=future,
+            enterprise_id="acme",
+            group_id="engineering",
+        )
+        # Strip the TTL on disk to simulate the legacy NULL case.
+        conn = sqlite3.connect(str(tmp_path / "ttl.db"))
+        try:
+            conn.execute(
+                "UPDATE knowledge_units SET pending_review_expires_at = NULL "
+                "WHERE id = ?",
+                (unit.id,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        items = store.sync.list_pending_review(
+            enterprise_id="acme", limit=10, offset=0
+        )
+        assert [i["knowledge_unit"].id for i in items] == [unit.id]
+        assert store.sync.count_pending_review(enterprise_id="acme") == 1
+
+
+# ---------------------------------------------------------------------------
+# Route-level: GET /review/pending-review honours the read-time filter.
+# ---------------------------------------------------------------------------
+
+
+class TestEndpointEnforcesTTL:
+    def test_endpoint_omits_expired_rows(self, client: TestClient) -> None:
+        """The HTTP surface must reflect the same filter — admins must
+        not see TTL-expired candidates regardless of sweeper state."""
+        _seed_user(username="admin_ttl", password="pw", role="admin")
+        s = _get_store()
+
+        past = (datetime.now(UTC) - timedelta(seconds=30)).isoformat()
+        future = (datetime.now(UTC) + timedelta(days=10)).isoformat()
+        s.sync.submit_pending_review(
+            _make_unit(summary="route-expired"),
+            reason="should not surface",
+            expires_at=past,
+            enterprise_id="acme",
+            group_id="engineering",
+        )
+        s.sync.submit_pending_review(
+            _make_unit(summary="route-fresh"),
+            reason="should surface",
+            expires_at=future,
+            enterprise_id="acme",
+            group_id="engineering",
+        )
+
+        token = _login_jwt(client, "admin_ttl", "pw")
+        resp = client.get(
+            "/review/pending-review",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["total"] == 1
+        summaries = [
+            i["knowledge_unit"]["insight"]["summary"] for i in body["items"]
+        ]
+        assert summaries == ["route-fresh"]
+
+    def test_endpoint_triggers_background_sweep(
+        self, client: TestClient
+    ) -> None:
+        """The route schedules a background sweep so on-disk state
+        eventually catches up. Verify that after a request the
+        previously-expired row's status moved to 'dropped' on disk —
+        the sweep ran via the BackgroundTask hook.
+
+        TestClient runs background tasks synchronously, so by the time
+        the response returns, the sweep has already executed.
+        """
+        _seed_user(username="admin_sweep", password="pw", role="admin")
+        s = _get_store()
+        past = (datetime.now(UTC) - timedelta(seconds=30)).isoformat()
+        unit = _make_unit(summary="will-be-swept")
+        s.sync.submit_pending_review(
+            unit,
+            reason="x",
+            expires_at=past,
+            enterprise_id="acme",
+            group_id="engineering",
+        )
+        token = _login_jwt(client, "admin_sweep", "pw")
+        resp = client.get(
+            "/review/pending-review",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+
+        # Inspect on-disk: the sweeper transitioned the expired row.
+        review = s.sync.get_review_status(unit.id)
+        assert review is not None
+        assert review["status"] == "dropped"
+        assert review["reviewed_by"] == "ttl_expired_sweeper"

--- a/server/backend/tests/test_propose_tenancy_regression.py
+++ b/server/backend/tests/test_propose_tenancy_regression.py
@@ -1,0 +1,290 @@
+"""Regression tests for #89 — KU tenancy must come from auth claims.
+
+The bug surfaced in the moscowmul3 onboarding (2026-05-05): KUs
+proposed via ``POST /propose`` with a valid API key landed in
+``enterprise_id=default-enterprise`` / ``group_id=default-group``
+regardless of the L2's configured Enterprise. Root cause: ``INSERT_UNIT``
+omitted the tenancy columns and let the schema-level ``server_default``
+populate them.
+
+This file pins the fix:
+
+* The propose handler resolves tenancy from the authenticated user's
+  row and passes it to ``store.insert(...)`` explicitly.
+* The store accepts ``enterprise_id`` / ``group_id`` kwargs and writes
+  them through ``INSERT_UNIT_WITH_TENANCY``.
+* The legacy fixture path (``store.sync.insert(unit)`` with no kwargs)
+  still uses the defaults, so existing test fixtures are unaffected.
+
+If a future change reintroduces the bug — e.g. by routing all inserts
+through ``INSERT_UNIT`` regardless of caller scope — these tests fail
+loudly. The smoke test is verbatim the workaround SQL from the bug
+report (``SELECT id, enterprise_id, group_id FROM knowledge_units``).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cq_server.app import _get_store, app
+from cq_server.auth import hash_password
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "tenancy.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    with TestClient(app) as c:
+        yield c
+
+
+def _seed_user(
+    *, username: str, password: str, enterprise_id: str, group_id: str
+) -> None:
+    """Create a user, then UPDATE their tenancy columns to non-default values.
+
+    ``store.sync.create_user`` lands the row at ``default-enterprise`` /
+    ``default-group``. The follow-up UPDATE is what makes this user
+    represent a real tenant — same recipe ``test_consults.py`` uses.
+    """
+    store = _get_store()
+    store.sync.create_user(username, hash_password(password))
+    with store._engine.begin() as conn:
+        conn.exec_driver_sql(
+            "UPDATE users SET enterprise_id = ?, group_id = ? WHERE username = ?",
+            (enterprise_id, group_id, username),
+        )
+
+
+def _login_jwt(client: TestClient, username: str, password: str) -> str:
+    resp = client.post("/auth/login", json={"username": username, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _mint_api_key(client: TestClient, jwt_token: str, *, name: str = "regression-89") -> str:
+    """Login + mint an API key. Propose requires API-key auth, not JWT."""
+    resp = client.post(
+        "/auth/api-keys",
+        headers={"Authorization": f"Bearer {jwt_token}"},
+        json={"name": name, "ttl": "30d"},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["token"]
+
+
+def _login_and_mint(client: TestClient, username: str, password: str) -> str:
+    """End-to-end: login with password, mint an API key, return the API key."""
+    jwt = _login_jwt(client, username, password)
+    return _mint_api_key(client, jwt)
+
+
+def _propose(client: TestClient, api_key: str, **overrides: object) -> dict:
+    body = {
+        "domains": ["agent-memory", "test-fleet"],
+        "insight": {
+            "summary": "Tenancy regression test KU",
+            "detail": "Filed by the #89 regression suite to pin the propose-handler tenancy fix.",
+            "action": "Read enterprise_id from the authenticated user row, never the schema default.",
+        },
+    }
+    body.update(overrides)
+    resp = client.post(
+        "/propose",
+        json=body,
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def _read_scope(db_path: Path, ku_id: str) -> tuple[str, str]:
+    """Inspect the on-disk row for the KU. Bypasses the store entirely."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        row = conn.execute(
+            "SELECT enterprise_id, group_id FROM knowledge_units WHERE id = ?",
+            (ku_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None, f"KU {ku_id} not found on disk"
+    return row[0], row[1]
+
+
+# ---------------------------------------------------------------------------
+# The headline regression — KU written via API matches authenticated user.
+# ---------------------------------------------------------------------------
+
+
+class TestProposeHonoursAuthClaims:
+    def test_ku_lands_in_authed_users_enterprise_not_default(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        """The bug: the KU lands in default-enterprise. The fix: it lands in moscowmul3.
+
+        Verbatim the bug-report repro shape — same user setup, same
+        propose body, same SELECT against the on-disk DB.
+        """
+        _seed_user(
+            username="bran",
+            password="pw",
+            enterprise_id="moscowmul3",
+            group_id="engineering",
+        )
+        api_key = _login_and_mint(client, "bran", "pw")
+        unit = _propose(client, api_key)
+
+        ent, grp = _read_scope(tmp_path / "tenancy.db", unit["id"])
+        assert ent == "moscowmul3", (
+            f"#89 regression: KU landed in {ent!r} instead of moscowmul3. "
+            "The propose handler must derive enterprise_id from the user "
+            "row, not the schema-level server_default."
+        )
+        assert grp == "engineering", (
+            f"#89 regression: KU group_id is {grp!r} instead of engineering"
+        )
+
+    def test_ku_never_lands_in_default_enterprise_for_authed_user(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        """Cover the inverse: even with an obviously-non-default user,
+        the row never falls back to ``default-enterprise``.
+
+        Different enterprise/group from the headline test — guards
+        against a regression where the fix worked for one specific
+        Enterprise but fell back for another (e.g. accidental string
+        equality).
+        """
+        _seed_user(
+            username="alice",
+            password="pw",
+            enterprise_id="acme",
+            group_id="solutions",
+        )
+        api_key = _login_and_mint(client, "alice", "pw")
+        unit = _propose(client, api_key)
+
+        ent, grp = _read_scope(tmp_path / "tenancy.db", unit["id"])
+        assert ent != "default-enterprise"
+        assert grp != "default-group"
+        assert (ent, grp) == ("acme", "solutions")
+
+    def test_two_users_two_enterprises_no_cross_contamination(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        """Two users in two different Enterprises propose; each KU lands
+        in its own user's tenant. Pins that the resolution is per-call,
+        not cached or thread-local.
+        """
+        _seed_user(
+            username="moscow_user",
+            password="pw",
+            enterprise_id="moscowmul3",
+            group_id="engineering",
+        )
+        _seed_user(
+            username="acme_user",
+            password="pw",
+            enterprise_id="acme",
+            group_id="solutions",
+        )
+        moscow_key = _login_and_mint(client, "moscow_user", "pw")
+        acme_key = _login_and_mint(client, "acme_user", "pw")
+
+        moscow_ku = _propose(client, moscow_key)
+        acme_ku = _propose(client, acme_key)
+
+        moscow_scope = _read_scope(tmp_path / "tenancy.db", moscow_ku["id"])
+        acme_scope = _read_scope(tmp_path / "tenancy.db", acme_ku["id"])
+        assert moscow_scope == ("moscowmul3", "engineering")
+        assert acme_scope == ("acme", "solutions")
+
+    def test_propose_rejects_when_user_row_missing_tenancy(
+        self, client: TestClient, tmp_path: Path
+    ) -> None:
+        """Defensive: if a future migration somehow leaves a user row
+        with NULL tenancy, the handler should fail loudly rather than
+        silently writing the KU into the schema default. We simulate
+        this by NULL-ing the columns on a real user."""
+        store = _get_store()
+        store.sync.create_user("nullable", hash_password("pw"))
+        # The migration enforces NOT NULL on these columns, so we have
+        # to drop the constraint to exercise the defensive path. Doing
+        # the SQL via the raw connection bypasses the schema check.
+        with store._engine.begin() as conn:
+            # SQLite allows NULL writes when ALTER TABLE has not yet
+            # rebuilt the column; we simulate the malformed-row state
+            # by writing empty strings (the handler treats them the
+            # same way: 500 rather than silent default).
+            conn.exec_driver_sql(
+                "UPDATE users SET enterprise_id = '', group_id = '' "
+                "WHERE username = 'nullable'"
+            )
+
+        api_key = _login_and_mint(client, "nullable", "pw")
+        resp = client.post(
+            "/propose",
+            json={
+                "domains": ["test-fleet"],
+                "insight": {
+                    "summary": "Should never land",
+                    "detail": "Bran filed this regression so the handler 500s "
+                    "rather than silently writing into default-enterprise.",
+                    "action": "Restore the user's tenancy columns and retry.",
+                },
+            },
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+        assert resp.status_code == 500
+        assert "tenancy claims" in resp.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Backwards-compatibility — legacy ``store.sync.insert(unit)`` path unchanged.
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyInsertPathPreserved:
+    def test_no_kwargs_insert_still_uses_server_defaults(
+        self, tmp_path: Path
+    ) -> None:
+        """The legacy fixture path (``store.sync.insert(unit)``) doesn't
+        carry tenancy — by design, since unit-test fixtures don't always
+        manufacture a tenant. The fix preserves that behaviour: the row
+        falls back to the schema-level defaults.
+
+        If this test fails it means the #89 fix accidentally broke the
+        zero-arg insert path; existing tenancy_columns + sqlite_store
+        tests would fire immediately. Pinning here makes the contract
+        explicit.
+        """
+        from cq.models import Insight, create_knowledge_unit
+
+        from cq_server.migrations import run_migrations
+        from cq_server.store import SqliteStore
+
+        db = tmp_path / "legacy.db"
+        run_migrations(f"sqlite:///{db}")
+        store = SqliteStore(db_path=db)
+        try:
+            unit = create_knowledge_unit(
+                domains=["test-fleet"],
+                insight=Insight(
+                    summary="Legacy insert path",
+                    detail="No kwargs => server_default fills the columns.",
+                    action="Verify the fix preserves backwards compat.",
+                ),
+            )
+            store.sync.insert(unit)
+            ent, grp = _read_scope(db, unit.id)
+            assert ent == "default-enterprise"
+            assert grp == "default-group"
+        finally:
+            store.close_sync()


### PR DESCRIPTION
## Summary

Stage 2 of #108 — wires the activity-log substrate (PR #120) into every existing write-path handler, fixes the #89 default-enterprise tenancy bug, ships the #103 pending_review tier, and exposes `GET /api/v1/activity` with admin-or-self auth scoping.

Branched on top of `feat/108-activity-log-schema` (Stage 1, merged as #120).

Closes #108
Closes #103
Closes #89

## Workstreams

### A — Instrumentation (#108)

New `cq_server/activity_logger.py` wraps `store.append_activity` for FastAPI BackgroundTasks. Every failure swallowed with a logged warning — the audit log is fire-and-forget by design. Wired into nine handlers:

| Handler | event_type | thread_or_chain_id |
|---|---|---|
| `GET /query` | `query` | — |
| `POST /propose` | `propose` | — |
| `POST /confirm/{id}` | `confirm` | — |
| `POST /flag/{id}` | `flag` | — |
| `POST /review/{id}/approve` | `review_resolve` | ku_id |
| `POST /review/{id}/reject` | `review_resolve` | ku_id |
| `POST /consults/request` | `consult_open` | thread_id |
| `POST /consults/{id}/messages` | `consult_reply` | thread_id |
| `POST /consults/{id}/close` | `consult_close` | thread_id |

Caller tenancy is resolved from the user row at task-execution time (not request time) so the response path stays off the audit DB.

### C — #89 default-enterprise tenancy fix

Bug: every KU proposed via `POST /propose` landed at `enterprise_id='default-enterprise'` regardless of the L2's configured Enterprise (surfaced during moscowmul3 onboarding 2026-05-05). Root cause: `INSERT_UNIT` omitted the tenancy columns and let the schema-level `server_default` populate them.

Fix:
- New `INSERT_UNIT_WITH_TENANCY` query writes enterprise_id + group_id explicitly. `INSERT_UNIT` keeps its 4-column shape for legacy fixture callers.
- `store.insert(...)` and `_insert_sync` accept `enterprise_id`/`group_id` kwargs.
- `propose_unit` resolves tenancy from the authenticated user row and passes it through. Defensive 500 if the user row is somehow missing tenancy — never silently writes into the default.

Regression test is verbatim the bug-report repro shape: seed user with `enterprise_id=moscowmul3`, propose via API key, `SELECT enterprise_id FROM knowledge_units` → assert `moscowmul3`.

### B — pending_review tier (#103)

Hard-finding queue for VIBE√-flagged candidates from reflect. Done **after** workstream C so submissions honour real tenancy from the start.

- Migration 0012 adds `pending_review_reason` + `pending_review_expires_at` columns.
- `status` column gains `pending_review` and `dropped` values. Used `status` instead of `tier` because the cq SDK `Tier` enum is PyPI-pinned (`cq-sdk~=0.9.1`); the status column is already the L2's lifecycle marker.
- Store helpers: `submit_pending_review`, `list_pending_review`, `count_pending_review`, `expire_pending_reviews` (TTL sweeper).
- New `GET /review/pending-review` admin endpoint, sorted by expiry ascending.
- `POST /review/{id}/reject` from a `pending_review` row transitions to `status='dropped'` — terminal, distinct from regular `rejected`. Approve still goes to `approved`.
- TTL sweeper is a callable helper; startup-loop wiring deferred to a follow-up so the helper can be exercised first.

### D — `GET /api/v1/activity`

New `cq_server/activity_routes.py` reads from the activity log with **admin-or-self** scoping:

- **Admin** caller: reads any persona within their Enterprise; honours `persona=` filter as-sent.
- **Non-admin** caller: silently scoped to their own persona. `persona=alice` while authed as bob → bob's events. No 403, no leak.
- Cross-Enterprise visibility impossible by construction (route always pins `tenant_enterprise` to caller's user-row enterprise).
- Filters: `persona`, `since`, `until`, `event_type`, AND-composed. Malformed ts → 422; unknown event_type → 422.
- Cursor pagination on `(ts DESC, id DESC)` via opaque `ts|id` cursor.
- Both JWT and API key bearer shapes accepted (PR #99's `get_current_user` carries through).

## Test plan

Backend suite went from 590 → 625 passing (35 new tests, same 5 pre-existing skips).

- [x] `tests/test_propose_tenancy_regression.py` — 5 tests pinning #89 fix
- [x] `tests/test_activity_log_instrumentation.py` — 8 tests covering every instrumented handler + failure-mode pin
- [x] `tests/test_pending_review_tier.py` — 11 tests covering state machine + route layer + migration upgrade/downgrade
- [x] `tests/test_activity_read_endpoint.py` — 11 tests covering auth, tenancy, filters, cursor pagination, API-key auth

Lint clean on all changed source files (`ruff check`).

## Manual smoke-test summary

End-to-end via `TestClient(app)` with full lifespan (Alembic + store init + AIGRP bootstrap + DSN cache + reputation publish loops). All instrumented handlers exercised in `test_activity_log_instrumentation.py`'s consult-lifecycle test (open → reply → close) which goes through three separate request/response cycles with BackgroundTasks executing between them. Activity rows verified on-disk via direct sqlite3 inspection (bypasses the store entirely so the test pins the SQL row, not the helper output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)