### PR TITLE
ci: foundational CodeBuild infra + ci-plugin canary (#168)

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,44 @@
+# `ci/` — AWS CodeBuild migration scaffolding
+
+Companion to GitHub Actions during the GHA → CodeBuild cut-over described in
+[`docs/decisions/13-gha-to-codebuild-migration.md`](../docs/decisions/13-gha-to-codebuild-migration.md).
+
+## Layout
+
+- `buildspecs/<workflow>.yml` — CodeBuild buildspec, one per workflow. Should
+  mirror the corresponding `.github/workflows/<workflow>.yaml` exactly. Don't
+  tighten or loosen behaviour during migration.
+- `../templates/codebuild-project.yaml` — reusable CloudFormation module that
+  emits one CodeBuild project + service role + log group per workflow. Same
+  module is copied verbatim into `8th-layer-marketing-website` and
+  `8th-layer-marketplace` for issues #169 and #170.
+
+## Deploying a project
+
+The shared CodeStar Connection (`OneZero1ai-github`) must be in `AVAILABLE`
+state before any project can pull source. After the operator authorises it
+in the AWS console, deploy the canary with:
+
+```bash
+aws --profile 8th-layer-app --region us-east-1 cloudformation deploy \
+  --template-file templates/codebuild-project.yaml \
+  --stack-name codebuild-ci-plugin-agent \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides \
+    RepoFullName=OneZero1ai/8th-layer-agent \
+    RepoShort=agent \
+    WorkflowName=ci-plugin \
+    BuildspecPath=ci/buildspecs/ci-plugin.yml \
+    ConnectionArn=arn:aws:codestar-connections:us-east-1:124074140789:connection/59c82259-9b0e-4a07-990e-732a9eedec71 \
+    WebhookFilePathFilter='^(plugins/cq/.*|schema/.*|\.github/workflows/ci-plugin\.yaml|ci/buildspecs/ci-plugin\.yml)$'
+```
+
+The `WebhookFilePathFilter` mirrors the GHA `paths:` filter for `ci-plugin.yaml`.
+
+## Rollback
+
+`aws cloudformation delete-stack --stack-name codebuild-ci-plugin-agent`. The
+existing `.github/workflows/ci-plugin.yaml` is left in place during the
+canary period — branch protection still required-checks the GHA name. Flip
+the required check to `ci-plugin-agent` only after the CodeBuild project
+has been green for 5 PRs and one forced-red cycle (per decision doc).

--- a/ci/buildspecs/ci-plugin.yml
+++ b/ci/buildspecs/ci-plugin.yml
@@ -1,0 +1,37 @@
+version: 0.2
+
+# CodeBuild equivalent of .github/workflows/ci-plugin.yaml.
+# Triggers (PR + push paths: plugins/cq/**, schema/**, ci-plugin workflow file)
+# are encoded on the CodeBuild project's webhook FilterGroups, not here —
+# see templates/codebuild-project.yaml in the same repo.
+#
+# Behavioural parity with the GHA workflow:
+#   - astral-sh/setup-uv@v7 (with cache enabled) → install uv via the official
+#     installer; cache uv's wheel/installer cache on the .uv-cache path.
+#   - `make setup-plugin lint-plugin` → identical command sequence.
+
+env:
+  variables:
+    UV_CACHE_DIR: /codebuild/output/.uv-cache
+    UV_NO_PROGRESS: "1"
+
+phases:
+  install:
+    commands:
+      - echo "Installing uv (mirrors astral-sh/setup-uv@v7)"
+      - curl -LsSf https://astral.sh/uv/install.sh | sh
+      - export PATH="$HOME/.local/bin:$PATH"
+      - uv --version
+  build:
+    commands:
+      - export PATH="$HOME/.local/bin:$PATH"
+      - echo "Running make setup-plugin lint-plugin"
+      - make setup-plugin lint-plugin
+
+cache:
+  paths:
+    # Mirror enable-cache:true on astral-sh/setup-uv — cache the uv install
+    # cache between builds. CodeBuild local cache only (no S3 needed at
+    # this scale).
+    - /codebuild/output/.uv-cache/**/*
+    - /root/.cache/uv/**/*

--- a/templates/codebuild-project.yaml
+++ b/templates/codebuild-project.yaml
@@ -1,0 +1,274 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Reusable CodeBuild project for one GHA-equivalent workflow in the 8th-Layer
+  CI migration (decision doc: docs/decisions/13-gha-to-codebuild-migration.md).
+
+  IAM Pattern B: this stack creates a per-workflow service role
+  (<WorkflowName>-<repo-short>-cb-role) with base perms (CloudWatch Logs,
+  CodeStarConnections:UseConnection). Extra managed policies can be attached
+  via the ExtraPolicyArns parameter. Workflows that need to assume an existing
+  deploy-target role (e.g. marketing-website-deployer) get an inline
+  sts:AssumeRole on that role ARN via DeployTargetRoleArn.
+
+  Webhook is configured for both PR (CREATED/UPDATED/REOPENED) and push-to-main
+  events. Source = GitHub via CodeStarConnections, so PR commit-status reports
+  back to GitHub automatically.
+
+Parameters:
+
+  RepoFullName:
+    Type: String
+    Description: GitHub repo in OWNER/REPO form (e.g. OneZero1ai/8th-layer-agent).
+    AllowedPattern: "^[^/]+/[^/]+$"
+
+  RepoShort:
+    Type: String
+    Description: >
+      Short slug for the repo, used as a suffix in resource names. Choose
+      something short and stable (e.g. "agent", "marketing", "marketplace").
+    AllowedPattern: "^[a-z0-9][a-z0-9-]{0,30}$"
+
+  WorkflowName:
+    Type: String
+    Description: >
+      Workflow identifier, mirroring the GHA file basename without extension
+      (e.g. "ci-plugin"). Used in CodeBuild project + role names.
+    AllowedPattern: "^[a-z0-9][a-z0-9-]{0,40}$"
+
+  BuildspecPath:
+    Type: String
+    Description: Path to the buildspec inside the repo (e.g. ci/buildspecs/ci-plugin.yml).
+    Default: ci/buildspecs/buildspec.yml
+
+  ConnectionArn:
+    Type: String
+    Description: CodeStar Connection ARN authorising CodeBuild to pull from GitHub.
+    AllowedPattern: "^arn:aws:codestar-connections:[a-z0-9-]+:\\d{12}:connection/[a-f0-9-]+$"
+
+  ExtraPolicyArns:
+    Type: CommaDelimitedList
+    Description: >
+      Optional managed policy ARNs to attach to the CodeBuild service role
+      (comma-separated). Empty by default.
+    Default: ""
+
+  DeployTargetRoleArn:
+    Type: String
+    Description: >
+      Optional ARN of an existing deploy-target role this build is allowed to
+      assume (IAM Pattern B). Leave blank for build-only workflows like lint.
+    Default: ""
+
+  EnableBatchBuild:
+    Type: String
+    Description: Enable CodeBuild batch builds (matrix support).
+    AllowedValues: ["true", "false"]
+    Default: "false"
+
+  ComputeType:
+    Type: String
+    Description: CodeBuild compute size.
+    AllowedValues:
+      - BUILD_GENERAL1_SMALL
+      - BUILD_GENERAL1_MEDIUM
+      - BUILD_GENERAL1_LARGE
+    Default: BUILD_GENERAL1_SMALL
+
+  EnvironmentImage:
+    Type: String
+    Description: CodeBuild managed image. Default = AL2 standard 5.0 (uv works on this).
+    Default: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+
+  PrivilegedMode:
+    Type: String
+    Description: Set true for Docker-in-Docker builds (release-server-image, etc.).
+    AllowedValues: ["true", "false"]
+    Default: "false"
+
+  LogRetentionDays:
+    Type: Number
+    Description: CloudWatch Logs retention for the project log group.
+    Default: 90
+    AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365]
+
+  WebhookFilePathFilter:
+    Type: String
+    Description: >
+      Optional regex applied to changed files in the webhook filter group(s).
+      Mirrors GHA `paths:`. Empty disables the FILE_PATH filter.
+    Default: ""
+
+  WebhookBaseBranch:
+    Type: String
+    Description: Branch name (regex) the webhook filters PR target / push refs against.
+    Default: "^refs/heads/main$"
+
+Conditions:
+  HasExtraPolicies: !Not [!Equals [!Join [",", !Ref ExtraPolicyArns], ""]]
+  HasDeployTargetRole: !Not [!Equals [!Ref DeployTargetRoleArn, ""]]
+  BatchBuildEnabled: !Equals [!Ref EnableBatchBuild, "true"]
+  HasFilePathFilter: !Not [!Equals [!Ref WebhookFilePathFilter, ""]]
+
+Resources:
+
+  ProjectLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/codebuild/${WorkflowName}-${RepoShort}
+      RetentionInDays: !Ref LogRetentionDays
+
+  ServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${WorkflowName}-${RepoShort}-cb-role
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        !If
+          - HasExtraPolicies
+          - !Ref ExtraPolicyArns
+          - !Ref AWS::NoValue
+      Policies:
+        - PolicyName: CodeBuildBaseLogging
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource:
+                  - !GetAtt ProjectLogGroup.Arn
+                  - !Sub ${ProjectLogGroup.Arn}:*
+        - PolicyName: CodeBuildSourceConnection
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - codestar-connections:UseConnection
+                  - codeconnections:UseConnection
+                Resource: !Ref ConnectionArn
+        - PolicyName: CodeBuildReportGroups
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - codebuild:CreateReportGroup
+                  - codebuild:CreateReport
+                  - codebuild:UpdateReport
+                  - codebuild:BatchPutTestCases
+                  - codebuild:BatchPutCodeCoverages
+                Resource: !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:report-group/${WorkflowName}-${RepoShort}-*
+        - !If
+          - HasDeployTargetRole
+          - PolicyName: AssumeDeployTargetRole
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: Allow
+                  Action: sts:AssumeRole
+                  Resource: !Ref DeployTargetRoleArn
+          - !Ref AWS::NoValue
+
+  Project:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub ${WorkflowName}-${RepoShort}
+      Description: !Sub "CodeBuild for ${RepoFullName} workflow ${WorkflowName} (decision doc 13)."
+      ServiceRole: !GetAtt ServiceRole.Arn
+      Source:
+        Type: GITHUB
+        Location: !Sub https://github.com/${RepoFullName}.git
+        Auth:
+          Type: CODECONNECTIONS
+          Resource: !Ref ConnectionArn
+        BuildSpec: !Ref BuildspecPath
+        ReportBuildStatus: true
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: !Ref ComputeType
+        Image: !Ref EnvironmentImage
+        PrivilegedMode: !Ref PrivilegedMode
+        ImagePullCredentialsType: CODEBUILD
+      LogsConfig:
+        CloudWatchLogs:
+          Status: ENABLED
+          GroupName: !Ref ProjectLogGroup
+      BuildBatchConfig:
+        !If
+          - BatchBuildEnabled
+          - ServiceRole: !GetAtt ServiceRole.Arn
+            TimeoutInMins: 60
+            Restrictions:
+              MaximumBuildsAllowed: 10
+              ComputeTypesAllowed:
+                - !Ref ComputeType
+          - !Ref AWS::NoValue
+      Triggers:
+        Webhook: true
+        BuildType:
+          !If [BatchBuildEnabled, BUILD_BATCH, BUILD]
+        FilterGroups:
+          # Group 1: Pull-request events (created / updated / reopened) targeting WebhookBaseBranch.
+          - - Type: EVENT
+              Pattern: PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED,PULL_REQUEST_REOPENED
+            - Type: BASE_REF
+              Pattern: !Ref WebhookBaseBranch
+            - !If
+              - HasFilePathFilter
+              - Type: FILE_PATH
+                Pattern: !Ref WebhookFilePathFilter
+              - !Ref AWS::NoValue
+          # Group 2: Push to WebhookBaseBranch.
+          - - Type: EVENT
+              Pattern: PUSH
+            - Type: HEAD_REF
+              Pattern: !Ref WebhookBaseBranch
+            - !If
+              - HasFilePathFilter
+              - Type: FILE_PATH
+                Pattern: !Ref WebhookFilePathFilter
+              - !Ref AWS::NoValue
+      ConcurrentBuildLimit: 4
+      Visibility: PRIVATE
+      Tags:
+        - Key: Project
+          Value: 8th-layer-agent
+        - Key: Workflow
+          Value: !Ref WorkflowName
+        - Key: ManagedBy
+          Value: cloudformation
+        - Key: DecisionDoc
+          Value: docs/decisions/13-gha-to-codebuild-migration.md
+
+Outputs:
+  ProjectName:
+    Description: CodeBuild project name (also the GitHub commit-status context).
+    Value: !Ref Project
+    Export:
+      Name: !Sub ${AWS::StackName}-ProjectName
+  ProjectArn:
+    Description: CodeBuild project ARN.
+    Value: !GetAtt Project.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-ProjectArn
+  ServiceRoleArn:
+    Description: CodeBuild service role ARN.
+    Value: !GetAtt ServiceRole.Arn
+    Export:
+      Name: !Sub ${AWS::StackName}-ServiceRoleArn
+  LogGroupName:
+    Description: CloudWatch log group for the project.
+    Value: !Ref ProjectLogGroup
+    Export:
+      Name: !Sub ${AWS::StackName}-LogGroupName


