### PR TITLE
chore(ci): ruff lint cleanup + detect-secrets baseline (#152)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,242 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "(pnpm-lock\\.yaml|uv\\.lock)$"
+      ]
+    }
+  ],
+  "results": {
+    "server/backend/src/cq_server/activity.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "server/backend/src/cq_server/activity.py",
+        "hashed_secret": "3ea6cf17f95e272933a3b927317b7210d1bac5d5",
+        "is_verified": false,
+        "line_number": 64
+      }
+    ],
+    "server/backend/src/cq_server/reflect.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "server/backend/src/cq_server/reflect.py",
+        "hashed_secret": "3ea6cf17f95e272933a3b927317b7210d1bac5d5",
+        "is_verified": false,
+        "line_number": 152
+      }
+    ],
+    "server/backend/tests/test_activity_log_instrumentation.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "server/backend/tests/test_activity_log_instrumentation.py",
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_verified": false,
+        "line_number": 133
+      }
+    ],
+    "server/backend/tests/test_activity_read_endpoint.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "server/backend/tests/test_activity_read_endpoint.py",
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_verified": false,
+        "line_number": 109
+      }
+    ],
+    "server/backend/tests/test_auto_approve_propose.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "server/backend/tests/test_auto_approve_propose.py",
+        "hashed_secret": "47cd6a7b491d6b2ca5ec3fa30143e0ece5cb8968",
+        "is_verified": false,
+        "line_number": 59
+      }
+    ],
+    "server/backend/tests/test_consents_revoke.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "server/backend/tests/test_consents_revoke.py",
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_verified": false,
+        "line_number": 44
+      }
+    ],
+    "server/backend/tests/test_consents_sign.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "server/backend/tests/test_consents_sign.py",
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_verified": false,
+        "line_number": 44
+      }
+    ],
+    "server/backend/tests/test_crosstalk_routes.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "server/backend/tests/test_crosstalk_routes.py",
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_verified": false,
+        "line_number": 73
+      }
+    ],
+    "server/backend/tests/test_pending_review_concurrency.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "server/backend/tests/test_pending_review_concurrency.py",
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_verified": false,
+        "line_number": 162
+      }
+    ],
+    "server/backend/tests/test_pending_review_tier.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "server/backend/tests/test_pending_review_tier.py",
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_verified": false,
+        "line_number": 221
+      }
+    ],
+    "server/backend/tests/test_pending_review_ttl.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "server/backend/tests/test_pending_review_ttl.py",
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_verified": false,
+        "line_number": 198
+      }
+    ],
+    "server/backend/tests/test_propose_tenancy_regression.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "server/backend/tests/test_propose_tenancy_regression.py",
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_verified": false,
+        "line_number": 133
+      }
+    ]
+  },
+  "generated_at": "2026-05-09T00:58:24Z"
+}

--- a/server/backend/alembic/versions/0001_phase6_step1_additive_tenancy_columns.py
+++ b/server/backend/alembic/versions/0001_phase6_step1_additive_tenancy_columns.py
@@ -100,15 +100,12 @@ def _add_tenancy_columns(table_name: str) -> None:
     # leaves pre-existing rows NULL. Postgres backfills automatically
     # but the UPDATE is a no-op in that case.
     op.execute(
-        sa.text(
-            f"UPDATE {table_name} SET enterprise_id = :ent "
-            "WHERE enterprise_id IS NULL"
-        ).bindparams(ent=DEFAULT_ENTERPRISE_ID)
+        sa.text(f"UPDATE {table_name} SET enterprise_id = :ent WHERE enterprise_id IS NULL").bindparams(
+            ent=DEFAULT_ENTERPRISE_ID
+        )
     )
     op.execute(
-        sa.text(
-            f"UPDATE {table_name} SET group_id = :grp WHERE group_id IS NULL"
-        ).bindparams(grp=DEFAULT_GROUP_ID)
+        sa.text(f"UPDATE {table_name} SET group_id = :grp WHERE group_id IS NULL").bindparams(grp=DEFAULT_GROUP_ID)
     )
 
     # Promote to NOT NULL now that every row has a value.

--- a/server/backend/alembic/versions/0002_phase6_step2_xgroup_consent.py
+++ b/server/backend/alembic/versions/0002_phase6_step2_xgroup_consent.py
@@ -61,12 +61,7 @@ def upgrade() -> None:
                 ),
             )
             # Backfill — same SQLite ALTER quirk as Phase 6 step 1.
-            op.execute(
-                sa.text(
-                    "UPDATE knowledge_units SET cross_group_allowed = 0 "
-                    "WHERE cross_group_allowed IS NULL"
-                )
-            )
+            op.execute(sa.text("UPDATE knowledge_units SET cross_group_allowed = 0 WHERE cross_group_allowed IS NULL"))
             with op.batch_alter_table("knowledge_units") as batch:
                 batch.alter_column(
                     "cross_group_allowed",

--- a/server/backend/alembic/versions/0003_phase6_step3_presence.py
+++ b/server/backend/alembic/versions/0003_phase6_step3_presence.py
@@ -62,9 +62,7 @@ def upgrade() -> None:
                     server_default=sa.text("'user'"),
                 ),
             )
-            op.execute(
-                sa.text("UPDATE users SET role = 'user' WHERE role IS NULL")
-            )
+            op.execute(sa.text("UPDATE users SET role = 'user' WHERE role IS NULL"))
             with op.batch_alter_table("users") as batch:
                 batch.alter_column(
                     "role",

--- a/server/backend/alembic/versions/0008_reputation_events.py
+++ b/server/backend/alembic/versions/0008_reputation_events.py
@@ -102,10 +102,6 @@ def downgrade() -> None:
     if _table_exists(bind, "reputation_chain_meta"):
         op.drop_table("reputation_chain_meta")
     if _table_exists(bind, "reputation_events"):
-        op.drop_index(
-            "idx_reputation_events_type_ts", table_name="reputation_events"
-        )
-        op.drop_index(
-            "idx_reputation_events_enterprise_ts", table_name="reputation_events"
-        )
+        op.drop_index("idx_reputation_events_type_ts", table_name="reputation_events")
+        op.drop_index("idx_reputation_events_enterprise_ts", table_name="reputation_events")
         op.drop_table("reputation_events")

--- a/server/backend/alembic/versions/0009_reputation_roots.py
+++ b/server/backend/alembic/versions/0009_reputation_roots.py
@@ -69,7 +69,5 @@ def downgrade() -> None:
     """Drop the roots table. Used by tests; not for production."""
     bind = op.get_bind()
     if _table_exists(bind, "reputation_roots"):
-        op.drop_index(
-            "idx_reputation_roots_published", table_name="reputation_roots"
-        )
+        op.drop_index("idx_reputation_roots_published", table_name="reputation_roots")
         op.drop_table("reputation_roots")

--- a/server/backend/alembic/versions/0010_reflect_submissions.py
+++ b/server/backend/alembic/versions/0010_reflect_submissions.py
@@ -98,12 +98,8 @@ def downgrade() -> None:
     """Drop the reflect_submissions table. Used by tests; not for production."""
     bind = op.get_bind()
     if _table_exists(bind, "reflect_submissions"):
-        op.drop_index(
-            "idx_reflect_submissions_state_batch", table_name="reflect_submissions"
-        )
-        op.drop_index(
-            "idx_reflect_submissions_dedup", table_name="reflect_submissions"
-        )
+        op.drop_index("idx_reflect_submissions_state_batch", table_name="reflect_submissions")
+        op.drop_index("idx_reflect_submissions_dedup", table_name="reflect_submissions")
         op.drop_index(
             "idx_reflect_submissions_session_submitted",
             table_name="reflect_submissions",

--- a/server/backend/alembic/versions/0012_pending_review_tier.py
+++ b/server/backend/alembic/versions/0012_pending_review_tier.py
@@ -90,13 +90,9 @@ def upgrade() -> None:
     existing = _column_names(bind, "knowledge_units")
     with op.batch_alter_table("knowledge_units") as batch:
         if "pending_review_reason" not in existing:
-            batch.add_column(
-                sa.Column("pending_review_reason", sa.Text(), nullable=True)
-            )
+            batch.add_column(sa.Column("pending_review_reason", sa.Text(), nullable=True))
         if "pending_review_expires_at" not in existing:
-            batch.add_column(
-                sa.Column("pending_review_expires_at", sa.Text(), nullable=True)
-            )
+            batch.add_column(sa.Column("pending_review_expires_at", sa.Text(), nullable=True))
 
 
 def downgrade() -> None:

--- a/server/backend/alembic/versions/0013_backfill_default_enterprise_kus.py
+++ b/server/backend/alembic/versions/0013_backfill_default_enterprise_kus.py
@@ -94,9 +94,7 @@ def upgrade() -> None:
     # Step 1: pull every still-default-enterprise KU id + data blob.
     # We need data because that's where ``created_by`` lives.
     candidates = bind.exec_driver_sql(
-        "SELECT id, data FROM knowledge_units "
-        "WHERE enterprise_id = 'default-enterprise' "
-        "AND group_id = 'default-group'"
+        "SELECT id, data FROM knowledge_units WHERE enterprise_id = 'default-enterprise' AND group_id = 'default-group'"
     ).fetchall()
     if not candidates:
         return
@@ -110,9 +108,7 @@ def upgrade() -> None:
         "WHERE enterprise_id != 'default-enterprise' "
         "OR group_id != 'default-group'"
     ).fetchall()
-    user_map: dict[str, tuple[str, str]] = {
-        row[0]: (row[1], row[2]) for row in user_rows
-    }
+    user_map: dict[str, tuple[str, str]] = {row[0]: (row[1], row[2]) for row in user_rows}
     if not user_map:
         # No users with non-default tenancy => no signal to backfill on.
         return
@@ -154,8 +150,7 @@ def upgrade() -> None:
     # Surface the count in alembic output for the operator's audit log.
     # Alembic captures stdout when running migrations.
     print(  # noqa: T201 — migration audit signal, not application logging
-        f"[0013] backfilled {backfilled} of {len(candidates)} "
-        f"default-enterprise KUs to their proposer's tenancy"
+        f"[0013] backfilled {backfilled} of {len(candidates)} default-enterprise KUs to their proposer's tenancy"
     )
 
 

--- a/server/backend/src/cq_server/store/_queries.py
+++ b/server/backend/src/cq_server/store/_queries.py
@@ -283,6 +283,5 @@ UPSERT_ACTIVITY_RETENTION_DAYS: TextClause = text(
 # Enterprise. Scoped per-tenant so a slow large-tenant sweep doesn't
 # block writes on every other tenant. Uses ``idx_activity_log_tenant_ts``.
 DELETE_ACTIVITY_OLDER_THAN: TextClause = text(
-    "DELETE FROM activity_log "
-    "WHERE tenant_enterprise = :tenant_enterprise AND ts < :cutoff_iso"
+    "DELETE FROM activity_log WHERE tenant_enterprise = :tenant_enterprise AND ts < :cutoff_iso"
 )

--- a/server/backend/src/cq_server/store/_sqlite.py
+++ b/server/backend/src/cq_server/store/_sqlite.py
@@ -96,6 +96,7 @@ class SqliteStore:
             return
         self._closed = True
         self._engine.dispose()
+
     @property
     def _lock(self):  # type: ignore[no-untyped-def]
         """Compat shim: legacy callers used ``with store._lock:`` to serialise.
@@ -122,7 +123,6 @@ class SqliteStore:
             self._compat_conn = self._engine.raw_connection()
         return self._compat_conn
 
-
     @property
     def sync(self) -> _SyncStoreProxy:
         """Sync proxy for callers not in an async context.
@@ -134,9 +134,7 @@ class SqliteStore:
         """
         return _SyncStoreProxy(self)
 
-    async def confidence_distribution(
-        self, *, enterprise_id: str | None = None
-    ) -> dict[str, int]:
+    async def confidence_distribution(self, *, enterprise_id: str | None = None) -> dict[str, int]:
         return await self._run_sync(self._confidence_distribution_sync)
 
     async def count(self) -> int:
@@ -145,14 +143,10 @@ class SqliteStore:
     async def count_active_api_keys_for_user(self, user_id: int) -> int:
         return await self._run_sync(self._count_active_api_keys_for_user_sync, user_id)
 
-    async def counts_by_status(
-        self, *, enterprise_id: str | None = None
-    ) -> dict[str, int]:
+    async def counts_by_status(self, *, enterprise_id: str | None = None) -> dict[str, int]:
         return await self._run_sync(self._counts_by_status_sync, enterprise_id=enterprise_id)
 
-    async def counts_by_tier(
-        self, *, enterprise_id: str | None = None
-    ) -> dict[str, int]:
+    async def counts_by_tier(self, *, enterprise_id: str | None = None) -> dict[str, int]:
         return await self._run_sync(self._counts_by_tier_sync)
 
     async def create_api_key(
@@ -182,16 +176,12 @@ class SqliteStore:
     async def create_user(self, username: str, password_hash: str) -> None:
         await self._run_sync(self._create_user_sync, username, password_hash)
 
-    async def daily_counts(
-        self, *, days: int = 30, enterprise_id: str | None = None
-    ) -> list[dict[str, Any]]:
+    async def daily_counts(self, *, days: int = 30, enterprise_id: str | None = None) -> list[dict[str, Any]]:
         if days <= 0:
             raise ValueError("days must be positive")
         return await self._run_sync(self._daily_counts_sync, days=days)
 
-    async def domain_counts(
-        self, *, enterprise_id: str | None = None
-    ) -> dict[str, int]:
+    async def domain_counts(self, *, enterprise_id: str | None = None) -> dict[str, int]:
         return await self._run_sync(self._domain_counts_sync)
 
     async def get(self, unit_id: str) -> KnowledgeUnit | None:
@@ -200,9 +190,7 @@ class SqliteStore:
     async def get_active_api_key_by_id(self, key_id: str) -> dict[str, Any] | None:
         return await self._run_sync(self._get_active_api_key_by_id_sync, key_id)
 
-    async def get_any(
-        self, unit_id: str, *, enterprise_id: str | None = None
-    ) -> KnowledgeUnit | None:
+    async def get_any(self, unit_id: str, *, enterprise_id: str | None = None) -> KnowledgeUnit | None:
         return await self._run_sync(self._get_any_sync, unit_id, enterprise_id=enterprise_id)
 
     async def get_api_key_for_user(self, *, user_id: int, key_id: str) -> dict[str, Any] | None:
@@ -269,9 +257,7 @@ class SqliteStore:
             limit=limit,
         )
 
-    async def pending_count(
-        self, *, enterprise_id: str | None = None
-    ) -> int:
+    async def pending_count(self, *, enterprise_id: str | None = None) -> int:
         return await self._run_sync(self._pending_count_sync, enterprise_id=enterprise_id)
 
     async def pending_queue(
@@ -281,9 +267,7 @@ class SqliteStore:
         offset: int = 0,
         enterprise_id: str | None = None,
     ) -> list[dict[str, Any]]:
-        return await self._run_sync(
-            self._pending_queue_sync, limit=limit, offset=offset, enterprise_id=enterprise_id
-        )
+        return await self._run_sync(self._pending_queue_sync, limit=limit, offset=offset, enterprise_id=enterprise_id)
 
     async def query(
         self,
@@ -307,9 +291,7 @@ class SqliteStore:
             group_id=group_id,
         )
 
-    async def recent_activity(
-        self, limit: int = 20, *, enterprise_id: str | None = None
-    ) -> list[dict[str, Any]]:
+    async def recent_activity(self, limit: int = 20, *, enterprise_id: str | None = None) -> list[dict[str, Any]]:
         return await self._run_sync(self._recent_activity_sync, limit=limit)
 
     async def revoke_api_key(self, *, user_id: int, key_id: str) -> bool:
@@ -388,13 +370,9 @@ class SqliteStore:
 
     async def count_pending_review(self, *, enterprise_id: str) -> int:
         """Return the size of the pending_review queue for one tenant."""
-        return await self._run_sync(
-            self._count_pending_review_sync, enterprise_id=enterprise_id
-        )
+        return await self._run_sync(self._count_pending_review_sync, enterprise_id=enterprise_id)
 
-    async def expire_pending_reviews(
-        self, *, enterprise_id: str, now_iso: str
-    ) -> list[str]:
+    async def expire_pending_reviews(self, *, enterprise_id: str, now_iso: str) -> list[str]:
         """Sweep expired pending_review rows for one tenant.
 
         Transitions every row with ``status='pending_review'`` AND
@@ -610,7 +588,11 @@ class SqliteStore:
         )
 
     async def semantic_query_with_scope(
-        self, query_vec: list[float], *, limit: int = 10, status: str = "approved",
+        self,
+        query_vec: list[float],
+        *,
+        limit: int = 10,
+        status: str = "approved",
     ) -> list[dict[str, Any]]:
         """Cosine-rank approved KUs returning scope + xgroup flag per row.
 
@@ -619,7 +601,9 @@ class SqliteStore:
         """
         return await self._run_sync(
             self._semantic_query_with_scope_sync,
-            query_vec=query_vec, limit=limit, status=status,
+            query_vec=query_vec,
+            limit=limit,
+            status=status,
         )
 
     async def delete(
@@ -947,10 +931,7 @@ class SqliteStore:
         from ..activity import EVENT_TYPES
 
         if event_type not in EVENT_TYPES:
-            raise ValueError(
-                f"unknown activity event_type {event_type!r}; "
-                f"expected one of {sorted(EVENT_TYPES)}"
-            )
+            raise ValueError(f"unknown activity event_type {event_type!r}; expected one of {sorted(EVENT_TYPES)}")
         await self._run_sync(
             self._append_activity_sync,
             activity_id=activity_id,
@@ -965,9 +946,7 @@ class SqliteStore:
             thread_or_chain_id=thread_or_chain_id,
         )
 
-    async def get_activity_retention_days(
-        self, *, enterprise_id: str
-    ) -> int:
+    async def get_activity_retention_days(self, *, enterprise_id: str) -> int:
         """Return the configured retention window for an Enterprise.
 
         Falls back to ``DEFAULT_RETENTION_DAYS`` (90) when no override
@@ -979,9 +958,7 @@ class SqliteStore:
             enterprise_id=enterprise_id,
         )
 
-    async def set_activity_retention_days(
-        self, *, enterprise_id: str, retention_days: int
-    ) -> None:
+    async def set_activity_retention_days(self, *, enterprise_id: str, retention_days: int) -> None:
         """Upsert the retention window for one Enterprise."""
         if retention_days <= 0:
             raise ValueError("retention_days must be positive")
@@ -991,9 +968,7 @@ class SqliteStore:
             retention_days=retention_days,
         )
 
-    async def purge_activity_older_than(
-        self, *, tenant_enterprise: str, cutoff_iso: str
-    ) -> int:
+    async def purge_activity_older_than(self, *, tenant_enterprise: str, cutoff_iso: str) -> int:
         """Delete activity rows for one tenant older than ``cutoff_iso``.
 
         Returns the number of deleted rows so the cron can log
@@ -1108,9 +1083,7 @@ class SqliteStore:
             group_id=group_id,
         )
 
-    async def get_crosstalk_thread(
-        self, *, thread_id: str, tenant_enterprise: str
-    ) -> dict[str, Any] | None:
+    async def get_crosstalk_thread(self, *, thread_id: str, tenant_enterprise: str) -> dict[str, Any] | None:
         """Fetch one thread row by id, tenancy-scoped.
 
         Returns ``None`` when the thread doesn't exist OR exists in a
@@ -1240,12 +1213,8 @@ class SqliteStore:
             submitted_at=submitted_at,
         )
 
-    async def get_reflect_submission(
-        self, submission_id: str
-    ) -> dict[str, Any] | None:
-        return await self._run_sync(
-            self._get_reflect_submission_sync, submission_id
-        )
+    async def get_reflect_submission(self, submission_id: str) -> dict[str, Any] | None:
+        return await self._run_sync(self._get_reflect_submission_sync, submission_id)
 
     async def find_recent_reflect_dedup(
         self,
@@ -1299,9 +1268,7 @@ class SqliteStore:
             enterprise_id=enterprise_id,
         )
 
-    async def list_reflect_submissions_for_recovery(
-        self, *, lookback_iso: str
-    ) -> list[dict[str, Any]]:
+    async def list_reflect_submissions_for_recovery(self, *, lookback_iso: str) -> list[dict[str, Any]]:
         """Return non-terminal submissions with non-null ``anthropic_batch_id`` newer than ``lookback_iso``.
 
         Used by the worker's R6 startup recovery scan; not exercised by
@@ -1519,8 +1486,7 @@ class SqliteStore:
         with self._engine.connect() as conn:
             if enterprise_id is not None:
                 row = conn.exec_driver_sql(
-                    "SELECT status, reviewed_by, reviewed_at FROM knowledge_units "
-                    "WHERE id = ? AND enterprise_id = ?",
+                    "SELECT status, reviewed_by, reviewed_at FROM knowledge_units WHERE id = ? AND enterprise_id = ?",
                     (unit_id, enterprise_id),
                 ).fetchone()
             else:
@@ -1615,10 +1581,7 @@ class SqliteStore:
                     conn.execute(INSERT_UNIT_DOMAIN, {"unit_id": unit.id, "domain": d})
                 if embedding is not None and embedding_model is not None:
                     conn.execute(
-                        text(
-                            "UPDATE knowledge_units SET embedding = :emb, "
-                            "embedding_model = :model WHERE id = :id"
-                        ),
+                        text("UPDATE knowledge_units SET embedding = :emb, embedding_model = :model WHERE id = :id"),
                         {"emb": embedding, "model": embedding_model, "id": unit.id},
                     )
         except IntegrityError as e:
@@ -1712,7 +1675,8 @@ class SqliteStore:
                     conn.exec_driver_sql(
                         "SELECT COUNT(*) FROM knowledge_units WHERE status = 'pending' AND enterprise_id = ?",
                         (enterprise_id,),
-                    ).scalar() or 0
+                    ).scalar()
+                    or 0
                 )
             return int(conn.execute(SELECT_PENDING_COUNT).scalar() or 0)
 
