### PR TITLE
fix(cq-hook): emit systemMessage for Stop event, not hookSpecificOutput

### DIFF
--- a/plugins/cq/hooks/claude_code/cq_cc_hook.py
+++ b/plugins/cq/hooks/claude_code/cq_cc_hook.py
@@ -24,10 +24,18 @@ Both modes:
     server-side ``/api/v1/reflect/submit`` 429 response.
 
 Output: when injecting, the hook writes a JSON object to stdout matching
-Claude Code's hook-output schema:
+Claude Code's hook-output schema. The schema differs by event:
 
-    {"hookSpecificOutput": {"hookEventName": "<event>",
-                            "additionalContext": "<reminder>"}}
+    PostToolUse → {"hookSpecificOutput": {"hookEventName": "PostToolUse",
+                                          "additionalContext": "<reminder>"}}
+    Stop        → {"systemMessage": "<reminder>"}
+
+Why two shapes: ``hookSpecificOutput.hookEventName`` only accepts
+``PreToolUse``, ``UserPromptSubmit``, ``PostToolUse``, ``PostToolBatch``.
+Emitting that envelope with ``hookEventName="Stop"`` triggers Claude
+Code's "Hook JSON output validation failed" error and silently drops the
+reminder. ``systemMessage`` is a top-level field accepted by every hook
+event, so Stop mode uses that instead.
 
 Otherwise the hook exits 0 with empty stdout (Claude Code treats this as
 "no opinion").
@@ -147,6 +155,22 @@ def run_post_tool_use(state_dir: Path, payload: dict) -> int:
     return 0
 
 
+def _emit_system_message(reminder: str) -> None:
+    """Write a Claude-Code hook-output JSON object using the top-level
+    ``systemMessage`` field.
+
+    Used for Stop mode: Claude Code's Stop hook schema does NOT accept
+    ``hookSpecificOutput.hookEventName="Stop"`` (only PreToolUse,
+    UserPromptSubmit, PostToolUse, PostToolBatch are valid for that field).
+    Emitting the deprecated shape produces a "Hook JSON output validation
+    failed" error in the user's terminal AND silently drops the reminder.
+
+    ``systemMessage`` is a top-level field accepted by every hook event,
+    so the reminder lands as an injected system note without schema noise.
+    """
+    sys.stdout.write(json.dumps({"systemMessage": reminder}))
+
+
 def _detect_error(payload: dict, tool_response) -> bool:
     """True if the tool reported an error.
 
@@ -258,7 +282,7 @@ def run_stop(state_dir: Path, payload: dict) -> int:
     if marker.exists():
         return 0
     marker.write_text(json.dumps({"ts": int(time.time())}))
-    _emit_additional_context("Stop", STOP_REMINDER)
+    _emit_system_message(STOP_REMINDER)
     return 0
 
 

--- a/plugins/cq/tests/test_cc_hook.py
+++ b/plugins/cq/tests/test_cc_hook.py
@@ -356,8 +356,11 @@ def test_stop_fires_reminder_once(cc_hook, tmp_path, monkeypatch, capsys):
         capsys,
     )
     parsed = json.loads(out)
-    assert parsed["hookSpecificOutput"]["hookEventName"] == "Stop"
-    assert "/cq:reflect" in parsed["hookSpecificOutput"]["additionalContext"]
+    # Stop uses top-level systemMessage — hookSpecificOutput.hookEventName="Stop"
+    # is rejected by Claude Code's hook-output validator.
+    assert "systemMessage" in parsed
+    assert "hookSpecificOutput" not in parsed
+    assert "/cq:reflect" in parsed["systemMessage"]
 
     # Second stop in the same session is a no-op (compact/resume re-fire).
     _, out2 = _run(
@@ -439,7 +442,8 @@ def test_rate_limit_expired_does_not_suppress(cc_hook, tmp_path, monkeypatch, ca
     (state_dir / "rate429.json").write_text(json.dumps({"retry_after_until": int(time.time()) - 1}))
     _, out = _run(cc_hook, monkeypatch, "stop", state_dir, {"session_id": "s-rl-expired"}, capsys)
     parsed = json.loads(out)
-    assert parsed["hookSpecificOutput"]["hookEventName"] == "Stop"
+    assert "systemMessage" in parsed
+    assert "/cq:reflect" in parsed["systemMessage"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Stop hook was emitting `hookSpecificOutput.hookEventName="Stop"` which Claude Code's hook-output schema rejects (only PreToolUse/UserPromptSubmit/PostToolUse/PostToolBatch valid for that envelope). Result: "Hook JSON output validation failed" on every session-end and the `/cq:reflect` reminder silently dropped.
- Stop mode now emits `{"systemMessage": "<reminder>"}` at top level — valid for every hook event and surfaces in the user's UI as an injected note. PostToolUse keeps `hookSpecificOutput` (that event IS valid for it).
- Updated the two test_cc_hook.py stop-mode assertions to match the new shape.

Refs 8th-layer-agent#133.

## Test plan
- [x] `pytest tests/test_cc_hook.py` — 18 passed
- [x] Manual: `echo '{"session_id": "test"}' | python3 hooks/claude_code/cq_cc_hook.py --mode stop` produces valid `{"systemMessage": "..."}` JSON
- [ ] Watch for "Hook JSON output validation failed" disappearing from session-end output after merge & plugin update

🤖 Generated with [Claude Code](https://claude.com/claude-code)