### PR DESCRIPTION
## Summary

First canary of the GHA → CodeBuild migration scoped in [`docs/decisions/13-gha-to-codebuild-migration.md`](https://github.com/OneZero1ai/8th-layer-agent/blob/main/docs/decisions/13-gha-to-codebuild-migration.md).

- **`templates/codebuild-project.yaml`** — reusable CloudFormation module: one CodeBuild project per workflow, **IAM Pattern B** service role (`<workflow>-<repo-short>-cb-role`), webhook filter groups for PR (created/updated/reopened) + push to `main`, optional `BatchBuild` for matrix workflows, optional `sts:AssumeRole` on a deploy-target role (e.g. `marketing-website-deployer`). Source = GitHub via CodeStarConnections so PR commit-status reports back automatically. Copyable verbatim into `8th-layer-marketing-website` / `8th-layer-marketplace` for #169 / #170.
- **`ci/buildspecs/ci-plugin.yml`** — buildspec mirroring `.github/workflows/ci-plugin.yaml` exactly (install `uv`, run `make setup-plugin lint-plugin`, cache uv install dir). No tighten / no loosen.
- **`ci/README.md`** — deploy + rollback runbook.
- The existing GHA workflow file is **intentionally untouched** for the Week-0 dual-run period.

## Status — blocked on operator action

Foundational AWS resources are already created in `8th-layer-app` (`124074140789` / `us-east-1`):

| Resource | ARN | State |
|---|---|---|
| CodeStar Connection `OneZero1ai-github` | `arn:aws:codestar-connections:us-east-1:124074140789:connection/59c82259-9b0e-4a07-990e-732a9eedec71` | **PENDING** — needs operator handshake |
| Secrets Manager `/8th-layer-agent/pypi-api-token` | `arn:aws:secretsmanager:us-east-1:124074140789:secret:/8th-layer-agent/pypi-api-token-OgN382` | placeholder; not yet used |

**Operator step:** AWS console → Developer Tools → Settings → Connections → select `OneZero1ai-github` → **Update pending connection** → click through GitHub OAuth → install / reuse the **AWS Connector for GitHub** app on the `OneZero1ai` org → grant the App access to `8th-layer-agent` (and later `8th-layer-marketing-website`, `8th-layer-marketplace`). Status flips to `AVAILABLE`.

## Deploy command (run after the connection is `AVAILABLE`)

```bash
aws --profile 8th-layer-app --region us-east-1 cloudformation deploy \
  --template-file templates/codebuild-project.yaml \
  --stack-name codebuild-ci-plugin-agent \
  --capabilities CAPABILITY_NAMED_IAM \
  --parameter-overrides \
    RepoFullName=OneZero1ai/8th-layer-agent \
    RepoShort=agent \
    WorkflowName=ci-plugin \
    BuildspecPath=ci/buildspecs/ci-plugin.yml \
    ConnectionArn=arn:aws:codestar-connections:us-east-1:124074140789:connection/59c82259-9b0e-4a07-990e-732a9eedec71 \
    WebhookFilePathFilter='^(plugins/cq/.*|schema/.*|\.github/workflows/ci-plugin\.yaml|ci/buildspecs/ci-plugin\.yml)$'
```

## Test plan

- [ ] Operator authorises `OneZero1ai-github` CodeStar Connection (status `AVAILABLE`).
- [ ] `cloudformation deploy` command above succeeds; stack reaches `CREATE_COMPLETE`.
- [ ] No-op PR touching `plugins/cq/**` shows a `ci-plugin-agent` commit-status check on the PR head SHA, green alongside the existing `Plugin CI / Lint` GHA check.
- [ ] Force a lint failure to verify the CodeBuild check goes red (Week-1 gate before flipping required checks).
- [ ] After 5 green PRs + 1 forced-red, flip branch-protection required check from `Plugin CI / Lint` → `ci-plugin-agent` and delete the GHA workflow in a follow-up PR.

## Notes / surprises

- **`codestar-connections` vs `codeconnections`.** AWS renamed the service in 2024. CFN `AWS::CodeBuild::Project` source uses `Auth.Type: CODECONNECTIONS` (new spelling), but IAM actions exist under both `codestar-connections:UseConnection` and `codeconnections:UseConnection`. Service role policy grants both for forward compatibility.
- **Webhook filter groups are AND-within-group, OR-across-groups.** PR group: `EVENT=PULL_REQUEST_*` AND `BASE_REF=main` AND (optional) `FILE_PATH=<regex>`; push group: `EVENT=PUSH` AND `HEAD_REF=main`. Two groups joined by OR is the equivalent shape of GHA `on: { push, pull_request }`.
- **`ReportBuildStatus: true`** under `Source` is what wires GitHub commit-status reporting; no separate webhook config needed.

Refs #168.
