### PR TITLE
feat(propose): allow tier override via request body or CQ_DEFAULT_KU_TIER

### DIFF
--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -61,6 +61,31 @@ class ProposeRequest(BaseModel):
     insight: Insight
     context: Context = Field(default_factory=Context)
     created_by: str = ""
+    tier: Tier | None = Field(
+        default=None,
+        description=(
+            "Visibility tier for the new KU. Defaults to the server-side "
+            "CQ_DEFAULT_KU_TIER env var, or 'private' when unset."
+        ),
+    )
+
+
+def _default_ku_tier() -> Tier:
+    """Resolve the server-side default tier for newly-proposed KUs.
+
+    Set ``CQ_DEFAULT_KU_TIER`` to one of ``local|private|public`` to flip
+    the default for an L2; falls back to ``private`` for backwards
+    compatibility (issue #90).
+    """
+    raw = os.environ.get("CQ_DEFAULT_KU_TIER", "").strip().lower()
+    if not raw:
+        return Tier.PRIVATE
+    try:
+        return Tier(raw)
+    except ValueError:
+        # Unknown value — log via FastAPI's default channels would require
+        # a logger; keep this hot-path silent and fall back to private.
+        return Tier.PRIVATE
 
 
 class FlagRequest(BaseModel):
@@ -1631,7 +1656,7 @@ async def propose_unit(
         domains=normalized,
         insight=request.insight,
         context=request.context,
-        tier=Tier.PRIVATE,
+        tier=request.tier or _default_ku_tier(),
         created_by=username,
     )
     # embed_text() is a blocking boto3 call; offload it so a slow

--- a/server/backend/tests/test_propose_tier.py
+++ b/server/backend/tests/test_propose_tier.py
@@ -1,0 +1,130 @@
+"""Regression tests for #90 — /propose tier resolution.
+
+Pre-fix every KU proposed via the API got ``tier=private`` regardless
+of any configuration, so KUs were invisible to anything querying
+``public`` until manually retiered. This module exercises the three
+allowed sources, in priority order:
+
+1. Explicit ``tier`` field in the request body
+2. ``CQ_DEFAULT_KU_TIER`` env var on the server
+3. Fallback to ``private`` (preserves pre-fix behaviour)
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cq_server.app import app
+from cq_server.auth import hash_password
+
+
+@pytest.fixture()
+def client_factory(tmp_path: Path):
+    def _factory(monkeypatch: pytest.MonkeyPatch, *, default_tier: str | None) -> TestClient:
+        monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "tier.db"))
+        monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+        monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+        if default_tier is None:
+            monkeypatch.delenv("CQ_DEFAULT_KU_TIER", raising=False)
+        else:
+            monkeypatch.setenv("CQ_DEFAULT_KU_TIER", default_tier)
+        return TestClient(app)
+
+    return _factory
+
+
+def _seed_user(client: TestClient) -> str:
+    from cq_server.app import _get_store
+
+    store = _get_store()
+    store.sync.create_user("alice", hash_password("alice-pw-123"))
+    with store._engine.begin() as conn:
+        conn.exec_driver_sql(
+            "UPDATE users SET enterprise_id = ?, group_id = ? WHERE username = ?",
+            ("team-dw", "engineering", "alice"),
+        )
+    jwt = client.post(
+        "/api/v1/auth/login",
+        json={"username": "alice", "password": "alice-pw-123"},
+    ).json()["token"]
+    key_resp = client.post(
+        "/api/v1/auth/api-keys",
+        headers={"Authorization": f"Bearer {jwt}"},
+        json={"name": "tier-test", "ttl": "30d"},
+    )
+    return key_resp.json()["token"]
+
+
+def _propose(client: TestClient, token: str, *, tier: str | None = None) -> str:
+    body = {
+        "domains": ["postgres", "test"],
+        "insight": {
+            "summary": "Tier resolution exercise — explicit tier wins over env, env wins over fallback.",
+            "detail": (
+                "When a /propose request specifies a tier in the body, the server uses it; "
+                "otherwise CQ_DEFAULT_KU_TIER selects the default; otherwise tier=private."
+            ),
+            "action": (
+                "Set CQ_DEFAULT_KU_TIER=public on team L2s to make new KUs queryable by default; "
+                "agents can still opt into private per-propose by passing tier=private in the body."
+            ),
+        },
+    }
+    if tier is not None:
+        body["tier"] = tier
+    resp = client.post(
+        "/api/v1/propose",
+        headers={"Authorization": f"Bearer {token}"},
+        json=body,
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _read_tier(unit_id: str) -> str:
+    conn = sqlite3.connect(os.environ["CQ_DB_PATH"])
+    try:
+        row = conn.execute(
+            "SELECT tier FROM knowledge_units WHERE id = ?", (unit_id,)
+        ).fetchone()
+        assert row is not None
+        return row[0]
+    finally:
+        conn.close()
+
+
+def test_default_tier_is_private(client_factory, monkeypatch):
+    """No env, no body field → 'private' (backwards compatible)."""
+    with client_factory(monkeypatch, default_tier=None) as client:
+        token = _seed_user(client)
+        unit_id = _propose(client, token)
+    assert _read_tier(unit_id) == "private"
+
+
+def test_env_override_public(client_factory, monkeypatch):
+    """CQ_DEFAULT_KU_TIER=public flips the server-side default."""
+    with client_factory(monkeypatch, default_tier="public") as client:
+        token = _seed_user(client)
+        unit_id = _propose(client, token)
+    assert _read_tier(unit_id) == "public"
+
+
+def test_request_body_tier_wins_over_env(client_factory, monkeypatch):
+    """Body `tier` takes precedence over the env var."""
+    with client_factory(monkeypatch, default_tier="public") as client:
+        token = _seed_user(client)
+        unit_id = _propose(client, token, tier="private")
+    assert _read_tier(unit_id) == "private"
+
+
+def test_unknown_env_falls_back_to_private(client_factory, monkeypatch):
+    """Garbled env value falls back to private rather than 500'ing."""
+    with client_factory(monkeypatch, default_tier="floof") as client:
+        token = _seed_user(client)
+        unit_id = _propose(client, token)
+    assert _read_tier(unit_id) == "private"

