### PR TITLE
feat(consults): add GET /consults/{thread_id} for thread metadata

### DIFF
--- a/server/backend/src/cq_server/consults.py
+++ b/server/backend/src/cq_server/consults.py
@@ -1077,3 +1077,23 @@ async def get_inbox(
         self_persona=self_persona,
         threads=[_to_thread_out(r) for r in rows],
     )
+
+
+# Registered last so the parameterised path ``/{thread_id}`` does not
+# shadow static routes like ``/inbox`` and ``/forward-request``.
+@router.get("/{thread_id}", response_model=ConsultThreadOut)
+async def get_consult_thread(
+    thread_id: str,
+    store: SqliteStore = Depends(get_store),
+    username: str = Depends(get_current_user),
+) -> ConsultThreadOut:
+    """Fetch thread metadata for a thread the caller participates in."""
+    self_l2_id, self_persona = await _self_identity(store, username)
+    thread = await store.get_consult(thread_id)
+    if thread is None:
+        raise HTTPException(status_code=404, detail="thread not found")
+    is_from = thread["from_l2_id"] == self_l2_id and thread["from_persona"] == self_persona
+    is_to = thread["to_l2_id"] == self_l2_id and thread["to_persona"] == self_persona
+    if not (is_from or is_to):
+        raise HTTPException(status_code=403, detail="not a participant in this thread")
+    return _to_thread_out(thread)

--- a/server/backend/tests/test_consults.py
+++ b/server/backend/tests/test_consults.py
@@ -22,9 +22,9 @@ from cq_server import network
 from cq_server.app import _get_store, app
 
 ALICE = "alice"  # acme/engineering
-BOB = "bob"      # acme/engineering — same L2 as Alice
+BOB = "bob"  # acme/engineering — same L2 as Alice
 CARLA = "carla"  # acme/solutions  — different L2 from Alice (cross-team)
-DAN = "dan"      # also acme/engineering — third-party for participant gating
+DAN = "dan"  # also acme/engineering — third-party for participant gating
 
 
 @pytest.fixture()
@@ -281,9 +281,7 @@ def test_closed_thread_excluded_from_inbox_by_default(client: TestClient) -> Non
     assert thread_id not in [t["thread_id"] for t in inbox["threads"]]
 
     # include_closed=true — audit view includes it
-    inbox_all = client.get(
-        "/api/v1/consults/inbox?include_closed=true", headers=_headers(client, BOB)
-    ).json()
+    inbox_all = client.get("/api/v1/consults/inbox?include_closed=true", headers=_headers(client, BOB)).json()
     assert thread_id in [t["thread_id"] for t in inbox_all["threads"]]
 
 

--- a/server/backend/tests/test_consults.py
+++ b/server/backend/tests/test_consults.py
@@ -164,6 +164,49 @@ def test_either_participant_can_reply(client: TestClient) -> None:
     assert [m["from_persona"] for m in msgs] == [ALICE, BOB, ALICE]
 
 
+def test_get_thread_metadata_by_id(client: TestClient) -> None:
+    """GET /consults/{thread_id} returns thread metadata for a participant."""
+    open_resp = client.post(
+        "/api/v1/consults/request",
+        headers=_headers(client, ALICE),
+        json={
+            "to_l2_id": "acme/engineering",
+            "to_persona": BOB,
+            "subject": "metadata fetch",
+            "content": "hi",
+        },
+    )
+    thread_id = open_resp.json()["thread_id"]
+
+    # Either participant can fetch
+    for caller in (ALICE, BOB):
+        r = client.get(
+            f"/api/v1/consults/{thread_id}",
+            headers=_headers(client, caller),
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["thread_id"] == thread_id
+        assert body["from_persona"] == ALICE
+        assert body["to_persona"] == BOB
+        assert body["status"] == "open"
+        assert body["subject"] == "metadata fetch"
+
+    # Non-participant gets 403
+    r = client.get(
+        f"/api/v1/consults/{thread_id}",
+        headers=_headers(client, DAN),
+    )
+    assert r.status_code == 403, r.text
+
+    # Unknown thread → 404
+    r = client.get(
+        "/api/v1/consults/th_does_not_exist",
+        headers=_headers(client, ALICE),
+    )
+    assert r.status_code == 404, r.text
+
+
 def test_non_participant_403_on_messages(client: TestClient) -> None:
     open_resp = client.post(
         "/api/v1/consults/request",


### PR DESCRIPTION
## Summary
- Closes OneZero1ai/8th-layer-core#42 — the bare-thread URL 404'd, only `/{thread_id}/messages` worked.
- Adds `GET /consults/{thread_id}` returning `ConsultThreadOut`. Same 401/403/404 contract as `/messages` + `/close`.
- Route is registered at the end of the file so the parameterised path doesn't shadow `/inbox` or `/forward-request`.

## Test plan
- [x] New test `test_get_thread_metadata_by_id` covers happy path (both participants), 403 for non-participant, 404 for unknown thread
- [x] Full `tests/test_consults.py` suite passes (12 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)