### PR TITLE
fix(crosstalk-mcp): lazy npm install on first cold-cache boot

### DIFF
--- a/plugins/cq/.claude-plugin/plugin.json
+++ b/plugins/cq/.claude-plugin/plugin.json
@@ -20,7 +20,7 @@
     },
     "crosstalk": {
       "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/crosstalk-mcp/src/server-l2-only.js"]
+      "args": ["${CLAUDE_PLUGIN_ROOT}/crosstalk-mcp/src/bootstrap.js"]
     }
   }
 }

--- a/plugins/cq/crosstalk-mcp/src/bootstrap.js
+++ b/plugins/cq/crosstalk-mcp/src/bootstrap.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * crosstalk-mcp bootstrap — closes the npm-install gap on first use.
+ *
+ * Claude Code's plugin loader does NOT run `npm install` for plugin MCP
+ * servers (per #127). Without dependencies, server-l2-only.js fails its
+ * top-level imports and the MCP fails to attach. Operators currently work
+ * around this with a manual `npm install` between `/plugin install 8l-cq`
+ * and the next session bounce — a hidden step that breaks the otherwise
+ * one-command onboarding flow.
+ *
+ * This shim:
+ *   1. Checks if node_modules exists alongside package.json.
+ *   2. If not, runs `npm install --omit=dev --no-audit --no-fund` once,
+ *      streaming output to stderr so the operator can see progress.
+ *   3. Dynamically imports the real server entry point.
+ *
+ * The install runs synchronously (spawnSync) and only on the cold-cache
+ * path. Once node_modules exists, this shim adds <5ms of overhead.
+ */
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pkgDir = resolve(__dirname, "..");
+const nodeModulesDir = resolve(pkgDir, "node_modules");
+
+if (!existsSync(nodeModulesDir)) {
+  process.stderr.write(
+    "crosstalk-mcp: node_modules missing, running `npm install` (one-time, ~30s)...\n",
+  );
+  const result = spawnSync(
+    "npm",
+    ["install", "--omit=dev", "--no-audit", "--no-fund"],
+    {
+      cwd: pkgDir,
+      stdio: ["ignore", "inherit", "inherit"],
+      env: process.env,
+    },
+  );
+  if (result.status !== 0) {
+    process.stderr.write(
+      `crosstalk-mcp: npm install failed (exit ${result.status}). ` +
+        "Falling back to manual install: `cd " +
+        pkgDir +
+        " && npm install`\n",
+    );
+    process.exit(1);
+  }
+  process.stderr.write("crosstalk-mcp: npm install OK, starting server\n");
+}
+
+await import("./server-l2-only.js");


### PR DESCRIPTION
Closes #127

## Summary

- New entry point `src/bootstrap.js` checks `node_modules` at startup. Missing → runs `npm install --omit=dev --no-audit --no-fund` once, streaming output to stderr, then dynamically imports `server-l2-only.js`.
- `plugin.json` updated to point at `bootstrap.js` instead of `server-l2-only.js`.
- Removes the manual `npm install` step that mu2 retry surfaced as a hidden gap between `/plugin install 8l-cq` and the first session bounce.

## Why

Claude Code's plugin loader does NOT run `npm install` for plugin-bundled MCP servers. Without deps, `server-l2-only.js` fails at top-level imports and the MCP fails to attach. claude-mux's mu2 retry pass (2026-05-07) called this out as an onboarding blocker.

The shim runs synchronously on the cold-cache path. Once `node_modules` exists, overhead drops to one `existsSync` + dynamic import (<5ms in practice).

## Test plan

- [x] **Cold cache** — `rm -rf node_modules && node src/bootstrap.js`. Bootstrap detects missing deps, runs npm install (130 packages), then prints the server's "connecting to (unconfigured)" readiness signal.
- [x] **Warm cache** — re-run without removing node_modules. Bootstrap skips install, server boots directly.
- [x] **Failure path** — npm install non-zero exit prints recovery hint pointing the operator at manual install.

## Notes

- Uses `spawnSync` rather than async because MCP stdio handshake hasn't started yet — blocking is fine.
- `--omit=dev --no-audit --no-fund` keeps the install path minimal and quiet.
- A future refinement could surface progress to the agent (via JSON-RPC notifications) instead of stderr, but stderr is what claude-mux drop wizard reads anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)