--- a/server/backend/tests/test_propose_tier.py
+++ b/server/backend/tests/test_propose_tier.py
@@ -50,7 +50,7 @@ def _seed_user(client: TestClient) -> str:
         )
     jwt = client.post(
         "/api/v1/auth/login",
-        json={"username": "alice", "password": "alice-pw-123"},
+        json={"username": "alice", "password": "alice-pw-123"},  # pragma: allowlist secret
     ).json()["token"]
     key_resp = client.post(
         "/api/v1/auth/api-keys",
@@ -89,9 +89,7 @@ def _propose(client: TestClient, token: str, *, tier: str | None = None) -> str:
 def _read_tier(unit_id: str) -> str:
     conn = sqlite3.connect(os.environ["CQ_DB_PATH"])
     try:
-        row = conn.execute(
-            "SELECT tier FROM knowledge_units WHERE id = ?", (unit_id,)
-        ).fetchone()
+        row = conn.execute("SELECT tier FROM knowledge_units WHERE id = ?", (unit_id,)).fetchone()
         assert row is not None
         return row[0]
     finally:


### PR DESCRIPTION
## Summary
- Closes #90. Pre-fix all `/propose` KUs landed at `tier=private`, hidden from `/query` until manually retiered.
- Adds `tier` to `ProposeRequest` and reads `CQ_DEFAULT_KU_TIER` env var as the server-side default. Resolution order: request body → env → `private`.
- New test module `test_propose_tier.py` (4 cases) covers all four branches (default, env, body-overrides-env, garbled-env-falls-back).

## Test plan
- [x] `pytest tests/test_propose_tier.py` — 4/4 pass
- [x] `pytest tests/test_auto_approve_propose.py tests/test_propose_tenancy_regression.py` — 11/11 pass (no regression in propose hot path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)