@@ -1984,12 +1948,11 @@ class SqliteStore:
                     "AND (pending_review_expires_at IS NULL "
                     "     OR pending_review_expires_at > ?)",
                     (enterprise_id, now_iso),
-                ).scalar() or 0
+                ).scalar()
+                or 0
             )
 
-    def _expire_pending_reviews_sync(
-        self, *, enterprise_id: str, now_iso: str
-    ) -> list[str]:
+    def _expire_pending_reviews_sync(self, *, enterprise_id: str, now_iso: str) -> list[str]:
         """Two-step sweep: SELECT the row ids first, then UPDATE.
 
         We return the ids so the caller can emit one ``review_resolve``
@@ -2852,7 +2815,11 @@ class SqliteStore:
         return scored[:limit]
 
     def _semantic_query_with_scope_sync(
-        self, *, query_vec: list[float], limit: int, status: str,
+        self,
+        *,
+        query_vec: list[float],
+        limit: int,
+        status: str,
     ) -> list[dict[str, Any]]:
         import numpy as np
 
@@ -3054,9 +3021,7 @@ class SqliteStore:
         from ._queries import INSERT_ACTIVITY_LOG
 
         payload_json = json.dumps(payload if payload is not None else {})
-        result_json = (
-            None if result_summary is None else json.dumps(result_summary)
-        )
+        result_json = None if result_summary is None else json.dumps(result_summary)
         with self._engine.begin() as conn:
             conn.execute(
                 INSERT_ACTIVITY_LOG,
@@ -3074,9 +3039,7 @@ class SqliteStore:
                 },
             )
 
-    def _get_activity_retention_days_sync(
-        self, *, enterprise_id: str
-    ) -> int:
+    def _get_activity_retention_days_sync(self, *, enterprise_id: str) -> int:
         from ..activity import DEFAULT_RETENTION_DAYS
         from ._queries import SELECT_ACTIVITY_RETENTION_DAYS
 
@@ -3089,9 +3052,7 @@ class SqliteStore:
             return DEFAULT_RETENTION_DAYS
         return int(row[0])
 
-    def _set_activity_retention_days_sync(
-        self, *, enterprise_id: str, retention_days: int
-    ) -> None:
+    def _set_activity_retention_days_sync(self, *, enterprise_id: str, retention_days: int) -> None:
         from ._queries import UPSERT_ACTIVITY_RETENTION_DAYS
 
         updated_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
@@ -3105,9 +3066,7 @@ class SqliteStore:
                 },
             )
 
-    def _purge_activity_older_than_sync(
-        self, *, tenant_enterprise: str, cutoff_iso: str
-    ) -> int:
+    def _purge_activity_older_than_sync(self, *, tenant_enterprise: str, cutoff_iso: str) -> int:
         from ._queries import DELETE_ACTIVITY_OLDER_THAN
 
         with self._engine.begin() as conn:
@@ -3187,9 +3146,7 @@ class SqliteStore:
             except (TypeError, ValueError):
                 payload = {}
             try:
-                result_summary = (
-                    json.loads(result_raw) if result_raw is not None else None
-                )
+                result_summary = json.loads(result_raw) if result_raw is not None else None
             except (TypeError, ValueError):
                 result_summary = None
             results.append(
@@ -3277,9 +3234,7 @@ class SqliteStore:
                 },
             )
 
-    def _get_crosstalk_thread_sync(
-        self, *, thread_id: str, tenant_enterprise: str
-    ) -> dict[str, Any] | None:
+    def _get_crosstalk_thread_sync(self, *, thread_id: str, tenant_enterprise: str) -> dict[str, Any] | None:
         with self._engine.connect() as conn:
             row = conn.execute(
                 text(
@@ -3565,15 +3520,10 @@ class SqliteStore:
                 },
             )
 
-    def _get_reflect_submission_sync(
-        self, submission_id: str
-    ) -> dict[str, Any] | None:
+    def _get_reflect_submission_sync(self, submission_id: str) -> dict[str, Any] | None:
         with self._engine.connect() as conn:
             row = conn.execute(
-                text(
-                    f"SELECT {self._REFLECT_COLUMNS} FROM reflect_submissions "
-                    "WHERE id = :id"
-                ),
+                text(f"SELECT {self._REFLECT_COLUMNS} FROM reflect_submissions WHERE id = :id"),
                 {"id": submission_id},
             ).fetchone()
         return None if row is None else self._reflect_row_to_dict(row)
@@ -3605,10 +3555,7 @@ class SqliteStore:
     ) -> int:
         with self._engine.connect() as conn:
             row = conn.execute(
-                text(
-                    "SELECT COUNT(*) FROM reflect_submissions "
-                    "WHERE session_id = :sid AND submitted_at >= :since"
-                ),
+                text("SELECT COUNT(*) FROM reflect_submissions WHERE session_id = :sid AND submitted_at >= :since"),
                 {"sid": session_id, "since": window_start_iso},
             ).fetchone()
         return int(row[0]) if row is not None else 0
@@ -3647,9 +3594,7 @@ class SqliteStore:
             ).fetchone()
         return None if row is None else self._reflect_row_to_dict(row)
 
-    def _list_reflect_submissions_for_recovery_sync(
-        self, *, lookback_iso: str
-    ) -> list[dict[str, Any]]:
+    def _list_reflect_submissions_for_recovery_sync(self, *, lookback_iso: str) -> list[dict[str, Any]]:
         with self._engine.connect() as conn:
             rows = conn.execute(
                 text(

--- a/server/backend/tests/test_activity_log_instrumentation.py
+++ b/server/backend/tests/test_activity_log_instrumentation.py
@@ -129,9 +129,7 @@ def _propose_one(client: TestClient, api_key: str) -> str:
 
 
 class TestProposeLogs:
-    def test_propose_writes_activity_row(
-        self, client: TestClient, tmp_path: Path
-    ) -> None:
+    def test_propose_writes_activity_row(self, client: TestClient, tmp_path: Path) -> None:
         _seed_user(username="proposer", password="pw")
         api_key = _mint_api_key(client, _login_jwt(client, "proposer", "pw"))
         ku_id = _propose_one(client, api_key)
@@ -156,9 +154,7 @@ class TestProposeLogs:
 
 
 class TestQueryLogs:
-    def test_query_writes_activity_row_with_result_summary(
-        self, client: TestClient, tmp_path: Path
-    ) -> None:
+    def test_query_writes_activity_row_with_result_summary(self, client: TestClient, tmp_path: Path) -> None:
         _seed_user(username="querier", password="pw")
         api_key = _mint_api_key(client, _login_jwt(client, "querier", "pw"))
         ku_id = _propose_one(client, api_key)
@@ -190,9 +186,7 @@ class TestQueryLogs:
 
 
 class TestConfirmFlagLogs:
-    def test_confirm_writes_activity_row(
-        self, client: TestClient, tmp_path: Path
-    ) -> None:
+    def test_confirm_writes_activity_row(self, client: TestClient, tmp_path: Path) -> None:
         _seed_user(username="confirmer", password="pw")
         api_key = _mint_api_key(client, _login_jwt(client, "confirmer", "pw"))
         ku_id = _propose_one(client, api_key)
@@ -213,9 +207,7 @@ class TestConfirmFlagLogs:
 
         assert _json.loads(confirm_rows[0]["payload"])["ku_id"] == ku_id
 
-    def test_flag_writes_activity_row_with_reason(
-        self, client: TestClient, tmp_path: Path
-    ) -> None:
+    def test_flag_writes_activity_row_with_reason(self, client: TestClient, tmp_path: Path) -> None:
         _seed_user(username="flagger", password="pw")
         api_key = _mint_api_key(client, _login_jwt(client, "flagger", "pw"))
         ku_id = _propose_one(client, api_key)
@@ -240,9 +232,7 @@ class TestConfirmFlagLogs:
 
 
 class TestReviewLogs:
-    def test_approve_writes_review_resolve_row(
-        self, client: TestClient, tmp_path: Path
-    ) -> None:
+    def test_approve_writes_review_resolve_row(self, client: TestClient, tmp_path: Path) -> None:
         _seed_user(username="proposer2", password="pw")
         _seed_user(username="admin1", password="pw", role="admin")
 
@@ -267,9 +257,7 @@ class TestReviewLogs:
         assert rr[0]["thread_or_chain_id"] == ku_id  # correlates to the KU
         assert rr[0]["persona"] == "admin1"
 
-    def test_reject_writes_review_resolve_row(
-        self, client: TestClient, tmp_path: Path
-    ) -> None:
+    def test_reject_writes_review_resolve_row(self, client: TestClient, tmp_path: Path) -> None:
         _seed_user(username="proposer3", password="pw")
         _seed_user(username="admin2", password="pw", role="admin")
 
@@ -293,9 +281,7 @@ class TestReviewLogs:
 
 
 class TestConsultLogs:
-    def test_consult_lifecycle_writes_open_reply_close(
-        self, client: TestClient, tmp_path: Path
-    ) -> None:
+    def test_consult_lifecycle_writes_open_reply_close(self, client: TestClient, tmp_path: Path) -> None:
         _seed_user(username="alice2", password="pw")
         _seed_user(username="bob2", password="pw")
         alice_jwt = _login_jwt(client, "alice2", "pw")

--- a/server/backend/tests/test_activity_read_endpoint.py
+++ b/server/backend/tests/test_activity_read_endpoint.py
@@ -103,9 +103,7 @@ class TestAuthAndScoping:
         resp = client.get("/api/v1/activity")
         assert resp.status_code == 401
 
-    def test_admin_sees_every_persona_in_their_enterprise(
-        self, client: TestClient
-    ) -> None:
+    def test_admin_sees_every_persona_in_their_enterprise(self, client: TestClient) -> None:
         import asyncio
 
         _seed_user(username="alice3", password="pw")

--- a/server/backend/tests/test_admin_delete.py
+++ b/server/backend/tests/test_admin_delete.py
@@ -1,4 +1,5 @@
 """Tests for the admin DELETE /review/{ku_id} endpoint."""
+
 from __future__ import annotations
 
 from collections.abc import Iterator
@@ -46,14 +47,14 @@ def _propose_payload(**overrides: Any) -> dict[str, Any]:
 
 def _admin_jwt(client: TestClient) -> str:
     """Bootstrap an admin user + return a JWT for /review/* endpoints."""
+    import contextlib
+
     from cq_server.app import _get_store
 
     store = _get_store()
     pw_hash = bcrypt.hashpw(b"admin", bcrypt.gensalt()).decode()
-    try:
-        store.sync.create_user("admin", pw_hash)
-    except Exception:
-        pass  # already exists
+    with contextlib.suppress(Exception):
+        store.sync.create_user("admin", pw_hash)  # already exists is OK
     store.sync.set_user_role("admin", "admin")
     resp = client.post("/auth/login", json={"username": "admin", "password": "admin"})
     assert resp.status_code == 200, resp.text

--- a/server/backend/tests/test_app.py
+++ b/server/backend/tests/test_app.py
@@ -140,21 +140,25 @@ class TestPropose:
         assert "placeholder" in resp.json()["detail"].lower()
 
     def test_propose_with_placeholder_summary_rejected(self, client: TestClient) -> None:
-        payload = _propose_payload(insight={
-            "summary": "test",
-            "detail": "this is a long enough detail that it would normally pass length checks",
-            "action": "do the thing",
-        })
+        payload = _propose_payload(
+            insight={
+                "summary": "test",
+                "detail": "this is a long enough detail that it would normally pass length checks",
+                "action": "do the thing",
+            }
+        )
         resp = client.post("/propose", json=payload)
         assert resp.status_code == 422
         assert "placeholder" in resp.json()["detail"].lower()
 
     def test_propose_with_summary_eq_detail_rejected(self, client: TestClient) -> None:
-        payload = _propose_payload(insight={
-            "summary": "Connections are expensive to create at request time",
-            "detail": "Connections are expensive to create at request time",
-            "action": "Use a connection pool with max size 10.",
-        })
+        payload = _propose_payload(
+            insight={
+                "summary": "Connections are expensive to create at request time",
+                "detail": "Connections are expensive to create at request time",
+                "action": "Use a connection pool with max size 10.",
+            }
+        )
         resp = client.post("/propose", json=payload)
         assert resp.status_code == 422
 
@@ -269,8 +273,7 @@ class TestQueryTenantScope:
         store = _get_store()
         with store._engine.begin() as _c:
             _c.exec_driver_sql(
-                "UPDATE knowledge_units SET enterprise_id = ?, group_id = ?, "
-                "cross_group_allowed = ? WHERE id = ?",
+                "UPDATE knowledge_units SET enterprise_id = ?, group_id = ?, cross_group_allowed = ? WHERE id = ?",
                 (enterprise_id, group_id, 1 if cross_group_allowed else 0, unit_id),
             )
 
@@ -315,9 +318,7 @@ class TestQueryTenantScope:
         blocked = self._seed_unit(client, domains=["xgroup-test"])
         allowed = self._seed_unit(client, domains=["xgroup-test"])
         self._set_ku_tenancy(blocked["id"], enterprise_id="acme", group_id="finance")
-        self._set_ku_tenancy(
-            allowed["id"], enterprise_id="acme", group_id="finance", cross_group_allowed=True
-        )
+        self._set_ku_tenancy(allowed["id"], enterprise_id="acme", group_id="finance", cross_group_allowed=True)
         self._set_user_tenancy(TEST_USERNAME, enterprise_id="acme", group_id="engineering")
         resp = client.get("/query", params={"domains": ["xgroup-test"]})
         assert resp.status_code == 200

--- a/server/backend/tests/test_auto_approve_propose.py
+++ b/server/backend/tests/test_auto_approve_propose.py
@@ -100,9 +100,7 @@ def _read_status(unit_id: str) -> str:
 
     conn = sqlite3.connect(os.environ["CQ_DB_PATH"])
     try:
-        row = conn.execute(
-            "SELECT status FROM knowledge_units WHERE id = ?", (unit_id,)
-        ).fetchone()
+        row = conn.execute("SELECT status FROM knowledge_units WHERE id = ?", (unit_id,)).fetchone()
         assert row is not None, f"unit {unit_id} not found"
         return row[0]
     finally:

--- a/server/backend/tests/test_bloom_prefilter.py
+++ b/server/backend/tests/test_bloom_prefilter.py
@@ -155,18 +155,18 @@ def _stub_embed(monkeypatch: pytest.MonkeyPatch, axis: int = 0, dim: int = 8) ->
 def _seed_diverse_fleet() -> list[network._L2Snapshot]:
     """6 L2s, each with a distinct domain set so the prefilter is exercised."""
     return [
-        _snap_with_bloom(slug="orion-eng", enterprise="orion", group="engineering",
-                         axis=0, domains=["cloudfront", "lambda"]),
-        _snap_with_bloom(slug="orion-sol", enterprise="orion", group="solutions",
-                         axis=1, domains=["bedrock", "titan"]),
-        _snap_with_bloom(slug="orion-gtm", enterprise="orion", group="gtm",
-                         axis=2, domains=["sales", "outbound"]),
-        _snap_with_bloom(slug="acme-eng", enterprise="acme", group="engineering",
-                         axis=3, domains=["kubernetes", "istio"]),
-        _snap_with_bloom(slug="acme-sol", enterprise="acme", group="solutions",
-                         axis=4, domains=["cloudfront", "edge", "cdn"]),
-        _snap_with_bloom(slug="acme-fin", enterprise="acme", group="finance",
-                         axis=5, domains=["sap", "quickbooks"]),
+        _snap_with_bloom(
+            slug="orion-eng", enterprise="orion", group="engineering", axis=0, domains=["cloudfront", "lambda"]
+        ),
+        _snap_with_bloom(slug="orion-sol", enterprise="orion", group="solutions", axis=1, domains=["bedrock", "titan"]),
+        _snap_with_bloom(slug="orion-gtm", enterprise="orion", group="gtm", axis=2, domains=["sales", "outbound"]),
+        _snap_with_bloom(
+            slug="acme-eng", enterprise="acme", group="engineering", axis=3, domains=["kubernetes", "istio"]
+        ),
+        _snap_with_bloom(
+            slug="acme-sol", enterprise="acme", group="solutions", axis=4, domains=["cloudfront", "edge", "cdn"]
+        ),
+        _snap_with_bloom(slug="acme-fin", enterprise="acme", group="finance", axis=5, domains=["sap", "quickbooks"]),
     ]
 
 

--- a/server/backend/tests/test_consents_revoke.py
+++ b/server/backend/tests/test_consents_revoke.py
@@ -8,6 +8,7 @@ Pins:
   - Once revoked, the consent is no longer "active" — /consents lists
     excludes it by default but include_expired=true still returns it.
 """
+
 from __future__ import annotations
 
 from collections.abc import Iterator
@@ -89,8 +90,7 @@ class TestRevokeHappyPath:
         store = _get_store()
         with store._engine.begin() as _c:
             rows = _c.exec_driver_sql(
-                "SELECT policy_applied FROM cross_l2_audit "
-                "WHERE consent_id = ? ORDER BY ts ASC",
+                "SELECT policy_applied FROM cross_l2_audit WHERE consent_id = ? ORDER BY ts ASC",
                 (cid,),
             ).fetchall()
         # One row from sign, one from revoke.

--- a/server/backend/tests/test_consents_sign.py
+++ b/server/backend/tests/test_consents_sign.py
@@ -8,6 +8,7 @@ Pins:
   - Admin-only — non-admin users get 403.
   - expires_at is honored (not echoed as the row's signed_at).
 """
+
 from __future__ import annotations
 
 from collections.abc import Iterator
@@ -91,8 +92,7 @@ class TestSignHappyPath:
         store = _get_store()
         with store._engine.begin() as _c:
             rows = _c.exec_driver_sql(
-                "SELECT policy_applied, consent_id FROM cross_l2_audit "
-                "WHERE consent_id = ?",
+                "SELECT policy_applied, consent_id FROM cross_l2_audit WHERE consent_id = ?",
                 (consent_id,),
             ).fetchall()
         assert len(rows) == 1

--- a/server/backend/tests/test_consults.py
+++ b/server/backend/tests/test_consults.py
@@ -22,9 +22,9 @@ from cq_server import network
 from cq_server.app import _get_store, app
 
 ALICE = "alice"  # acme/engineering
-BOB = "bob"      # acme/engineering — same L2 as Alice
+BOB = "bob"  # acme/engineering — same L2 as Alice
 CARLA = "carla"  # acme/solutions  — different L2 from Alice (cross-team)
-DAN = "dan"      # also acme/engineering — third-party for participant gating
+DAN = "dan"  # also acme/engineering — third-party for participant gating
 
 
 @pytest.fixture()
@@ -238,9 +238,7 @@ def test_closed_thread_excluded_from_inbox_by_default(client: TestClient) -> Non
     assert thread_id not in [t["thread_id"] for t in inbox["threads"]]
 
     # include_closed=true — audit view includes it
-    inbox_all = client.get(
-        "/api/v1/consults/inbox?include_closed=true", headers=_headers(client, BOB)
-    ).json()
+    inbox_all = client.get("/api/v1/consults/inbox?include_closed=true", headers=_headers(client, BOB)).json()
     assert thread_id in [t["thread_id"] for t in inbox_all["threads"]]
 
 

--- a/server/backend/tests/test_cross_l2_routing.py
+++ b/server/backend/tests/test_cross_l2_routing.py
@@ -32,7 +32,7 @@ from cq_server import consults, network
 from cq_server.app import _get_store, app
 
 ALICE = "alice"  # acme/engineering — this L2
-DAN = "dan"      # acme/engineering — also this L2
+DAN = "dan"  # acme/engineering — also this L2
 
 ACME_PEER_KEY = "test-acme-peer-key-thirty-two-chars"
 
@@ -171,9 +171,7 @@ def test_cross_l2_request_mirrors_local_and_forwards_to_peer(
     assert payload["from_persona"] == ALICE
 
 
-def test_cross_l2_message_forwards_to_other_side(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_cross_l2_message_forwards_to_other_side(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     """When Alice replies on a cross-L2 thread, the reply forwards to the OTHER L2."""
     forwarded: list[dict[str, Any]] = []
 
@@ -354,27 +352,35 @@ def test_forward_request_rejects_anonymous(client: TestClient) -> None:
 def test_forward_message_appends_to_existing_thread(client: TestClient) -> None:
     h = {"Authorization": f"Bearer {ACME_PEER_KEY}", "x-8l-forwarder-l2-id": "acme/solutions"}
     # First, mirror the thread via /forward-request
-    client.post("/api/v1/consults/forward-request", headers=h, json={
-        "thread_id": "th_msg_a",
-        "message_id": "msg_msg_a_1",
-        "from_l2_id": "acme/solutions",
-        "from_persona": "carla",
-        "to_l2_id": "acme/engineering",
-        "to_persona": ALICE,
-        "content": "open",
-        "created_at": "2026-05-01T18:00:00+00:00",
-    })
+    client.post(
+        "/api/v1/consults/forward-request",
+        headers=h,
+        json={
+            "thread_id": "th_msg_a",
+            "message_id": "msg_msg_a_1",
+            "from_l2_id": "acme/solutions",
+            "from_persona": "carla",
+            "to_l2_id": "acme/engineering",
+            "to_persona": ALICE,
+            "content": "open",
+            "created_at": "2026-05-01T18:00:00+00:00",
+        },
+    )
     # Append a reply via /forward-message — note the reply is from
     # acme/engineering (forwarder identity must match body.from_l2_id).
     h_reply = {"Authorization": f"Bearer {ACME_PEER_KEY}", "x-8l-forwarder-l2-id": "acme/engineering"}
-    r = client.post("/api/v1/consults/forward-message", headers=h_reply, json={
-        "thread_id": "th_msg_a",
-        "message_id": "msg_msg_a_2",
-        "from_l2_id": "acme/engineering",
-        "from_persona": ALICE,
-        "content": "reply",
-        "created_at": "2026-05-01T18:05:00+00:00",
-    })
+    r = client.post(
+        "/api/v1/consults/forward-message",
+        headers=h_reply,
+        json={
+            "thread_id": "th_msg_a",
+            "message_id": "msg_msg_a_2",
+            "from_l2_id": "acme/engineering",
+            "from_persona": ALICE,
+            "content": "reply",
+            "created_at": "2026-05-01T18:05:00+00:00",
+        },
+    )
     assert r.status_code == 201, r.text
 
     # Both messages visible to alice
@@ -388,20 +394,24 @@ def test_forward_message_appends_to_existing_thread(client: TestClient) -> None:
 def test_forward_message_lazily_creates_missing_thread(client: TestClient) -> None:
     """If /forward-request was lost, /forward-message backfills the thread row."""
     h = {"Authorization": f"Bearer {ACME_PEER_KEY}", "x-8l-forwarder-l2-id": "acme/solutions"}
-    r = client.post("/api/v1/consults/forward-message", headers=h, json={
-        "thread_id": "th_lazy_a",
-        "message_id": "msg_lazy_a",
-        "from_l2_id": "acme/solutions",
-        "from_persona": "carla",
-        "content": "reply (asker-side init lost)",
-        "created_at": "2026-05-01T19:00:00+00:00",
-        "thread_subject": "recovered",
-        "thread_to_l2_id": "acme/engineering",
-        "thread_to_persona": ALICE,
-        "thread_from_l2_id": "acme/solutions",
-        "thread_from_persona": "carla",
-        "thread_created_at": "2026-05-01T18:55:00+00:00",
-    })
+    r = client.post(
+        "/api/v1/consults/forward-message",
+        headers=h,
+        json={
+            "thread_id": "th_lazy_a",
+            "message_id": "msg_lazy_a",
+            "from_l2_id": "acme/solutions",
+            "from_persona": "carla",
+            "content": "reply (asker-side init lost)",
+            "created_at": "2026-05-01T19:00:00+00:00",
+            "thread_subject": "recovered",
+            "thread_to_l2_id": "acme/engineering",
+            "thread_to_persona": ALICE,
+            "thread_from_l2_id": "acme/solutions",
+            "thread_from_persona": "carla",
+            "thread_created_at": "2026-05-01T18:55:00+00:00",
+        },
+    )
     assert r.status_code == 201, r.text
 
     # Alice's inbox has the lazily-created thread
@@ -411,14 +421,18 @@ def test_forward_message_lazily_creates_missing_thread(client: TestClient) -> No
 
 def test_forward_message_missing_thread_no_metadata_400(client: TestClient) -> None:
     h = {"Authorization": f"Bearer {ACME_PEER_KEY}", "x-8l-forwarder-l2-id": "acme/solutions"}
-    r = client.post("/api/v1/consults/forward-message", headers=h, json={
-        "thread_id": "th_missing",
-        "message_id": "msg_x",
-        "from_l2_id": "acme/solutions",
-        "from_persona": "carla",
-        "content": "no thread no metadata",
-        "created_at": "2026-05-01T20:00:00+00:00",
-    })
+    r = client.post(
+        "/api/v1/consults/forward-message",
+        headers=h,
+        json={
+            "thread_id": "th_missing",
+            "message_id": "msg_x",
+            "from_l2_id": "acme/solutions",
+            "from_persona": "carla",
+            "content": "no thread no metadata",
+            "created_at": "2026-05-01T20:00:00+00:00",
+        },
+    )
     assert r.status_code == 400
 
 

--- a/server/backend/tests/test_crosstalk_routes.py
+++ b/server/backend/tests/test_crosstalk_routes.py
@@ -37,9 +37,7 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
         yield c
 
 
-def _seed_user(
-    *, username: str, password: str, enterprise_id: str, group_id: str, role: str = "user"
-) -> None:
+def _seed_user(*, username: str, password: str, enterprise_id: str, group_id: str, role: str = "user") -> None:
     store = _get_store()
     store.sync.create_user(username, hash_password(password))
     with store._engine.begin() as conn:
@@ -51,9 +49,7 @@ def _seed_user(
 
 def _login_and_mint(client: TestClient, username: str, password: str) -> str:
     """Log in, mint an API key, return the API-key bearer token."""
-    jwt_resp = client.post(
-        "/auth/login", json={"username": username, "password": password}
-    )
+    jwt_resp = client.post("/auth/login", json={"username": username, "password": password})
     assert jwt_resp.status_code == 200, jwt_resp.text
     jwt = jwt_resp.json()["token"]
 
@@ -119,9 +115,7 @@ def test_reply_appends_to_existing_thread(client: TestClient) -> None:
     assert reply.status_code == 201, reply.text
 
     # Alice retrieves the thread; should see both messages
-    thread = client.get(
-        f"/crosstalk/threads/{thread_id}", headers=_bearer(alice_key)
-    ).json()
+    thread = client.get(f"/crosstalk/threads/{thread_id}", headers=_bearer(alice_key)).json()
     assert thread["thread"]["status"] == "open"
     assert len(thread["messages"]) == 2
     assert thread["messages"][0]["content"] == "ping"
@@ -143,18 +137,14 @@ def test_non_participant_cannot_read_thread(client: TestClient) -> None:
     )
     thread_id = send.json()["thread_id"]
 
-    resp = client.get(
-        f"/crosstalk/threads/{thread_id}", headers=_bearer(charlie_key)
-    )
+    resp = client.get(f"/crosstalk/threads/{thread_id}", headers=_bearer(charlie_key))
     assert resp.status_code == 403
 
 
 def test_admin_sees_all_threads_in_tenant(client: TestClient) -> None:
     _seed_user(username="alice", password="pw", enterprise_id="acme", group_id="eng")
     _seed_user(username="bob", password="pw", enterprise_id="acme", group_id="eng")
-    _seed_user(
-        username="rootadmin", password="pw", enterprise_id="acme", group_id="eng", role="admin"
-    )
+    _seed_user(username="rootadmin", password="pw", enterprise_id="acme", group_id="eng", role="admin")
 
     alice_key = _login_and_mint(client, "alice", "pw")
     admin_key = _login_and_mint(client, "rootadmin", "pw")
@@ -169,9 +159,7 @@ def test_admin_sees_all_threads_in_tenant(client: TestClient) -> None:
     assert threads["count"] >= 1
     # Admin can read the thread even though they're not a participant
     thread_id = threads["items"][0]["id"]
-    resp = client.get(
-        f"/crosstalk/threads/{thread_id}", headers=_bearer(admin_key)
-    )
+    resp = client.get(f"/crosstalk/threads/{thread_id}", headers=_bearer(admin_key))
     assert resp.status_code == 200
 
 
@@ -192,9 +180,7 @@ def test_cross_enterprise_isolation(client: TestClient) -> None:
     thread_id = send.json()["thread_id"]
 
     # Eve (different enterprise) cannot see the thread
-    resp = client.get(
-        f"/crosstalk/threads/{thread_id}", headers=_bearer(eve_key)
-    )
+    resp = client.get(f"/crosstalk/threads/{thread_id}", headers=_bearer(eve_key))
     assert resp.status_code == 404
 
 
@@ -251,24 +237,18 @@ def test_inbox_mark_read_clears_unread(client: TestClient) -> None:
         json={"to": "bob", "content": "hi"},
     )
 
-    inbox = client.get(
-        "/crosstalk/inbox?mark_read=true", headers=_bearer(bob_key)
-    ).json()
+    inbox = client.get("/crosstalk/inbox?mark_read=true", headers=_bearer(bob_key)).json()
     assert inbox["count"] == 1
 
     inbox2 = client.get("/crosstalk/inbox", headers=_bearer(bob_key)).json()
     assert inbox2["count"] == 0  # marked read; no longer unread
 
 
-def test_activity_log_captures_crosstalk_events(
-    client: TestClient, tmp_path: Path
-) -> None:
+def test_activity_log_captures_crosstalk_events(client: TestClient, tmp_path: Path) -> None:
     """Send + reply + close should each fire the corresponding activity event."""
     _seed_user(username="alice", password="pw", enterprise_id="acme", group_id="eng")
     _seed_user(username="bob", password="pw", enterprise_id="acme", group_id="eng")
-    _seed_user(
-        username="rootadmin", password="pw", enterprise_id="acme", group_id="eng", role="admin"
-    )
+    _seed_user(username="rootadmin", password="pw", enterprise_id="acme", group_id="eng", role="admin")
 
     alice_key = _login_and_mint(client, "alice", "pw")
     bob_key = _login_and_mint(client, "bob", "pw")
@@ -299,8 +279,7 @@ def test_activity_log_captures_crosstalk_events(
     conn = sqlite3.connect(db_path)
     try:
         rows = conn.execute(
-            "SELECT event_type, persona FROM activity_log "
-            "WHERE thread_or_chain_id = ? ORDER BY ts ASC",
+            "SELECT event_type, persona FROM activity_log WHERE thread_or_chain_id = ? ORDER BY ts ASC",
             (thread_id,),
         ).fetchall()
     finally:
@@ -316,9 +295,7 @@ def test_activity_log_captures_crosstalk_events(
         "/activity?event_type=crosstalk_send",
         headers=_bearer(admin_key),
     ).json()
-    assert any(
-        e["thread_or_chain_id"] == thread_id for e in api_resp["items"]
-    )
+    assert any(e["thread_or_chain_id"] == thread_id for e in api_resp["items"])
 
 
 def test_idempotency_send_with_client_thread_and_message_ids(client: TestClient) -> None:
@@ -360,9 +337,7 @@ def test_idempotency_send_with_client_thread_and_message_ids(client: TestClient)
     assert second.json()["sent_at"] == first.json()["sent_at"]
 
     # Thread has only 1 message
-    thread = client.get(
-        f"/crosstalk/threads/{client_thread_id}", headers=_bearer(alice_key)
-    ).json()
+    thread = client.get(f"/crosstalk/threads/{client_thread_id}", headers=_bearer(alice_key)).json()
     assert len(thread["messages"]) == 1
     assert thread["messages"][0]["content"] == "first send"
 
@@ -390,9 +365,7 @@ def test_idempotency_append_to_existing_thread_via_send(client: TestClient) -> N
     assert second.json()["thread_id"] == thread_id
     assert second.json()["message_id"] != first.json()["message_id"]
 
-    thread = client.get(
-        f"/crosstalk/threads/{thread_id}", headers=_bearer(alice_key)
-    ).json()
+    thread = client.get(f"/crosstalk/threads/{thread_id}", headers=_bearer(alice_key)).json()
     assert len(thread["messages"]) == 2
 
 

--- a/server/backend/tests/test_daily_root.py
+++ b/server/backend/tests/test_daily_root.py
@@ -25,9 +25,7 @@ def conn(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> sqlite3.Connection:
 
 
 class TestComputeRoot:
-    def test_empty_day_returns_zero_event_root(
-        self, conn: sqlite3.Connection
-    ) -> None:
+    def test_empty_day_returns_zero_event_root(self, conn: sqlite3.Connection) -> None:
         # No events for the day — root should be the empty-day constant.
         result = compute_root_for_day(conn, "test-corp", "2026-01-01")
         conn.commit()
@@ -36,9 +34,7 @@ class TestComputeRoot:
         assert result["first_event_id"] is None
         assert result["last_event_id"] is None
 
-    def test_root_matches_merkle_over_payload_hashes(
-        self, conn: sqlite3.Connection
-    ) -> None:
+    def test_root_matches_merkle_over_payload_hashes(self, conn: sqlite3.Connection) -> None:
         # Write 3 events at known times (today's UTC date by default).
         from datetime import UTC, datetime
 
@@ -66,8 +62,7 @@ class TestComputeRoot:
 
         # Read the payload hashes in the same ts-ASC order
         rows = conn.execute(
-            "SELECT payload_hash FROM reputation_events "
-            "WHERE enterprise_id = ? ORDER BY ts ASC, event_id ASC",
+            "SELECT payload_hash FROM reputation_events WHERE enterprise_id = ? ORDER BY ts ASC, event_id ASC",
             ("test-corp",),
         ).fetchall()
         leaf_hashes = [r[0] for r in rows]
@@ -80,9 +75,7 @@ class TestComputeRoot:
         assert result["first_event_id"] == e1
         assert result["last_event_id"] == e3
 
-    def test_idempotent_recompute_returns_existing(
-        self, conn: sqlite3.Connection
-    ) -> None:
+    def test_idempotent_recompute_returns_existing(self, conn: sqlite3.Connection) -> None:
         from datetime import UTC, datetime
 
         today = datetime.now(UTC).date().isoformat()
@@ -103,20 +96,19 @@ class TestComputeRoot:
 
         # Only one row should exist for that (enterprise, day).
         n = conn.execute(
-            "SELECT COUNT(*) FROM reputation_roots "
-            "WHERE enterprise_id = ? AND root_date = ?",
+            "SELECT COUNT(*) FROM reputation_roots WHERE enterprise_id = ? AND root_date = ?",
             ("test-corp", today),
         ).fetchone()[0]
         assert n == 1
 
-    def test_chain_meta_advances_after_compute(
-        self, conn: sqlite3.Connection
-    ) -> None:
+    def test_chain_meta_advances_after_compute(self, conn: sqlite3.Connection) -> None:
         from datetime import UTC, datetime
 
         today = datetime.now(UTC).date().isoformat()
         reputation.record_event(
-            conn, event_type="consult.closed", body={"i": 1},
+            conn,
+            event_type="consult.closed",
+            body={"i": 1},
         )
         conn.commit()
 
@@ -124,8 +116,7 @@ class TestComputeRoot:
         conn.commit()
 
         last_day = conn.execute(
-            "SELECT last_root_published_day FROM reputation_chain_meta "
-            "WHERE enterprise_id = ?",
+            "SELECT last_root_published_day FROM reputation_chain_meta WHERE enterprise_id = ?",
             ("test-corp",),
         ).fetchone()[0]
         assert last_day == today
@@ -152,9 +143,7 @@ class TestSignedRoot:
             from datetime import UTC, datetime
 
             today = datetime.now(UTC).date().isoformat()
-            reputation.record_event(
-                conn, event_type="consult.closed", body={"i": 1}
-            )
+            reputation.record_event(conn, event_type="consult.closed", body={"i": 1})
             conn.commit()
 
             result = compute_root_for_day(conn, "test-corp", today)
@@ -173,9 +162,7 @@ class TestSignedRoot:
                     "last_event_id": result["last_event_id"],
                 }
             )
-            ok = verify_raw(
-                result["signing_key_id"], canonical, result["signature_b64u"]
-            )
+            ok = verify_raw(result["signing_key_id"], canonical, result["signature_b64u"])
             assert ok is True
         finally:
             forward_sign.reload_l2_privkey()

--- a/server/backend/tests/test_default_enterprise_backfill.py
+++ b/server/backend/tests/test_default_enterprise_backfill.py
@@ -151,9 +151,7 @@ def _step_to_0013(db_path: Path) -> subprocess.CompletedProcess[str]:
 
 
 class TestLegacyRowReassignment:
-    def test_default_enterprise_row_with_known_proposer_gets_reassigned(
-        self, db: Path
-    ) -> None:
+    def test_default_enterprise_row_with_known_proposer_gets_reassigned(self, db: Path) -> None:
         conn = sqlite3.connect(str(db))
         try:
             _seed_user(
@@ -178,9 +176,7 @@ class TestLegacyRowReassignment:
         assert ent == "moscowmul3"
         assert grp == "engineering"
 
-    def test_two_proposers_two_enterprises_each_row_lands_correctly(
-        self, db: Path
-    ) -> None:
+    def test_two_proposers_two_enterprises_each_row_lands_correctly(self, db: Path) -> None:
         """Pin per-row resolution. Two legacy KUs from two proposers
         in two enterprises — each row gets its own proposer's tenancy,
         not the wrong one (no thread-local cache, no cross-row leak).
@@ -265,9 +261,7 @@ class TestRowsLeftAlone:
         finally:
             conn.close()
 
-    def test_row_whose_proposer_is_also_default_stays_default(
-        self, db: Path
-    ) -> None:
+    def test_row_whose_proposer_is_also_default_stays_default(self, db: Path) -> None:
         """If the proposer is themselves at default tenancy, there's
         no useful signal — the migration shouldn't pretend to "fix"
         the row by re-tenanting it to default-enterprise (no-op).
@@ -280,9 +274,7 @@ class TestRowsLeftAlone:
                 enterprise_id="default-enterprise",
                 group_id="default-group",
             )
-            _seed_legacy_ku(
-                conn, unit_id="dual-default", created_by="default_user"
-            )
+            _seed_legacy_ku(conn, unit_id="dual-default", created_by="default_user")
             conn.commit()
         finally:
             conn.close()
@@ -299,9 +291,7 @@ class TestRowsLeftAlone:
         finally:
             conn.close()
 
-    def test_row_already_at_non_default_tenancy_is_not_overwritten(
-        self, db: Path
-    ) -> None:
+    def test_row_already_at_non_default_tenancy_is_not_overwritten(self, db: Path) -> None:
         """A row proposed *after* the #89 fix has the right tenancy
         already — the migration must not touch it (the WHERE clause's
         ``enterprise_id = 'default-enterprise'`` guard).

--- a/server/backend/tests/test_demo_scenarios.py
+++ b/server/backend/tests/test_demo_scenarios.py
@@ -66,9 +66,7 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
 
 
 def _login(client: TestClient) -> str:
-    resp = client.post(
-        "/api/v1/auth/login", json={"username": ALICE, "password": "pw"}
-    )
+    resp = client.post("/api/v1/auth/login", json={"username": ALICE, "password": "pw"})
     return resp.json()["token"]
 
 
@@ -118,9 +116,7 @@ def _patch_fleet_calls(
         captured["lookups"].append(l2["slug"])
         return ({"results": []}, 5)
 
-    async def _fake_forward(
-        client, target, *, requester, requester_persona, query_vec, query_text
-    ):
+    async def _fake_forward(client, target, *, requester, requester_persona, query_vec, query_text):
         captured["forward_query_targets"].append(target["slug"])
         if forward_query_status != 200:
             return None, 7
@@ -158,8 +154,12 @@ class TestCrossGroupScenario:
         captured = _patch_fleet_calls(
             monkeypatch,
             target_axis_for={
-                "orion-eng": 1, "orion-sol": 2, "orion-gtm": 3,
-                "acme-eng": 5, "acme-sol": 0, "acme-fin": 6,
+                "orion-eng": 1,
+                "orion-sol": 2,
+                "orion-gtm": 3,
+                "acme-eng": 5,
+                "acme-sol": 0,
+                "acme-fin": 6,
             },
         )
         jwt = _login(client)
@@ -192,8 +192,12 @@ class TestCrossEnterpriseBlocked:
         captured = _patch_fleet_calls(
             monkeypatch,
             target_axis_for={
-                "orion-eng": 0, "orion-sol": 2, "orion-gtm": 3,
-                "acme-eng": 5, "acme-sol": 4, "acme-fin": 6,
+                "orion-eng": 0,
+                "orion-sol": 2,
+                "orion-gtm": 3,
+                "acme-eng": 5,
+                "acme-sol": 4,
+                "acme-fin": 6,
             },
             forward_query_response={
                 "responder_l2_id": "orion/engineering",
@@ -223,15 +227,17 @@ class TestCrossEnterpriseBlocked:
 
 
 class TestCrossEnterpriseConsentedPrecondition:
-    def test_412_when_no_consent_row(
-        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_412_when_no_consent_row(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
         _stub_embed(monkeypatch, axis=0)
         _patch_fleet_calls(
             monkeypatch,
             target_axis_for={
-                "orion-eng": 0, "orion-sol": 2, "orion-gtm": 3,
-                "acme-eng": 5, "acme-sol": 4, "acme-fin": 6,
+                "orion-eng": 0,
+                "orion-sol": 2,
+                "orion-gtm": 3,
+                "acme-eng": 5,
+                "acme-sol": 4,
+                "acme-fin": 6,
             },
         )
         jwt = _login(client)
@@ -249,9 +255,7 @@ class TestCrossEnterpriseConsentedPrecondition:
         detail = body["detail"]
         assert detail["error"] == "no_consent"
 
-    def test_200_when_consent_exists(
-        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_200_when_consent_exists(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
         # Seed a consent row from acme/eng -> orion/eng.
         store = _get_store()
         store.sync.insert_cross_enterprise_consent(
@@ -270,8 +274,12 @@ class TestCrossEnterpriseConsentedPrecondition:
         _patch_fleet_calls(
             monkeypatch,
             target_axis_for={
-                "orion-eng": 0, "orion-sol": 2, "orion-gtm": 3,
-                "acme-eng": 5, "acme-sol": 4, "acme-fin": 6,
+                "orion-eng": 0,
+                "orion-sol": 2,
+                "orion-gtm": 3,
+                "acme-eng": 5,
+                "acme-sol": 4,
+                "acme-fin": 6,
             },
         )
         jwt = _login(client)
@@ -305,9 +313,7 @@ class TestUnknownScenario:
 
 
 class TestUnknownRequesterSlug:
-    def test_422_on_unknown_slug(
-        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_422_on_unknown_slug(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
         _stub_embed(monkeypatch, axis=0)
         jwt = _login(client)
         resp = client.post(

--- a/server/backend/tests/test_directory_client.py
+++ b/server/backend/tests/test_directory_client.py
@@ -86,14 +86,10 @@ class TestCryptoHelpers:
         # Flip a byte in the canonical payload — sig over the original
         # payload should no longer verify.
         tampered = envelope["payload_canonical"].replace('"a":1', '"a":2')
-        ok = dc.verify_envelope_signature(
-            envelope["signing_key_id"], tampered, envelope["signature"]
-        )
+        ok = dc.verify_envelope_signature(envelope["signing_key_id"], tampered, envelope["signature"])
         assert ok is False
 
-    def test_verify_rejects_wrong_key(
-        self, keypair: Ed25519PrivateKey, keypair_b: Ed25519PrivateKey
-    ) -> None:
+    def test_verify_rejects_wrong_key(self, keypair: Ed25519PrivateKey, keypair_b: Ed25519PrivateKey) -> None:
         envelope = dc.sign_envelope(keypair, {"a": 1})
         ok = dc.verify_envelope_signature(
             dc.public_key_b64u(keypair_b),
@@ -102,9 +98,7 @@ class TestCryptoHelpers:
         )
         assert ok is False
 
-    def test_load_private_key_roundtrip(
-        self, tmp_path: Path, keypair: Ed25519PrivateKey
-    ) -> None:
+    def test_load_private_key_roundtrip(self, tmp_path: Path, keypair: Ed25519PrivateKey) -> None:
         p = tmp_path / "k.key"
         p.write_bytes(keypair.private_bytes_raw())
         loaded = dc.load_private_key(p)
@@ -124,14 +118,10 @@ class TestCryptoHelpers:
 
 class TestFeatureFlag:
     @pytest.mark.asyncio
-    async def test_disabled_skips_bootstrap(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ) -> None:
+    async def test_disabled_skips_bootstrap(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         monkeypatch.setenv("CQ_DIRECTORY_ENABLED", "false")
         called: list[str] = []
-        monkeypatch.setattr(
-            dc, "_announce_with_retries", lambda *a, **kw: called.append("announce")
-        )
+        monkeypatch.setattr(dc, "_announce_with_retries", lambda *a, **kw: called.append("announce"))
         # Should return immediately without any side effects.
         from cq_server.store import SqliteStore
 
@@ -141,9 +131,7 @@ class TestFeatureFlag:
         store.sync.close()
 
     @pytest.mark.asyncio
-    async def test_enabled_but_unconfigured_skips(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ) -> None:
+    async def test_enabled_but_unconfigured_skips(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         # Enabled but no privkey path → graceful skip, not crash.
         monkeypatch.setenv("CQ_DIRECTORY_ENABLED", "true")
         monkeypatch.delenv("CQ_ENTERPRISE_ROOT_PRIVKEY_PATH", raising=False)
@@ -169,9 +157,7 @@ class TestFeatureFlag:
         # NB: no privkey path, no contact email — pull-only doesn't need them.
 
         announce_called: list[str] = []
-        monkeypatch.setattr(
-            dc, "_announce_with_retries", lambda *a, **kw: announce_called.append("nope")
-        )
+        monkeypatch.setattr(dc, "_announce_with_retries", lambda *a, **kw: announce_called.append("nope"))
         # Stub the pull loop to record-and-return immediately so the test
         # doesn't actually loop forever.
         pull_called: list[tuple] = []
@@ -201,9 +187,7 @@ class TestFeatureFlag:
 
 class TestAnnounce:
     @pytest.mark.asyncio
-    async def test_announce_201_first_time(
-        self, monkeypatch: pytest.MonkeyPatch, keypair: Ed25519PrivateKey
-    ) -> None:
+    async def test_announce_201_first_time(self, monkeypatch: pytest.MonkeyPatch, keypair: Ed25519PrivateKey) -> None:
         captured: dict[str, Any] = {}
 
         async def handler(request: httpx.Request) -> httpx.Response:
@@ -244,9 +228,7 @@ class TestAnnounce:
         assert env["payload"]["enterprise_id"] == "acme"
         assert env["signing_key_id"] == dc.public_key_b64u(keypair)
         # Signature must verify against the canonical bytes.
-        assert dc.verify_envelope_signature(
-            env["signing_key_id"], env["payload_canonical"], env["signature"]
-        )
+        assert dc.verify_envelope_signature(env["signing_key_id"], env["payload_canonical"], env["signature"])
 
     @pytest.mark.asyncio
     async def test_announce_200_on_update(self, keypair: Ed25519PrivateKey) -> None:
@@ -269,9 +251,7 @@ class TestAnnounce:
                 display_name="Acme",
                 visibility="public",
                 contact_email="a@b.c",
-                l2_endpoints=[
-                    {"l2_id": "acme/eng", "endpoint_url": "https://x", "groups": ["eng"]}
-                ],
+                l2_endpoints=[{"l2_id": "acme/eng", "endpoint_url": "https://x", "groups": ["eng"]}],
                 discoverable_topics=[],
             )
         assert status == 200
@@ -388,13 +368,9 @@ class TestPullAndPersist:
                     },
                 )
             if path.endswith("/enterprises/acme/key"):
-                return httpx.Response(
-                    200, json={"root_pubkey": dc.public_key_b64u(keypair)}
-                )
+                return httpx.Response(200, json={"root_pubkey": dc.public_key_b64u(keypair)})
             if path.endswith("/enterprises/rival/key"):
-                return httpx.Response(
-                    200, json={"root_pubkey": dc.public_key_b64u(keypair_b)}
-                )
+                return httpx.Response(200, json={"root_pubkey": dc.public_key_b64u(keypair_b)})
             return httpx.Response(404)
 
         original_async_client = httpx.AsyncClient
@@ -441,13 +417,9 @@ class TestPullAndPersist:
                     },
                 )
             if path.endswith("/enterprises/acme/key"):
-                return httpx.Response(
-                    200, json={"root_pubkey": dc.public_key_b64u(keypair)}
-                )
+                return httpx.Response(200, json={"root_pubkey": dc.public_key_b64u(keypair)})
             if path.endswith("/enterprises/rival/key"):
-                return httpx.Response(
-                    200, json={"root_pubkey": dc.public_key_b64u(keypair_b)}
-                )
+                return httpx.Response(200, json={"root_pubkey": dc.public_key_b64u(keypair_b)})
             return httpx.Response(404)
 
         original_async_client = httpx.AsyncClient
@@ -507,9 +479,7 @@ class TestPullAndPersist:
 
 
 class TestSchema:
-    def test_directory_peerings_table_exists_and_upserts(
-        self, app_client: TestClient
-    ) -> None:
+    def test_directory_peerings_table_exists_and_upserts(self, app_client: TestClient) -> None:
         store = _get_store()
         store.sync.upsert_directory_peering(
             offer_id="off_schema",

--- a/server/backend/tests/test_dsn_resolve.py
+++ b/server/backend/tests/test_dsn_resolve.py
@@ -83,9 +83,7 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
 
 
 def _login(client: TestClient) -> str:
-    resp = client.post(
-        "/api/v1/auth/login", json={"username": ALICE, "password": "pw"}
-    )
+    resp = client.post("/api/v1/auth/login", json={"username": ALICE, "password": "pw"})
     assert resp.status_code == 200, resp.text
     return resp.json()["token"]
 
@@ -162,9 +160,7 @@ class TestDsnResolveHappyPath:
 
 
 class TestDsnPolicyDecisions:
-    def test_same_enterprise_same_group_is_full_body(
-        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_same_enterprise_same_group_is_full_body(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
         # Alice = acme/engineering. Make her own L2 the top candidate.
         _stub_embed(monkeypatch, axis=0)
 
@@ -184,16 +180,19 @@ class TestDsnPolicyDecisions:
         resp = client.post(
             "/api/v1/network/dsn/resolve",
             headers={"Authorization": f"Bearer {jwt}"},
-            json={"intent": "anything", "max_candidates": 6, "caller_enterprise": "acme", "caller_group": "engineering"},
+            json={
+                "intent": "anything",
+                "max_candidates": 6,
+                "caller_enterprise": "acme",
+                "caller_group": "engineering",
+            },
         )
         body = resp.json()
         own = next(c for c in body["candidates"] if c["l2_id"] == "acme/engineering")
         assert own["policy_if_queried"] == "full_body"
         assert own["policy_reason"] == "same_enterprise_same_group"
 
-    def test_cross_enterprise_no_consent_is_denied(
-        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_cross_enterprise_no_consent_is_denied(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
         _stub_embed(monkeypatch, axis=0)
         _stub_fanout_six_l2s(monkeypatch, target_axis=0)
         jwt = _login(client)
@@ -212,16 +211,19 @@ class TestDsnPolicyDecisions:
         assert orion["policy_if_queried"] == "denied"
         assert orion["policy_reason"] == "cross_enterprise_no_consent"
 
-    def test_same_enterprise_xgroup_is_summary_only(
-        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_same_enterprise_xgroup_is_summary_only(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
         _stub_embed(monkeypatch, axis=0)
         _stub_fanout_six_l2s(monkeypatch, target_axis=0)
         jwt = _login(client)
         resp = client.post(
             "/api/v1/network/dsn/resolve",
             headers={"Authorization": f"Bearer {jwt}"},
-            json={"intent": "anything", "max_candidates": 6, "caller_enterprise": "acme", "caller_group": "engineering"},
+            json={
+                "intent": "anything",
+                "max_candidates": 6,
+                "caller_enterprise": "acme",
+                "caller_group": "engineering",
+            },
         )
         body = resp.json()
         # acme/solutions vs Alice (acme/engineering) -> summary_only.
@@ -231,9 +233,7 @@ class TestDsnPolicyDecisions:
 
 
 class TestDsnEmbedFailure:
-    def test_503_when_embedding_unavailable(
-        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_503_when_embedding_unavailable(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(network, "embed_text", lambda text: None)
         jwt = _login(client)
         resp = client.post(

--- a/server/backend/tests/test_ed25519_forward_signing.py
+++ b/server/backend/tests/test_ed25519_forward_signing.py
@@ -84,9 +84,7 @@ def other_keypair() -> Ed25519PrivateKey:
 
 
 class TestKeypairBootstrap:
-    def test_generates_new_key_when_missing(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_generates_new_key_when_missing(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         path = tmp_path / "fresh.key"
         monkeypatch.setenv("CQ_AIGRP_L2_PRIVKEY_PATH", str(path))
         forward_sign.reload_l2_privkey()
@@ -95,9 +93,7 @@ class TestKeypairBootstrap:
         assert path.exists()
         assert len(path.read_bytes()) == 32
 
-    def test_loads_existing_key(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_loads_existing_key(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         path = tmp_path / "existing.key"
         seeded = Ed25519PrivateKey.generate()
         path.write_bytes(seeded.private_bytes_raw())
@@ -107,9 +103,7 @@ class TestKeypairBootstrap:
         assert pk is not None
         assert public_key_b64u(pk) == public_key_b64u(seeded)
 
-    def test_corrupt_key_disables_signing(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_corrupt_key_disables_signing(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         path = tmp_path / "corrupt.key"
         path.write_bytes(b"too-short")
         monkeypatch.setenv("CQ_AIGRP_L2_PRIVKEY_PATH", str(path))
@@ -126,9 +120,7 @@ class TestKeypairBootstrap:
 
 
 class TestHelloPubkeyExchange:
-    def test_hello_records_pubkey(
-        self, aigrp_client: TestClient, peer_keypair: Ed25519PrivateKey
-    ) -> None:
+    def test_hello_records_pubkey(self, aigrp_client: TestClient, peer_keypair: Ed25519PrivateKey) -> None:
         peer_pub = public_key_b64u(peer_keypair)
         r = aigrp_client.post(
             "/api/v1/aigrp/hello",
@@ -145,9 +137,7 @@ class TestHelloPubkeyExchange:
         store = _get_store()
         assert store.sync.get_aigrp_peer_pubkey(PEER_L2) == peer_pub
 
-    def test_peers_endpoint_exposes_pubkey(
-        self, aigrp_client: TestClient, peer_keypair: Ed25519PrivateKey
-    ) -> None:
+    def test_peers_endpoint_exposes_pubkey(self, aigrp_client: TestClient, peer_keypair: Ed25519PrivateKey) -> None:
         peer_pub = public_key_b64u(peer_keypair)
         # The /aigrp/hello response is what new joiners use to learn the
         # mesh topology — it must include our own pubkey in the self_entry
@@ -166,16 +156,12 @@ class TestHelloPubkeyExchange:
         hello_peers = {p["l2_id"]: p for p in hello.json()["peers"]}
         assert hello_peers[SELF_L2]["public_key_ed25519"] == forward_sign.self_public_key_b64u()
         # /aigrp/peers reflects the recorded peer rows — joiner is in there.
-        r = aigrp_client.get(
-            "/api/v1/aigrp/peers", headers={"authorization": f"Bearer {PEER_KEY}"}
-        )
+        r = aigrp_client.get("/api/v1/aigrp/peers", headers={"authorization": f"Bearer {PEER_KEY}"})
         assert r.status_code == 200
         peers = {p["l2_id"]: p for p in r.json()["peers"]}
         assert peers[PEER_L2]["public_key_ed25519"] == peer_pub
 
-    def test_rehello_same_key_is_idempotent(
-        self, aigrp_client: TestClient, peer_keypair: Ed25519PrivateKey
-    ) -> None:
+    def test_rehello_same_key_is_idempotent(self, aigrp_client: TestClient, peer_keypair: Ed25519PrivateKey) -> None:
         peer_pub = public_key_b64u(peer_keypair)
         body = {
             "l2_id": PEER_L2,
@@ -194,9 +180,7 @@ class TestHelloPubkeyExchange:
         store = _get_store()
         assert store.sync.get_aigrp_peer_pubkey(PEER_L2) == peer_pub
 
-    def test_legacy_hello_without_pubkey_yields_null(
-        self, aigrp_client: TestClient
-    ) -> None:
+    def test_legacy_hello_without_pubkey_yields_null(self, aigrp_client: TestClient) -> None:
         r = aigrp_client.post(
             "/api/v1/aigrp/hello",
             headers={"authorization": f"Bearer {PEER_KEY}"},
@@ -222,9 +206,7 @@ def _pack_vec(vec: list[float]) -> bytes:
 
 
 class TestSenderSideSignatures:
-    def test_forward_query_sender_signs_body(
-        self, aigrp_client: TestClient, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_forward_query_sender_signs_body(self, aigrp_client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
         """``network._call_forward_query`` adds X-8L-Forwarder-Sig that
         verifies against this L2's pubkey + JCS(body) || forwarder id."""
         captured: dict[str, Any] = {}
@@ -264,13 +246,9 @@ class TestSenderSideSignatures:
         # Verify it against this L2's own pubkey.
         self_pub = forward_sign.self_public_key_b64u()
         assert self_pub
-        assert forward_sign.verify_forward_signature(
-            self_pub, captured["json"], "acme/solutions", sig_header
-        )
+        assert forward_sign.verify_forward_signature(self_pub, captured["json"], "acme/solutions", sig_header)
 
-    def test_consult_forward_request_signed(
-        self, aigrp_client: TestClient, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_consult_forward_request_signed(self, aigrp_client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
         captured: list[dict[str, Any]] = []
 
         class StubResp:
@@ -287,9 +265,7 @@ class TestSenderSideSignatures:
             def __exit__(self, *a: Any) -> None:
                 return None
 
-            def post(
-                self, url: str, *, headers: dict[str, str], json: dict[str, Any]
-            ) -> StubResp:
+            def post(self, url: str, *, headers: dict[str, str], json: dict[str, Any]) -> StubResp:
                 captured.append({"headers": headers, "json": json})
                 return StubResp()
 
@@ -357,9 +333,7 @@ def _forward_query_body(axis: int = 0) -> dict[str, Any]:
 
 
 class TestReceiverVerification:
-    def test_valid_signature_accepted(
-        self, aigrp_client: TestClient, peer_keypair: Ed25519PrivateKey
-    ) -> None:
+    def test_valid_signature_accepted(self, aigrp_client: TestClient, peer_keypair: Ed25519PrivateKey) -> None:
         store = _get_store()
         _seed_peer(store, public_key_b64u(peer_keypair))
         body = _forward_query_body()
@@ -392,9 +366,7 @@ class TestReceiverVerification:
         assert r.status_code == 403
         assert "missing" in r.json()["detail"].lower()
 
-    def test_tampered_body_rejected(
-        self, aigrp_client: TestClient, peer_keypair: Ed25519PrivateKey
-    ) -> None:
+    def test_tampered_body_rejected(self, aigrp_client: TestClient, peer_keypair: Ed25519PrivateKey) -> None:
         store = _get_store()
         _seed_peer(store, public_key_b64u(peer_keypair))
         body = _forward_query_body()
@@ -458,9 +430,7 @@ class TestReceiverVerification:
         assert r.status_code == 200
         assert any("legacy unsigned forward" in m for m in caplog.messages)
 
-    def test_strict_mode_rejects_legacy(
-        self, aigrp_client: TestClient, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_strict_mode_rejects_legacy(self, aigrp_client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
         store = _get_store()
         _seed_peer(store, None)  # legacy peer
         monkeypatch.setenv("CQ_REQUIRE_SIGNED_FORWARDS", "true")

--- a/server/backend/tests/test_forward_query.py
+++ b/server/backend/tests/test_forward_query.py
@@ -97,8 +97,7 @@ def _seed_ku(
     # Set tenancy scope + xgroup flag explicitly.
     with store._engine.begin() as _c:
         _c.exec_driver_sql(
-            "UPDATE knowledge_units SET enterprise_id = ?, group_id = ?, "
-            "cross_group_allowed = ? WHERE id = ?",
+            "UPDATE knowledge_units SET enterprise_id = ?, group_id = ?, cross_group_allowed = ? WHERE id = ?",
             (enterprise_id, group_id, 1 if cross_group_allowed else 0, unit.id),
         )
     return unit.id
@@ -376,9 +375,7 @@ class TestAuth:
 
 
 class TestDefaultsSafety:
-    def test_legacy_default_scope_does_not_leak_to_strangers(
-        self, aigrp_client: TestClient
-    ) -> None:
+    def test_legacy_default_scope_does_not_leak_to_strangers(self, aigrp_client: TestClient) -> None:
         # A KU with default-enterprise / default-group is in a different
         # Enterprise from the responder (acme). Must not leak.
         _seed_ku(
@@ -465,10 +462,11 @@ class TestSchemaConstraints:
         import sqlalchemy.exc
 
         store = _get_store()
-        with pytest.raises((sqlite3.IntegrityError, sqlalchemy.exc.IntegrityError)):
-            with store._engine.begin() as conn:
-                conn.exec_driver_sql(
-                    "INSERT INTO knowledge_units (id, data, cross_group_allowed) "
-                    "VALUES (?, ?, ?)",
-                    ("ku_null_xgroup", "{}", None),
-                )
+        with (
+            pytest.raises((sqlite3.IntegrityError, sqlalchemy.exc.IntegrityError)),
+            store._engine.begin() as conn,
+        ):
+            conn.exec_driver_sql(
+                "INSERT INTO knowledge_units (id, data, cross_group_allowed) VALUES (?, ?, ?)",
+                ("ku_null_xgroup", "{}", None),
+            )

--- a/server/backend/tests/test_merkle.py
+++ b/server/backend/tests/test_merkle.py
@@ -17,9 +17,7 @@ class TestEmptyAndSingle:
 
     def test_empty_constant_is_stable(self) -> None:
         # Locking the constant down — any change is a wire-format change.
-        expected = "sha256:" + hashlib.sha256(
-            b"8l-reputation-empty-day-v1"
-        ).hexdigest()
+        expected = "sha256:" + hashlib.sha256(b"8l-reputation-empty-day-v1").hexdigest()
         assert expected == EMPTY_DAY_ROOT
 
     def test_single_leaf_root_is_just_that_leaf(self) -> None:
@@ -34,7 +32,7 @@ class TestPairAndOdd:
         b = _h("b")
         # Manual computation: sha256(a_bytes || b_bytes)
         expected_root_bytes = hashlib.sha256(
-            bytes.fromhex(a[len("sha256:"):]) + bytes.fromhex(b[len("sha256:"):])
+            bytes.fromhex(a[len("sha256:") :]) + bytes.fromhex(b[len("sha256:") :])
         ).digest()
         assert merkle_root([a, b]) == "sha256:" + expected_root_bytes.hex()
 
@@ -42,12 +40,8 @@ class TestPairAndOdd:
         a, b, c = _h("a"), _h("b"), _h("c")
         # Tree shape with 3 leaves:
         #   root = H(H(a||b) || H(c||c))
-        ab = hashlib.sha256(
-            bytes.fromhex(a[7:]) + bytes.fromhex(b[7:])
-        ).digest()
-        cc = hashlib.sha256(
-            bytes.fromhex(c[7:]) + bytes.fromhex(c[7:])
-        ).digest()
+        ab = hashlib.sha256(bytes.fromhex(a[7:]) + bytes.fromhex(b[7:])).digest()
+        cc = hashlib.sha256(bytes.fromhex(c[7:]) + bytes.fromhex(c[7:])).digest()
         root = hashlib.sha256(ab + cc).digest()
         assert merkle_root([a, b, c]) == "sha256:" + root.hex()
 

--- a/server/backend/tests/test_migration_0002_xgroup_consent.py
+++ b/server/backend/tests/test_migration_0002_xgroup_consent.py
@@ -33,9 +33,7 @@ def _run_alembic(db_path: Path, command: str, target: str) -> subprocess.Complet
 
 
 def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
-    row = conn.execute(
-        "SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?", (name,)
-    ).fetchone()
+    row = conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?", (name,)).fetchone()
     return row is not None
 
 
@@ -78,9 +76,7 @@ class TestUpgradeDowngradeEmpty:
 
 
 class TestUpgradeOnLegacyDb:
-    def test_upgrade_on_populated_legacy_db_adds_column_and_tables(
-        self, tmp_path: Path
-    ) -> None:
+    def test_upgrade_on_populated_legacy_db_adds_column_and_tables(self, tmp_path: Path) -> None:
         db = tmp_path / "alembic_legacy.db"
 
         # Pre-step-1 shape: knowledge_units / users without tenancy
@@ -109,6 +105,7 @@ class TestUpgradeOnLegacyDb:
         # The bare CLI path doesn't stamp, so it errors trying to
         # create knowledge_units a second time.
         from cq_server.migrations import run_migrations
+
         run_migrations(f"sqlite:///{db}")
 
         check = sqlite3.connect(str(db))

--- a/server/backend/tests/test_migration_0003_presence.py
+++ b/server/backend/tests/test_migration_0003_presence.py
@@ -5,6 +5,7 @@ Mirrors the pattern in ``test_migration_0002_xgroup_consent.py``. Runs
 empty DB and a populated legacy DB; both cycles must complete without
 raising and end with the expected schema.
 """
+
 from __future__ import annotations
 
 import os
@@ -32,9 +33,7 @@ def _run_alembic(db_path: Path, command: str, target: str) -> subprocess.Complet
 
 
 def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
-    row = conn.execute(
-        "SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?", (name,)
-    ).fetchone()
+    row = conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?", (name,)).fetchone()
     return row is not None
 
 
@@ -79,9 +78,7 @@ class TestUpgradeDowngradeEmpty:
 
 
 class TestUpgradeOnLegacyDb:
-    def test_upgrade_on_populated_legacy_db_adds_role_and_peers(
-        self, tmp_path: Path
-    ) -> None:
+    def test_upgrade_on_populated_legacy_db_adds_role_and_peers(self, tmp_path: Path) -> None:
         db = tmp_path / "alembic_legacy.db"
         # Pre-step-1 shape: minimal users/knowledge_units, no tenancy /
         # xgroup / role columns. Seed one user so the role-backfill is
@@ -106,6 +103,7 @@ class TestUpgradeOnLegacyDb:
         # Use the python runtime path so the legacy DB is stamped at
         # baseline before the chain walks; the bare CLI doesn't stamp.
         from cq_server.migrations import run_migrations
+
         run_migrations(f"sqlite:///{db}")
 
         check = sqlite3.connect(str(db))
@@ -116,9 +114,7 @@ class TestUpgradeOnLegacyDb:
             assert _column_exists(check, "users", "role")
             assert _table_exists(check, "peers")
             # Backfill: legacy user gets role='user'.
-            row = check.execute(
-                "SELECT role FROM users WHERE username = 'legacy-user'"
-            ).fetchone()
+            row = check.execute("SELECT role FROM users WHERE username = 'legacy-user'").fetchone()
             assert row is not None
             assert row[0] == "user"
         finally:

--- a/server/backend/tests/test_migration_0011_activity_log.py
+++ b/server/backend/tests/test_migration_0011_activity_log.py
@@ -39,9 +39,7 @@ from pathlib import Path
 import pytest
 
 
-def _run_alembic(
-    db_path: Path, command: str, target: str
-) -> subprocess.CompletedProcess[str]:
+def _run_alembic(db_path: Path, command: str, target: str) -> subprocess.CompletedProcess[str]:
     repo_root = Path(__file__).resolve().parents[1]
     return subprocess.run(
         ["uv", "run", "alembic", command, target],
@@ -58,9 +56,7 @@ def _run_alembic(
 
 
 def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
-    row = conn.execute(
-        "SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?", (name,)
-    ).fetchone()
+    row = conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?", (name,)).fetchone()
     return row is not None
 
 
@@ -116,8 +112,7 @@ class TestUpgradeDowngradeEmpty:
 
             # Retention config has the 90-day default.
             row = check.execute(
-                "SELECT dflt_value FROM pragma_table_info('activity_retention_config') "
-                "WHERE name = 'retention_days'"
+                "SELECT dflt_value FROM pragma_table_info('activity_retention_config') WHERE name = 'retention_days'"
             ).fetchone()
             assert row is not None
             assert row[0] == "90"
@@ -148,9 +143,7 @@ class TestUpgradeOnLegacyDb:
     touching pre-existing rows.
     """
 
-    def test_upgrade_creates_tables_without_disturbing_legacy_rows(
-        self, tmp_path: Path
-    ) -> None:
+    def test_upgrade_creates_tables_without_disturbing_legacy_rows(self, tmp_path: Path) -> None:
         db = tmp_path / "alembic_legacy.db"
         conn = sqlite3.connect(str(db))
         conn.executescript(
@@ -171,6 +164,7 @@ class TestUpgradeOnLegacyDb:
         conn.close()
 
         from cq_server.migrations import run_migrations
+
         run_migrations(f"sqlite:///{db}")
 
         check = sqlite3.connect(str(db))
@@ -178,9 +172,7 @@ class TestUpgradeOnLegacyDb:
             assert _table_exists(check, "activity_log")
             assert _table_exists(check, "activity_retention_config")
             # Legacy row survived.
-            row = check.execute(
-                "SELECT id FROM knowledge_units WHERE id = 'legacy_ku'"
-            ).fetchone()
+            row = check.execute("SELECT id FROM knowledge_units WHERE id = 'legacy_ku'").fetchone()
             assert row is not None
             assert row[0] == "legacy_ku"
         finally:
@@ -212,9 +204,7 @@ class TestCheckConstraints:
             )
         conn.close()
 
-    def test_event_type_accepts_every_locked_enum_value(
-        self, tmp_path: Path
-    ) -> None:
+    def test_event_type_accepts_every_locked_enum_value(self, tmp_path: Path) -> None:
         db = tmp_path / "ck_event_ok.db"
         sqlite3.connect(str(db)).close()
         up = _run_alembic(db, "upgrade", "head")
@@ -225,9 +215,7 @@ class TestCheckConstraints:
         conn = sqlite3.connect(str(db))
         for i, et in enumerate(sorted(EVENT_TYPES)):
             conn.execute(
-                "INSERT INTO activity_log "
-                "(id, ts, tenant_enterprise, event_type, payload) "
-                "VALUES (?, ?, ?, ?, ?)",
+                "INSERT INTO activity_log (id, ts, tenant_enterprise, event_type, payload) VALUES (?, ?, ?, ?, ?)",
                 (f"act_ok_{i:02d}", "2026-05-06T00:00:00Z", "ent", et, "{}"),
             )
         conn.commit()
@@ -288,14 +276,18 @@ class TestSqliteStoreActivityHelpers:
                 thread_or_chain_id=None,
             )
 
-            row = store.sync._engine.connect().execute(
-                __import__("sqlalchemy").text(
-                    "SELECT id, tenant_enterprise, tenant_group, persona, human, "
-                    "event_type, payload, result_summary, thread_or_chain_id "
-                    "FROM activity_log WHERE id = :id"
-                ),
-                {"id": aid},
-            ).fetchone()
+            row = (
+                store.sync._engine.connect()
+                .execute(
+                    __import__("sqlalchemy").text(
+                        "SELECT id, tenant_enterprise, tenant_group, persona, human, "
+                        "event_type, payload, result_summary, thread_or_chain_id "
+                        "FROM activity_log WHERE id = :id"
+                    ),
+                    {"id": aid},
+                )
+                .fetchone()
+            )
             assert row is not None
             assert row[0] == aid
             assert row[1] == "ent-1"
@@ -305,15 +297,14 @@ class TestSqliteStoreActivityHelpers:
             assert row[5] == "query"
             # JSON round-trip preserves shape.
             import json as _json
+
             assert _json.loads(row[6]) == {"domains": ["api"], "limit": 5}
             assert _json.loads(row[7]) == {"ku_ids": ["ku_x"], "cache_hit": False}
             assert row[8] is None
         finally:
             store.sync.close()
 
-    async def test_append_activity_rejects_unknown_event_type(
-        self, tmp_path: Path
-    ) -> None:
+    async def test_append_activity_rejects_unknown_event_type(self, tmp_path: Path) -> None:
         from cq_server.activity import generate_activity_id, now_iso_z
         from cq_server.store import SqliteStore
 
@@ -333,9 +324,7 @@ class TestSqliteStoreActivityHelpers:
         finally:
             store.sync.close()
 
-    async def test_append_activity_allows_null_persona_and_group(
-        self, tmp_path: Path
-    ) -> None:
+    async def test_append_activity_allows_null_persona_and_group(self, tmp_path: Path) -> None:
         """System events log without a persona / group / human."""
         from cq_server.activity import generate_activity_id, now_iso_z
         from cq_server.store import SqliteStore
@@ -358,9 +347,7 @@ class TestSqliteStoreActivityHelpers:
             cnt = (
                 store.sync._engine.connect()
                 .execute(
-                    __import__("sqlalchemy").text(
-                        "SELECT COUNT(*) FROM activity_log WHERE id = :id"
-                    ),
+                    __import__("sqlalchemy").text("SELECT COUNT(*) FROM activity_log WHERE id = :id"),
                     {"id": aid},
                 )
                 .scalar()
@@ -377,10 +364,7 @@ class TestRetentionConfigHelpers:
         db = tmp_path / "ret_default.db"
         store = SqliteStore(db_path=db)
         try:
-            assert (
-                await store.get_activity_retention_days(enterprise_id="any-ent")
-                == 90
-            )
+            assert await store.get_activity_retention_days(enterprise_id="any-ent") == 90
         finally:
             store.sync.close()
 
@@ -390,26 +374,13 @@ class TestRetentionConfigHelpers:
         db = tmp_path / "ret_set.db"
         store = SqliteStore(db_path=db)
         try:
-            await store.set_activity_retention_days(
-                enterprise_id="ent-1", retention_days=30
-            )
-            assert (
-                await store.get_activity_retention_days(enterprise_id="ent-1")
-                == 30
-            )
+            await store.set_activity_retention_days(enterprise_id="ent-1", retention_days=30)
+            assert await store.get_activity_retention_days(enterprise_id="ent-1") == 30
             # Upsert overrides existing value.
-            await store.set_activity_retention_days(
-                enterprise_id="ent-1", retention_days=180
-            )
-            assert (
-                await store.get_activity_retention_days(enterprise_id="ent-1")
-                == 180
-            )
+            await store.set_activity_retention_days(enterprise_id="ent-1", retention_days=180)
+            assert await store.get_activity_retention_days(enterprise_id="ent-1") == 180
             # Sibling enterprise still defaults.
-            assert (
-                await store.get_activity_retention_days(enterprise_id="ent-2")
-                == 90
-            )
+            assert await store.get_activity_retention_days(enterprise_id="ent-2") == 90
         finally:
             store.sync.close()
 
@@ -420,21 +391,15 @@ class TestRetentionConfigHelpers:
         store = SqliteStore(db_path=db)
         try:
             with pytest.raises(ValueError):
-                await store.set_activity_retention_days(
-                    enterprise_id="ent-1", retention_days=0
-                )
+                await store.set_activity_retention_days(enterprise_id="ent-1", retention_days=0)
             with pytest.raises(ValueError):
-                await store.set_activity_retention_days(
-                    enterprise_id="ent-1", retention_days=-7
-                )
+                await store.set_activity_retention_days(enterprise_id="ent-1", retention_days=-7)
         finally:
             store.sync.close()
 
 
 class TestPurgeOlderThan:
-    async def test_purge_deletes_only_old_rows_for_named_tenant(
-        self, tmp_path: Path
-    ) -> None:
+    async def test_purge_deletes_only_old_rows_for_named_tenant(self, tmp_path: Path) -> None:
         from datetime import UTC, datetime, timedelta
 
         from cq_server.activity import generate_activity_id
@@ -478,19 +443,15 @@ class TestPurgeOlderThan:
             )
 
             # Purge ent-1 only.
-            deleted = await store.purge_activity_older_than(
-                tenant_enterprise="ent-1", cutoff_iso=cutoff_iso
-            )
+            deleted = await store.purge_activity_older_than(tenant_enterprise="ent-1", cutoff_iso=cutoff_iso)
             assert deleted == 1
 
             # ent-1 still has the recent row; ent-2 still has its old row.
             import sqlalchemy as _sa
+
             with store.sync._engine.connect() as conn:
                 rows = conn.execute(
-                    _sa.text(
-                        "SELECT tenant_enterprise, ts FROM activity_log "
-                        "ORDER BY tenant_enterprise, ts"
-                    )
+                    _sa.text("SELECT tenant_enterprise, ts FROM activity_log ORDER BY tenant_enterprise, ts")
                 ).fetchall()
             assert [(r[0], r[1]) for r in rows] == [
                 ("ent-1", recent_ts),

--- a/server/backend/tests/test_migrations.py
+++ b/server/backend/tests/test_migrations.py
@@ -318,9 +318,7 @@ class TestExistingPreAlembicDatabase:
                 assert table in after_schema, f"original table {table} missing post-migration"
                 before_cols = {c[0] for c in before_shape["columns"]}
                 after_cols = {c[0] for c in after_schema[table]["columns"]}
-                assert before_cols <= after_cols, (
-                    f"columns lost on {table}: {before_cols - after_cols}"
-                )
+                assert before_cols <= after_cols, f"columns lost on {table}: {before_cols - after_cols}"
 
             # Original-table row counts unchanged.
             for table in before["counts"]:
@@ -349,9 +347,7 @@ class TestExistingPreAlembicDatabase:
         # Snapshot the post-first-run schema, then run a second time.
         with _open_ro(db) as conn:
             after_first_run = _normalized_schema(conn)
-            counts_first_run = _row_counts(
-                conn, _user_table_names(conn) - {"alembic_version"}
-            )
+            counts_first_run = _row_counts(conn, _user_table_names(conn) - {"alembic_version"})
 
         run_migrations(_sqlite_url(db))
 
@@ -466,8 +462,7 @@ class TestBaselineMatchesLegacySchema:
             cols_a = {(c[0], c[1]) for c in schema_a[table]["columns"]}
             cols_b = {(c[0], c[1]) for c in schema_b[table]["columns"]}
             assert cols_b == cols_a, (
-                f"column drift on {table}: "
-                f"legacy-only={cols_a - cols_b}, migration-only={cols_b - cols_a}"
+                f"column drift on {table}: legacy-only={cols_a - cols_b}, migration-only={cols_b - cols_a}"
             )
 
 

--- a/server/backend/tests/test_network_dsn_cache.py
+++ b/server/backend/tests/test_network_dsn_cache.py
@@ -121,9 +121,7 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
 
 
 def _login(client: TestClient) -> str:
-    resp = client.post(
-        "/api/v1/auth/login", json={"username": ALICE, "password": "pw"}
-    )
+    resp = client.post("/api/v1/auth/login", json={"username": ALICE, "password": "pw"})
     assert resp.status_code == 200, resp.text
     return resp.json()["token"]
 

--- a/server/backend/tests/test_network_topology.py
+++ b/server/backend/tests/test_network_topology.py
@@ -81,22 +81,15 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
 
 
 def _login(client: TestClient, username: str = ALICE) -> str:
-    resp = client.post(
-        "/api/v1/auth/login", json={"username": username, "password": "pw"}
-    )
+    resp = client.post("/api/v1/auth/login", json={"username": username, "password": "pw"})
     assert resp.status_code == 200, resp.text
     return resp.json()["token"]
 
 
 class TestTopologyHappyPath:
-    def test_all_six_l2s_aggregated(
-        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_all_six_l2s_aggregated(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
         async def _fake_fan_out(fleet):
-            return [
-                _snapshot(slug=l2["slug"], enterprise=l2["enterprise"], group=l2["group"])
-                for l2 in fleet
-            ]
+            return [_snapshot(slug=l2["slug"], enterprise=l2["enterprise"], group=l2["group"]) for l2 in fleet]
 
         monkeypatch.setattr(network, "_fan_out_all", _fake_fan_out)
         jwt = _login(client)
@@ -139,9 +132,7 @@ class TestPartialFleetFailure:
                     )
                     snaps.append(snap)
                 else:
-                    snaps.append(
-                        _snapshot(slug=l2["slug"], enterprise=l2["enterprise"], group=l2["group"])
-                    )
+                    snaps.append(_snapshot(slug=l2["slug"], enterprise=l2["enterprise"], group=l2["group"]))
             return snaps
 
         monkeypatch.setattr(network, "_fan_out_all", _fake_fan_out)
@@ -170,10 +161,7 @@ class TestTopologyCache:
 
         async def _fake_fan_out(fleet):
             call_count["n"] += 1
-            return [
-                _snapshot(slug=l2["slug"], enterprise=l2["enterprise"], group=l2["group"])
-                for l2 in fleet
-            ]
+            return [_snapshot(slug=l2["slug"], enterprise=l2["enterprise"], group=l2["group"]) for l2 in fleet]
 
         monkeypatch.setattr(network, "_fan_out_all", _fake_fan_out)
         jwt = _login(client)

--- a/server/backend/tests/test_peers_active.py
+++ b/server/backend/tests/test_peers_active.py
@@ -8,6 +8,7 @@ Pins:
   - group filter narrows within the same Enterprise.
   - include_self=False + self_persona excludes the caller's own row.
 """
+
 from __future__ import annotations
 
 from collections.abc import Iterator
@@ -22,7 +23,7 @@ from cq_server.app import _get_store, app
 from cq_server.deps import require_api_key
 
 ALICE = "alice"  # acme/engineering
-BOB = "bob"      # acme/solutions
+BOB = "bob"  # acme/solutions
 CARLA = "carla"  # initech/r-and-d (cross-Enterprise)
 
 
@@ -135,7 +136,7 @@ class TestDiscoverableFilter:
 class TestGroupFilter:
     def test_group_param_narrows_to_one_group(self, client: TestClient) -> None:
         _heartbeat(client, as_user=ALICE, persona="persona-alice")  # acme/engineering
-        _heartbeat(client, as_user=BOB, persona="persona-bob")      # acme/solutions
+        _heartbeat(client, as_user=BOB, persona="persona-bob")  # acme/solutions
         body = _list_active(client, as_user=ALICE, include_self=True, group="solutions")
         personas = {p["persona"] for p in body["active_peers"]}
         assert personas == {"persona-bob"}
@@ -145,18 +146,14 @@ class TestIncludeSelf:
     def test_self_excluded_by_default_when_persona_passed(self, client: TestClient) -> None:
         _heartbeat(client, as_user=ALICE, persona="persona-me")
         _heartbeat(client, as_user=ALICE, persona="persona-other")
-        body = _list_active(
-            client, as_user=ALICE, include_self=False, self_persona="persona-me"
-        )
+        body = _list_active(client, as_user=ALICE, include_self=False, self_persona="persona-me")
         personas = {p["persona"] for p in body["active_peers"]}
         assert "persona-me" not in personas
         assert "persona-other" in personas
 
     def test_include_self_true_returns_self(self, client: TestClient) -> None:
         _heartbeat(client, as_user=ALICE, persona="persona-me")
-        body = _list_active(
-            client, as_user=ALICE, include_self=True, self_persona="persona-me"
-        )
+        body = _list_active(client, as_user=ALICE, include_self=True, self_persona="persona-me")
         personas = {p["persona"] for p in body["active_peers"]}
         assert "persona-me" in personas
 

--- a/server/backend/tests/test_peers_heartbeat.py
+++ b/server/backend/tests/test_peers_heartbeat.py
@@ -8,6 +8,7 @@ Pins:
   - persona is the primary key — two heartbeats with the same persona
     end up as one row.
 """
+
 from __future__ import annotations
 
 import json
@@ -41,8 +42,7 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
         # Promote Alice to a foreign tenancy scope. Bob stays default.
         with store._engine.begin() as _c:
             _c.exec_driver_sql(
-                "UPDATE users SET enterprise_id = 'acme', group_id = 'engineering' "
-                "WHERE username = ?",
+                "UPDATE users SET enterprise_id = 'acme', group_id = 'engineering' WHERE username = ?",
                 (ALICE,),
             )
         yield c
@@ -95,9 +95,7 @@ class TestHeartbeatUpsert:
             # And there should be exactly one row in the DB.
             store = _get_store()
             with store._engine.begin() as _c:
-                count = _c.exec_driver_sql(
-                    "SELECT COUNT(*) FROM peers WHERE persona = 'persona-x'"
-                ).fetchone()[0]
+                count = _c.exec_driver_sql("SELECT COUNT(*) FROM peers WHERE persona = 'persona-x'").fetchone()[0]
             assert count == 1
         finally:
             _clear_override()

--- a/server/backend/tests/test_pending_review_concurrency.py
+++ b/server/backend/tests/test_pending_review_concurrency.py
@@ -118,9 +118,7 @@ class TestSetReviewStatusReturnValue:
         assert review["status"] == "approved"
         assert review["reviewed_by"] == "first"
 
-    def test_dropped_status_also_blocks_subsequent_writes(
-        self, store: SqliteStore
-    ) -> None:
+    def test_dropped_status_also_blocks_subsequent_writes(self, store: SqliteStore) -> None:
         """``dropped`` (the pending_review→reject terminal) must also
         block further transitions. Pins that the WHERE clause's
         terminal-state list covers all three values, not just
@@ -156,9 +154,7 @@ class TestSetReviewStatusReturnValue:
 
 
 class TestRouteRaceProduces409:
-    def test_concurrent_approve_then_reject_returns_409(
-        self, client: TestClient
-    ) -> None:
+    def test_concurrent_approve_then_reject_returns_409(self, client: TestClient) -> None:
         """Two admins race on the same KU. The first /approve wins; the
         second /reject must 409 with the terminal status, not silently
         overwrite the audit row.
@@ -210,9 +206,7 @@ class TestRouteRaceProduces409:
         assert b_resp.status_code == 409
         assert "approved" in b_resp.json()["detail"]
 
-    def test_concurrent_reject_after_approve_does_not_corrupt_audit(
-        self, client: TestClient, tmp_path: Path
-    ) -> None:
+    def test_concurrent_reject_after_approve_does_not_corrupt_audit(self, client: TestClient, tmp_path: Path) -> None:
         """Pin the on-disk shape: after the racing reject 409s, the
         ``reviewed_by`` row in the DB is still the winning admin's
         username — not the loser's. This is the audit-corruption
@@ -237,9 +231,7 @@ class TestRouteRaceProduces409:
                     "action": "Inspect the SQLite row directly.",
                 },
             },
-            headers={
-                "Authorization": f"Bearer {prop_key_resp.json()['token']}"
-            },
+            headers={"Authorization": f"Bearer {prop_key_resp.json()['token']}"},
         )
         assert propose.status_code == 201, propose.text
         ku_id = propose.json()["id"]

--- a/server/backend/tests/test_pending_review_tier.py
+++ b/server/backend/tests/test_pending_review_tier.py
@@ -94,9 +94,7 @@ def _login_jwt(client: TestClient, username: str, password: str) -> str:
 
 
 class TestSubmitPendingReview:
-    def test_submission_lands_with_status_and_reason_columns(
-        self, store: SqliteStore, tmp_path: Path
-    ) -> None:
+    def test_submission_lands_with_status_and_reason_columns(self, store: SqliteStore, tmp_path: Path) -> None:
         unit = _make_unit()
         expires = (datetime.now(UTC) + timedelta(days=30)).isoformat()
         store.sync.submit_pending_review(
@@ -130,9 +128,7 @@ class TestSubmitPendingReview:
 
 
 class TestPendingReviewListAndCount:
-    def test_listing_orders_by_expires_ascending(
-        self, store: SqliteStore
-    ) -> None:
+    def test_listing_orders_by_expires_ascending(self, store: SqliteStore) -> None:
         # Three pending-review rows with different expiries.
         soon = (datetime.now(UTC) + timedelta(days=1)).isoformat()
         mid = (datetime.now(UTC) + timedelta(days=15)).isoformat()
@@ -154,9 +150,7 @@ class TestPendingReviewListAndCount:
 
         assert store.sync.count_pending_review(enterprise_id="acme") == 3
 
-    def test_listing_scopes_by_enterprise(
-        self, store: SqliteStore
-    ) -> None:
+    def test_listing_scopes_by_enterprise(self, store: SqliteStore) -> None:
         """Cross-tenant: an acme pending-review row must NOT appear in
         moscowmul3's queue. Pin against accidental cross-tenant leak."""
         store.sync.submit_pending_review(
@@ -173,12 +167,8 @@ class TestPendingReviewListAndCount:
             enterprise_id="moscowmul3",
             group_id="engineering",
         )
-        acme_items = store.sync.list_pending_review(
-            enterprise_id="acme", limit=10, offset=0
-        )
-        moscow_items = store.sync.list_pending_review(
-            enterprise_id="moscowmul3", limit=10, offset=0
-        )
+        acme_items = store.sync.list_pending_review(enterprise_id="acme", limit=10, offset=0)
+        moscow_items = store.sync.list_pending_review(enterprise_id="moscowmul3", limit=10, offset=0)
         assert [i["knowledge_unit"].insight.summary for i in acme_items] == ["acme-only"]
         assert [i["knowledge_unit"].insight.summary for i in moscow_items] == ["moscow-only"]
 
@@ -206,9 +196,7 @@ class TestExpirePendingReviews:
         )
 
         now_iso = datetime.now(UTC).isoformat()
-        dropped = store.sync.expire_pending_reviews(
-            enterprise_id="acme", now_iso=now_iso
-        )
+        dropped = store.sync.expire_pending_reviews(enterprise_id="acme", now_iso=now_iso)
         assert dropped == [drop.id]
 
         # The non-expired row stays put; the expired row is now status=dropped.
@@ -267,9 +255,7 @@ class TestPendingReviewRoute:
         )
         assert resp.status_code == 403  # require_admin gate
 
-    def test_approve_from_pending_review_transitions_to_approved(
-        self, client: TestClient
-    ) -> None:
+    def test_approve_from_pending_review_transitions_to_approved(self, client: TestClient) -> None:
         _seed_user(username="admin_approve", password="pw", role="admin")
         s = _get_store()
         unit = _make_unit()
@@ -289,9 +275,7 @@ class TestPendingReviewRoute:
         assert resp.status_code == 200, resp.text
         assert resp.json()["status"] == "approved"
 
-    def test_reject_from_pending_review_transitions_to_dropped_not_rejected(
-        self, client: TestClient
-    ) -> None:
+    def test_reject_from_pending_review_transitions_to_dropped_not_rejected(self, client: TestClient) -> None:
         """The lifecycle distinction (#103): operator rejection of a
         pending_review row sets status='dropped', not 'rejected'.
         Pins the spec line "pending_review → dropped (operator rejects)".
@@ -316,9 +300,7 @@ class TestPendingReviewRoute:
         # Critical assertion: dropped, not rejected.
         assert resp.json()["status"] == "dropped"
 
-    def test_reject_from_regular_pending_still_uses_rejected(
-        self, client: TestClient
-    ) -> None:
+    def test_reject_from_regular_pending_still_uses_rejected(self, client: TestClient) -> None:
         """The dropped distinction is *only* for pending_review. A
         regular ``status='pending'`` rejection still goes to
         ``status='rejected'`` — unchanged from pre-#103 behaviour."""

--- a/server/backend/tests/test_pending_review_ttl.py
+++ b/server/backend/tests/test_pending_review_ttl.py
@@ -93,9 +93,7 @@ def _login_jwt(client: TestClient, username: str, password: str) -> str:
 
 
 class TestListFiltersExpiredRows:
-    def test_expired_row_invisible_in_list_even_before_sweep(
-        self, store: SqliteStore
-    ) -> None:
+    def test_expired_row_invisible_in_list_even_before_sweep(self, store: SqliteStore) -> None:
         """Submit a row whose TTL has already passed at insert time
         (sweeper has not run). The list query must not include it.
         Pre-fix the row appeared in the result; the read filter closes
@@ -123,18 +121,13 @@ class TestListFiltersExpiredRows:
         # The sweeper has NOT run yet; the on-disk status of the
         # expired row is still 'pending_review'. The read filter is
         # what keeps it out of the response.
-        items = store.sync.list_pending_review(
-            enterprise_id="acme", limit=10, offset=0
-        )
+        items = store.sync.list_pending_review(enterprise_id="acme", limit=10, offset=0)
         summaries = [i["knowledge_unit"].insight.summary for i in items]
         assert summaries == ["fresh"], (
-            f"#121 finding 2: expired pending_review row leaked into "
-            f"list. Got {summaries!r}; expected only ['fresh']."
+            f"#121 finding 2: expired pending_review row leaked into list. Got {summaries!r}; expected only ['fresh']."
         )
 
-    def test_count_matches_list_under_ttl_filter(
-        self, store: SqliteStore
-    ) -> None:
+    def test_count_matches_list_under_ttl_filter(self, store: SqliteStore) -> None:
         """count_pending_review must agree with list_pending_review on
         which rows are visible — otherwise dashboard pagination breaks
         (total: 5 with only 3 items rendered).
@@ -154,15 +147,11 @@ class TestListFiltersExpiredRows:
                 group_id="engineering",
             )
 
-        listed = store.sync.list_pending_review(
-            enterprise_id="acme", limit=10, offset=0
-        )
+        listed = store.sync.list_pending_review(enterprise_id="acme", limit=10, offset=0)
         counted = store.sync.count_pending_review(enterprise_id="acme")
         assert len(listed) == counted == 1
 
-    def test_null_expires_at_continues_to_appear(
-        self, store: SqliteStore, tmp_path: Path
-    ) -> None:
+    def test_null_expires_at_continues_to_appear(self, store: SqliteStore, tmp_path: Path) -> None:
         """Defensive: a row with NULL ``pending_review_expires_at``
         means "no TTL configured". The read filter uses
         ``IS NULL OR > now`` so those rows still appear — same shape
@@ -185,17 +174,14 @@ class TestListFiltersExpiredRows:
         conn = sqlite3.connect(str(tmp_path / "ttl.db"))
         try:
             conn.execute(
-                "UPDATE knowledge_units SET pending_review_expires_at = NULL "
-                "WHERE id = ?",
+                "UPDATE knowledge_units SET pending_review_expires_at = NULL WHERE id = ?",
                 (unit.id,),
             )
             conn.commit()
         finally:
             conn.close()
 
-        items = store.sync.list_pending_review(
-            enterprise_id="acme", limit=10, offset=0
-        )
+        items = store.sync.list_pending_review(enterprise_id="acme", limit=10, offset=0)
         assert [i["knowledge_unit"].id for i in items] == [unit.id]
         assert store.sync.count_pending_review(enterprise_id="acme") == 1
 
@@ -237,14 +223,10 @@ class TestEndpointEnforcesTTL:
         assert resp.status_code == 200, resp.text
         body = resp.json()
         assert body["total"] == 1
-        summaries = [
-            i["knowledge_unit"]["insight"]["summary"] for i in body["items"]
-        ]
+        summaries = [i["knowledge_unit"]["insight"]["summary"] for i in body["items"]]
         assert summaries == ["route-fresh"]
 
-    def test_endpoint_triggers_background_sweep(
-        self, client: TestClient
-    ) -> None:
+    def test_endpoint_triggers_background_sweep(self, client: TestClient) -> None:
         """The route schedules a background sweep so on-disk state
         eventually catches up. Verify that after a request the
         previously-expired row's status moved to 'dropped' on disk —

--- a/server/backend/tests/test_propose_tenancy_regression.py
+++ b/server/backend/tests/test_propose_tenancy_regression.py
@@ -44,9 +44,7 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
         yield c
 
 
-def _seed_user(
-    *, username: str, password: str, enterprise_id: str, group_id: str
-) -> None:
+def _seed_user(*, username: str, password: str, enterprise_id: str, group_id: str) -> None:
     """Create a user, then UPDATE their tenancy columns to non-default values.
 
     ``store.sync.create_user`` lands the row at ``default-enterprise`` /
@@ -124,9 +122,7 @@ def _read_scope(db_path: Path, ku_id: str) -> tuple[str, str]:
 
 
 class TestProposeHonoursAuthClaims:
-    def test_ku_lands_in_authed_users_enterprise_not_default(
-        self, client: TestClient, tmp_path: Path
-    ) -> None:
+    def test_ku_lands_in_authed_users_enterprise_not_default(self, client: TestClient, tmp_path: Path) -> None:
         """The bug: the KU lands in default-enterprise. The fix: it lands in moscowmul3.
 
         Verbatim the bug-report repro shape — same user setup, same
@@ -147,13 +143,9 @@ class TestProposeHonoursAuthClaims:
             "The propose handler must derive enterprise_id from the user "
             "row, not the schema-level server_default."
         )
-        assert grp == "engineering", (
-            f"#89 regression: KU group_id is {grp!r} instead of engineering"
-        )
+        assert grp == "engineering", f"#89 regression: KU group_id is {grp!r} instead of engineering"
 
-    def test_ku_never_lands_in_default_enterprise_for_authed_user(
-        self, client: TestClient, tmp_path: Path
-    ) -> None:
+    def test_ku_never_lands_in_default_enterprise_for_authed_user(self, client: TestClient, tmp_path: Path) -> None:
         """Cover the inverse: even with an obviously-non-default user,
         the row never falls back to ``default-enterprise``.
 
@@ -176,9 +168,7 @@ class TestProposeHonoursAuthClaims:
         assert grp != "default-group"
         assert (ent, grp) == ("acme", "solutions")
 
-    def test_two_users_two_enterprises_no_cross_contamination(
-        self, client: TestClient, tmp_path: Path
-    ) -> None:
+    def test_two_users_two_enterprises_no_cross_contamination(self, client: TestClient, tmp_path: Path) -> None:
         """Two users in two different Enterprises propose; each KU lands
         in its own user's tenant. Pins that the resolution is per-call,
         not cached or thread-local.
@@ -206,9 +196,7 @@ class TestProposeHonoursAuthClaims:
         assert moscow_scope == ("moscowmul3", "engineering")
         assert acme_scope == ("acme", "solutions")
 
-    def test_propose_rejects_when_user_row_missing_tenancy(
-        self, client: TestClient, tmp_path: Path
-    ) -> None:
+    def test_propose_rejects_when_user_row_missing_tenancy(self, client: TestClient, tmp_path: Path) -> None:
         """Defensive: if a future migration somehow leaves a user row
         with NULL tenancy, the handler should fail loudly rather than
         silently writing the KU into the schema default. We simulate
@@ -223,10 +211,7 @@ class TestProposeHonoursAuthClaims:
             # rebuilt the column; we simulate the malformed-row state
             # by writing empty strings (the handler treats them the
             # same way: 500 rather than silent default).
-            conn.exec_driver_sql(
-                "UPDATE users SET enterprise_id = '', group_id = '' "
-                "WHERE username = 'nullable'"
-            )
+            conn.exec_driver_sql("UPDATE users SET enterprise_id = '', group_id = '' WHERE username = 'nullable'")
 
         api_key = _login_and_mint(client, "nullable", "pw")
         resp = client.post(
@@ -252,9 +237,7 @@ class TestProposeHonoursAuthClaims:
 
 
 class TestLegacyInsertPathPreserved:
-    def test_no_kwargs_insert_still_uses_server_defaults(
-        self, tmp_path: Path
-    ) -> None:
+    def test_no_kwargs_insert_still_uses_server_defaults(self, tmp_path: Path) -> None:
         """The legacy fixture path (``store.sync.insert(unit)``) doesn't
         carry tenancy — by design, since unit-test fixtures don't always
         manufacture a tenant. The fix preserves that behaviour: the row

--- a/server/backend/tests/test_quality.py
+++ b/server/backend/tests/test_quality.py
@@ -1,4 +1,5 @@
 """Tests for the propose-time content quality guards."""
+
 from __future__ import annotations
 
 from cq.models import Insight
@@ -122,8 +123,9 @@ class TestAcceptanceCases:
             ["lambda", "vpc", "cold-start"],
             Insight(
                 summary="VPC-attached Lambda functions cannot reach public APIs by default",
-                detail="When a Lambda is configured with a VPC, outbound traffic routes through the VPC. Without a NAT gateway or VPC endpoint, public APIs are unreachable. The error appears as a generic timeout, not a network-error, masking the cause.",
-                action="Add a NAT gateway in a public subnet and route the Lambda's private subnet through it, OR add VPC endpoints for the specific AWS services the Lambda calls.",
+                # Long fixture strings mirror real Strands probe payloads — wrapping would distort the test data.
+                detail="When a Lambda is configured with a VPC, outbound traffic routes through the VPC. Without a NAT gateway or VPC endpoint, public APIs are unreachable. The error appears as a generic timeout, not a network-error, masking the cause.",  # noqa: E501
+                action="Add a NAT gateway in a public subnet and route the Lambda's private subnet through it, OR add VPC endpoints for the specific AWS services the Lambda calls.",  # noqa: E501
             ),
         )
         assert reason is None

--- a/server/backend/tests/test_queries.py
+++ b/server/backend/tests/test_queries.py
@@ -33,6 +33,7 @@ from cq_server.store import _queries as q
 async def db(tmp_path: Path) -> AsyncIterator[tuple[SqliteStore, Engine]]:
     """Shared on-disk SQLite database with both a SqliteStore and an SA engine."""
     from cq_server.migrations import run_migrations
+
     db_path = tmp_path / "test.db"
     run_migrations(f"sqlite:///{db_path}")
     store = SqliteStore(db_path=db_path)

--- a/server/backend/tests/test_reflect.py
+++ b/server/backend/tests/test_reflect.py
@@ -64,10 +64,7 @@ def alice_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Te
                 from sqlalchemy import text as _text
 
                 conn.execute(
-                    _text(
-                        "UPDATE users SET enterprise_id = 'ent-bob' "
-                        "WHERE username = :u"
-                    ),
+                    _text("UPDATE users SET enterprise_id = 'ent-bob' WHERE username = :u"),
                     {"u": BOB_USERNAME},
                 )
         yield client
@@ -215,9 +212,7 @@ class TestStatus:
         )
         assert resp.status_code == 404
 
-    def test_status_cross_enterprise_isolation(
-        self, alice_client: TestClient, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_status_cross_enterprise_isolation(self, alice_client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
         # Alice creates a submission. Bob (different Enterprise) tries
         # to read it via the same submission_id and sees 404.
         submit_resp = alice_client.post(

--- a/server/backend/tests/test_reputation.py
+++ b/server/backend/tests/test_reputation.py
@@ -33,12 +33,7 @@ def conn(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> sqlite3.Connection:
 
 class TestSchema:
     def test_migration_creates_reputation_tables(self, conn: sqlite3.Connection) -> None:
-        names = {
-            r[0]
-            for r in conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table'"
-            ).fetchall()
-        }
+        names = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
         assert "reputation_events" in names
         assert "reputation_chain_meta" in names
 
@@ -139,9 +134,7 @@ class TestRecordEvent:
             "SELECT last_event_id, last_event_hash FROM reputation_chain_meta WHERE enterprise_id = ?",
             ("test-corp",),
         ).fetchone()
-        count_before = conn.execute(
-            "SELECT COUNT(*) FROM reputation_events"
-        ).fetchone()[0]
+        count_before = conn.execute("SELECT COUNT(*) FROM reputation_events").fetchone()[0]
 
         # Force the chain-meta upsert to raise mid-record_event. The
         # event-row INSERT will already have happened by then.
@@ -150,20 +143,14 @@ class TestRecordEvent:
 
         monkeypatch.setattr(reputation, "_upsert_chain_meta", _boom)
 
-        result = reputation.record_event(
-            conn, event_type="consult.closed", body={"i": 2}
-        )
+        result = reputation.record_event(conn, event_type="consult.closed", body={"i": 2})
         assert result is None  # best-effort returned None per contract
         # Caller's commit happens — verify nothing leaked.
         conn.commit()
 
         # Event row from the failed call must NOT have persisted.
-        count_after = conn.execute(
-            "SELECT COUNT(*) FROM reputation_events"
-        ).fetchone()[0]
-        assert count_after == count_before, (
-            "savepoint failed to roll back the orphan event row"
-        )
+        count_after = conn.execute("SELECT COUNT(*) FROM reputation_events").fetchone()[0]
+        assert count_after == count_before, "savepoint failed to roll back the orphan event row"
 
         # Chain meta still points at e1, NOT a fictitious advance.
         meta_after = conn.execute(
@@ -201,9 +188,7 @@ class TestSigning:
         forward_sign.reload_l2_privkey()  # picks up the new path
 
         try:
-            eid = reputation.record_event(
-                conn, event_type="consult.closed", body={"thread_id": "th_signed"}
-            )
+            eid = reputation.record_event(conn, event_type="consult.closed", body={"thread_id": "th_signed"})
             conn.commit()
             assert eid is not None
 
@@ -235,15 +220,12 @@ class TestSigning:
         forward_sign.reload_l2_privkey()
 
         try:
-            eid = reputation.record_event(
-                conn, event_type="ku.event", body={"unit_id": "ku_42", "verb": "approve"}
-            )
+            eid = reputation.record_event(conn, event_type="ku.event", body={"unit_id": "ku_42", "verb": "approve"})
             conn.commit()
             assert eid is not None
 
             row = conn.execute(
-                "SELECT payload_canonical, signature_b64u, signing_key_id "
-                "FROM reputation_events WHERE event_id = ?",
+                "SELECT payload_canonical, signature_b64u, signing_key_id FROM reputation_events WHERE event_id = ?",
                 (eid,),
             ).fetchone()
             canonical_str, sig, kid = row
@@ -271,9 +253,7 @@ class TestSigning:
         forward_sign.reload_l2_privkey()
 
         try:
-            eid = reputation.record_event(
-                conn, event_type="consult.closed", body={"thread_id": "th_unsigned"}
-            )
+            eid = reputation.record_event(conn, event_type="consult.closed", body={"thread_id": "th_unsigned"})
             conn.commit()
             if eid is None:
                 # If load_or_create_l2_privkey raised (ran on a system that

--- a/server/backend/tests/test_reputation_verifier.py
+++ b/server/backend/tests/test_reputation_verifier.py
@@ -20,9 +20,7 @@ from cq_server.reputation_verifier import (
 
 
 @pytest.fixture()
-def conn_with_signing(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> sqlite3.Connection:
+def conn_with_signing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> sqlite3.Connection:
     """DB with an L2 signing key in place — events come out signed."""
     monkeypatch.setenv("CQ_ENTERPRISE", "test-corp")
     monkeypatch.setenv("CQ_GROUP", "engineering")
@@ -72,9 +70,7 @@ class TestChain:
         assert result["ok"] is True
         assert result["count"] == 0
 
-    def test_intact_chain_verifies(
-        self, conn_with_signing: sqlite3.Connection
-    ) -> None:
+    def test_intact_chain_verifies(self, conn_with_signing: sqlite3.Connection) -> None:
         for i in range(5):
             reputation.record_event(
                 conn_with_signing,
@@ -89,9 +85,7 @@ class TestChain:
         assert result["ok"] is True
         assert result["count"] == 5
 
-    def test_broken_chain_detected(
-        self, conn_with_signing: sqlite3.Connection
-    ) -> None:
+    def test_broken_chain_detected(self, conn_with_signing: sqlite3.Connection) -> None:
         for i in range(3):
             reputation.record_event(
                 conn_with_signing,
@@ -109,22 +103,14 @@ class TestChain:
 
 
 class TestPayloadHashes:
-    def test_intact_payloads_verify(
-        self, conn_with_signing: sqlite3.Connection
-    ) -> None:
-        reputation.record_event(
-            conn_with_signing, event_type="ku.event", body={"unit_id": "ku_x"}
-        )
+    def test_intact_payloads_verify(self, conn_with_signing: sqlite3.Connection) -> None:
+        reputation.record_event(conn_with_signing, event_type="ku.event", body={"unit_id": "ku_x"})
         conn_with_signing.commit()
         events = _read_events(conn_with_signing, "test-corp")
         assert verify_event_payload_hashes(events)["ok"] is True
 
-    def test_tampered_canonical_detected(
-        self, conn_with_signing: sqlite3.Connection
-    ) -> None:
-        reputation.record_event(
-            conn_with_signing, event_type="ku.event", body={"unit_id": "ku_x"}
-        )
+    def test_tampered_canonical_detected(self, conn_with_signing: sqlite3.Connection) -> None:
+        reputation.record_event(conn_with_signing, event_type="ku.event", body={"unit_id": "ku_x"})
         conn_with_signing.commit()
         events = _read_events(conn_with_signing, "test-corp")
         events[0]["payload_canonical"] = '{"tampered":true}'
@@ -134,12 +120,8 @@ class TestPayloadHashes:
 
 
 class TestSignatures:
-    def test_signed_events_verify(
-        self, conn_with_signing: sqlite3.Connection
-    ) -> None:
-        reputation.record_event(
-            conn_with_signing, event_type="ku.event", body={"unit_id": "ku_x"}
-        )
+    def test_signed_events_verify(self, conn_with_signing: sqlite3.Connection) -> None:
+        reputation.record_event(conn_with_signing, event_type="ku.event", body={"unit_id": "ku_x"})
         conn_with_signing.commit()
         events = _read_events(conn_with_signing, "test-corp")
         result = verify_event_signatures(events)
@@ -147,12 +129,8 @@ class TestSignatures:
         assert result["signed_count"] == 1
         assert result["unsigned_count"] == 0
 
-    def test_tampered_signature_detected(
-        self, conn_with_signing: sqlite3.Connection
-    ) -> None:
-        reputation.record_event(
-            conn_with_signing, event_type="ku.event", body={"unit_id": "ku_x"}
-        )
+    def test_tampered_signature_detected(self, conn_with_signing: sqlite3.Connection) -> None:
+        reputation.record_event(conn_with_signing, event_type="ku.event", body={"unit_id": "ku_x"})
         conn_with_signing.commit()
         events = _read_events(conn_with_signing, "test-corp")
         # Flip a character in the signature
@@ -164,9 +142,7 @@ class TestSignatures:
 
 
 class TestRoot:
-    def test_root_verifies_against_events(
-        self, conn_with_signing: sqlite3.Connection
-    ) -> None:
+    def test_root_verifies_against_events(self, conn_with_signing: sqlite3.Connection) -> None:
         today = datetime.now(UTC).date().isoformat()
         for i in range(4):
             reputation.record_event(
@@ -186,9 +162,7 @@ class TestRoot:
         assert result["root_matches_events"] is True
         assert result["signature_valid"] is True
 
-    def test_root_mismatch_detected_when_event_dropped(
-        self, conn_with_signing: sqlite3.Connection
-    ) -> None:
+    def test_root_mismatch_detected_when_event_dropped(self, conn_with_signing: sqlite3.Connection) -> None:
         today = datetime.now(UTC).date().isoformat()
         for i in range(3):
             reputation.record_event(

--- a/server/backend/tests/test_sqlite_store_e2e.py
+++ b/server/backend/tests/test_sqlite_store_e2e.py
@@ -17,7 +17,9 @@ from fastapi.testclient import TestClient
 from cq_server.app import app
 
 
-@pytest.mark.skip(reason="phase-2 follow-up: app.state.store still SqliteStore, async SqliteStore not wired (task #100)")
+@pytest.mark.skip(
+    reason="phase-2 follow-up: app.state.store still SqliteStore, async SqliteStore not wired (task #100)"
+)
 def test_e2e_propose_via_store_query_via_api(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     db = tmp_path / "smoke.db"
     monkeypatch.setenv("CQ_DB_PATH", str(db))

--- a/server/backend/tests/test_sqlite_store_fork_delta.py
+++ b/server/backend/tests/test_sqlite_store_fork_delta.py
@@ -49,12 +49,8 @@ class TestDirectoryPeerings:
             last_synced_at="2026-05-03T00:00:00Z",
         )
         # Bidirectional lookup
-        a_to_b = store.sync.find_active_directory_peering(
-            from_enterprise="acme", to_enterprise="globex"
-        )
-        b_to_a = store.sync.find_active_directory_peering(
-            from_enterprise="globex", to_enterprise="acme"
-        )
+        a_to_b = store.sync.find_active_directory_peering(from_enterprise="acme", to_enterprise="globex")
+        b_to_a = store.sync.find_active_directory_peering(from_enterprise="globex", to_enterprise="acme")
         assert a_to_b is not None
         assert b_to_a is not None
         assert a_to_b["offer_id"] == "ofr_1"
@@ -79,9 +75,7 @@ class TestDirectoryPeerings:
             accept_signing_key_id="X",
             last_synced_at="2026-05-03T00:00:00Z",
         )
-        result = store.sync.find_active_directory_peering(
-            from_enterprise="acme", to_enterprise="globex"
-        )
+        result = store.sync.find_active_directory_peering(from_enterprise="acme", to_enterprise="globex")
         assert result is None
 
     @pytest.mark.asyncio
@@ -135,9 +129,7 @@ class TestAigrpPeers:
         assert peer["last_signature_at"] is not None  # signature_received=True
 
     @pytest.mark.asyncio
-    async def test_unsigned_upsert_keeps_existing_signature(
-        self, store: SqliteStore
-    ) -> None:
+    async def test_unsigned_upsert_keeps_existing_signature(self, store: SqliteStore) -> None:
         # First upsert with signature
         store.sync.upsert_aigrp_peer(
             l2_id="acme/eng",
@@ -173,7 +165,5 @@ class TestAigrpPeers:
         assert second["endpoint_url"] == "https://acme.example/eng-v2"
 
     @pytest.mark.asyncio
-    async def test_get_pubkey_returns_none_for_unknown(
-        self, store: SqliteStore
-    ) -> None:
+    async def test_get_pubkey_returns_none_for_unknown(self, store: SqliteStore) -> None:
         assert store.sync.get_aigrp_peer_pubkey("ghost/eng") is None

--- a/server/backend/tests/test_tenancy_columns.py
+++ b/server/backend/tests/test_tenancy_columns.py
@@ -48,6 +48,7 @@ def _make_unit(**overrides: Any) -> KnowledgeUnit:
 @pytest.fixture()
 def store(tmp_path: Path) -> Iterator[SqliteStore]:
     from cq_server.migrations import run_migrations
+
     db = tmp_path / "tenancy.db"
     run_migrations(f"sqlite:///{db}")
     s = SqliteStore(db_path=db)
@@ -90,8 +91,7 @@ class TestNewRowDefaults:
             store._engine.begin() as conn,
         ):
             conn.exec_driver_sql(
-                "INSERT INTO knowledge_units (id, data, enterprise_id, group_id) "
-                "VALUES (?, ?, ?, ?)",
+                "INSERT INTO knowledge_units (id, data, enterprise_id, group_id) VALUES (?, ?, ?, ?)",
                 ("ku_null", "{}", None, "default-group"),
             )
 
@@ -164,6 +164,7 @@ class TestAlembicMigration:
         # Use the python runtime path so the legacy DB is stamped at
         # baseline before the upgrade walks the chain.
         from cq_server.migrations import run_migrations
+
         run_migrations(f"sqlite:///{db}")
 
         # Inspect the row scope post-migration.

--- a/server/backend/tests/test_x_enterprise_consult.py
+++ b/server/backend/tests/test_x_enterprise_consult.py
@@ -132,11 +132,13 @@ def _capture_x_enterprise_forwards(
         target_endpoint: dict[str, Any],
         payload: dict[str, Any],
     ) -> None:
-        captured.append({
-            "peering": peering,
-            "target_endpoint": target_endpoint,
-            "payload": payload,
-        })
+        captured.append(
+            {
+                "peering": peering,
+                "target_endpoint": target_endpoint,
+                "payload": payload,
+            }
+        )
 
     monkeypatch.setattr(consults, "_x_enterprise_forward_request", _fake_x_enterprise_forward)
     return captured
@@ -177,9 +179,7 @@ def test_bearer_swap_yields_different_bearer() -> None:
 
 def test_find_active_peering_returns_match(client: TestClient) -> None:
     _seed_peering(offer_id="off_a")
-    p = _get_store().sync.find_active_directory_peering(
-        from_enterprise="acme", to_enterprise="globex"
-    )
+    p = _get_store().sync.find_active_directory_peering(from_enterprise="acme", to_enterprise="globex")
     assert p is not None
     assert p["offer_id"] == "off_a"
 
@@ -187,9 +187,7 @@ def test_find_active_peering_returns_match(client: TestClient) -> None:
 def test_find_active_peering_is_bidirectional(client: TestClient) -> None:
     """Peering from A→B is also queryable as B→A."""
     _seed_peering(offer_id="off_b", from_ent="acme", to_ent="globex")
-    p = _get_store().sync.find_active_directory_peering(
-        from_enterprise="globex", to_enterprise="acme"
-    )
+    p = _get_store().sync.find_active_directory_peering(from_enterprise="globex", to_enterprise="acme")
     assert p is not None
     assert p["offer_id"] == "off_b"
 
@@ -197,17 +195,13 @@ def test_find_active_peering_is_bidirectional(client: TestClient) -> None:
 def test_find_active_peering_skips_expired(client: TestClient) -> None:
     """Past expires_at = no row."""
     _seed_peering(offer_id="off_old", expires_at="2020-01-01T00:00:00Z")
-    p = _get_store().sync.find_active_directory_peering(
-        from_enterprise="acme", to_enterprise="globex"
-    )
+    p = _get_store().sync.find_active_directory_peering(from_enterprise="acme", to_enterprise="globex")
     assert p is None
 
 
 def test_find_active_peering_skips_non_active(client: TestClient) -> None:
     _seed_peering(offer_id="off_pending", status="pending")
-    p = _get_store().sync.find_active_directory_peering(
-        from_enterprise="acme", to_enterprise="globex"
-    )
+    p = _get_store().sync.find_active_directory_peering(from_enterprise="acme", to_enterprise="globex")
     assert p is None
 
 
@@ -216,9 +210,7 @@ def test_find_active_peering_skips_non_active(client: TestClient) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cross_enterprise_routes_via_directory_peering(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_cross_enterprise_routes_via_directory_peering(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     _seed_peering(offer_id="off_e2e")
     captured = _capture_x_enterprise_forwards(monkeypatch)
     token = _login(client)
@@ -241,9 +233,7 @@ def test_cross_enterprise_routes_via_directory_peering(
     assert forward["payload"]["content"] == "cross-enterprise hello"
 
 
-def test_cross_enterprise_no_peering_returns_403(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_cross_enterprise_no_peering_returns_403(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     captured = _capture_x_enterprise_forwards(monkeypatch)
     token = _login(client)
     r = client.post(
@@ -342,9 +332,7 @@ def test_cross_enterprise_logging_policy_no_log_skips_message_row(
     assert body["messages"] == []
 
 
-def test_cross_enterprise_mutual_log_writes_full_body(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_cross_enterprise_mutual_log_writes_full_body(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     """Default policy mutual_log_required → asker side sees full content."""
     _seed_peering(offer_id="off_mutual")
     _capture_x_enterprise_forwards(monkeypatch)
@@ -369,9 +357,7 @@ def test_cross_enterprise_mutual_log_writes_full_body(
     assert msgs.json()["messages"][0]["content"] == "full content visible"
 
 
-def test_malformed_to_l2_id_returns_400(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_malformed_to_l2_id_returns_400(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
     """to_l2_id without enterprise/group separator is rejected before lookup."""
     _capture_x_enterprise_forwards(monkeypatch)
     token = _login(client)
@@ -409,17 +395,13 @@ def test_x_enterprise_forward_request_sends_bearer_and_sig_headers(
         def __exit__(self, *_a: Any) -> None:
             pass
 
-        def post(
-            self, url: str, *, headers: dict[str, str], json: dict[str, Any]
-        ) -> httpx.Response:
+        def post(self, url: str, *, headers: dict[str, str], json: dict[str, Any]) -> httpx.Response:
             captured.append({"url": url, "headers": headers, "json": json})
             return httpx.Response(201)
 
     monkeypatch.setattr(consults.httpx, "Client", _FakeClient)
 
-    peering = _get_store().sync.find_active_directory_peering(
-        from_enterprise="acme", to_enterprise="globex"
-    )
+    peering = _get_store().sync.find_active_directory_peering(from_enterprise="acme", to_enterprise="globex")
     assert peering is not None
     target_endpoint = json.loads(peering["to_l2_endpoints_json"])[0]
 

--- a/server/scripts/backfill-embeddings.py
+++ b/server/scripts/backfill-embeddings.py
@@ -44,6 +44,7 @@ def _payload(data_str: str) -> tuple[str, str, str]:
 
 
 def main() -> int:
+    """Backfill embeddings for knowledge units missing them; return process exit code."""
     db_path = Path(os.environ.get("CQ_DB_PATH", "/data/cq.db"))
     batch = int(os.environ.get("BACKFILL_BATCH", "50"))
     cap = int(os.environ.get("BACKFILL_LIMIT", "0"))


### PR DESCRIPTION
Fixes the CI hygiene drift tracked as task #152 — ruff lint cleanup + detect-secrets baseline refresh.

## Summary

**Ruff (`ruff check`):** 8 violations fixed, 0 remaining.

| Rule | Count | Fix |
|---|---|---|
| `SIM105` | 1 | `try/except/pass` → `contextlib.suppress` |
| `SIM117` | 1 | nested `with` → combined |
| `E501` | 4 | 3 wrapped; 2 `# noqa: E501` on Strands probe fixture strings (wrapping would distort the test payload) |
| `D103` | 1 | added docstring to `backfill-embeddings.py:main()` |
| `I` (isort) | 1 | auto-fixed in `app.py` |

**Ruff format:** 53 files reformatted to match the v0.15.4 style pinned in `.pre-commit-config.yaml`. Pure whitespace/line-break drift, no semantic change. Looks like a one-shot version-bump catch-up — files predate the v0.15.4 hook.

**detect-secrets baseline:** Created fresh (was absent despite the pre-commit hook referencing it). 12 findings, **all false positives**:

- 2 × Crockford base32 alphabet constant `"0123456789ABCDEFGHJKMNPQRSTVWXYZ"` in `activity.py` / `reflect.py` (used for ULID generation)
- 10 × test-fixture passwords in `tests/` (literal `"pw"` / `"alice-pw-123"` etc.)

No real leaks found. Baseline excludes `pnpm-lock.yaml` and `uv.lock` to match the pre-commit hook's exclude pattern.

## Test plan

- [ ] `ruff check .` exits clean
- [ ] `ruff format --check .` exits clean
- [ ] `detect-secrets-hook --baseline .secrets.baseline` exits clean against current tree
- [ ] CI pipeline passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)