### PR TITLE
chore: legacy brand URL cleanup (8thlayer.onezero1.ai → 8th-layer.ai)

### DIFF
--- a/plugins/cq/.claude-plugin/plugin.json
+++ b/plugins/cq/.claude-plugin/plugin.json
@@ -2,11 +2,11 @@
   "name": "8l-cq",
   "version": "0.9.0+8l-dev",
   "description": "8th-Layer.ai agent — Apache-2.0 fork of Mozilla.AI's cq plugin (https://github.com/mozilla-ai/cq) adding enterprise execution: AIGRP intra-Enterprise routing, DSN intent resolution, L3 live consults, multi-tenant scope, directory + reputation log primitives. Speaks the cq protocol natively (MCP server is still named 'cq' for protocol compatibility); pair with an 8th-Layer.ai tenant Remote for the enterprise feature set. v0.9 adds the crosstalk MCP server (l2-only mode) for inter-agent messaging through the tenant L2 — productized from the prototype that originated in claude-mux.",
-  "homepage": "https://8thlayer.onezero1.ai",
+  "homepage": "https://8th-layer.ai",
   "author": {
     "name": "OneZero1.ai",
     "email": "support@onezero1.ai",
-    "url": "https://8thlayer.onezero1.ai"
+    "url": "https://8th-layer.ai"
   },
   "repository": "https://github.com/OneZero1ai/8th-layer-agent",
   "license": "Apache-2.0",

--- a/server/backend/src/cq_server/network.py
+++ b/server/backend/src/cq_server/network.py
@@ -329,7 +329,7 @@ class DsnResolveRequest(BaseModel):
     include_consented_cross_enterprise: bool = True
     # Optional caller scope for policy_if_queried decisions. Defaults
     # to ('marketing', 'public') when omitted — the public-viewer
-    # scope used by 8thlayer.onezero1.ai. Internal callers can pass
+    # scope used by 8th-layer.ai. Internal callers can pass
     # their actual scope to get accurate policy hints.
     caller_enterprise: str = Field(default="", max_length=128)
     caller_group: str = Field(default="", max_length=128)
@@ -684,7 +684,7 @@ async def network_topology(
     Public read — no auth. Returns only operator-authorized topology
     metadata (L2 names, KU counts, peer table, declared-discoverable
     presence rows, active consent edges). The data is intended for the
-    public marketing site at 8thlayer.onezero1.ai.
+    public marketing site at 8th-layer.ai.
 
     Cached in-process for ``TOPOLOGY_CACHE_TTL_SECONDS`` to damp the
     frontend's 5s poll loop. Per-L2 failures are tolerated (rendered
@@ -725,7 +725,7 @@ async def network_dsn_resolve(
     ``/aigrp/forward-query`` against it, so the frontend can pre-render
     boundary edges. Caller scope defaults to ('marketing', 'public')
     when not provided — that's the public-viewer scope used by
-    8thlayer.onezero1.ai. Internal demo callers can pass their actual
+    8th-layer.ai. Internal demo callers can pass their actual
     scope via ``caller_enterprise`` / ``caller_group``.
     """
     caller_ent = request.caller_enterprise or "marketing"

--- a/server/backend/tests/test_network_topology.py
+++ b/server/backend/tests/test_network_topology.py
@@ -183,7 +183,7 @@ class TestTopologyCache:
 class TestTopologyAuth:
     def test_no_auth_required_public_read(self, client: TestClient) -> None:
         # Topology is intentionally public for the marketing site at
-        # 8thlayer.onezero1.ai — no JWT required.
+        # 8th-layer.ai — no JWT required.
         resp = client.post("/api/v1/network/topology")
         assert resp.status_code == 200
 

--- a/server/backend/tests/test_tenancy_columns.py
+++ b/server/backend/tests/test_tenancy_columns.py
@@ -5,7 +5,7 @@ These tests pin two invariants:
   1. New rows written through the propose-time path land in the
      ``default-enterprise`` / ``default-group`` scope.
   2. Pre-existing rows on a "legacy" DB (the shape that production looks
-     like at https://8thlayer.onezero1.ai right now — no tenancy
+     like at https://8th-layer.ai right now — no tenancy
      columns) get backfilled to the same defaults when the migration /
      the runtime ``ensure_tenancy_columns`` helper runs.
 


### PR DESCRIPTION
## Summary

Sweep the repo for residual references to the legacy `8thlayer.onezero1.ai` domain and switch them to the current `8th-layer.ai` brand. Part of the broader rebrand cleanup — the product moved to 8th-Layer.ai months ago, but the cq plugin manifest and a handful of doc comments still broadcast the old URL.

## Changes

- **`plugins/cq/.claude-plugin/plugin.json`** — `homepage` and `author.url` switched to `https://8th-layer.ai`. New Claude Code installs that surface the manifest will see the correct brand.
- **`server/backend/src/cq_server/network.py`** — three docstring/comment refs to the public marketing site updated.
- **`server/backend/tests/test_tenancy_columns.py`** + **`server/backend/tests/test_network_topology.py`** — illustrative URL refs in docstrings/comments updated. Neither test issues HTTP against the URL; safe in-place edit.

## Intentionally left alone

- **`server/backend/src/cq_server/directory_client.py`** — keeps its `(legacy: directory.8thlayer.onezero1.ai)` parenthetical because it's documenting the rename for future readers.

## Test plan

- [ ] CI passes (no behavior change; pure string edits in docstrings, comments, and a JSON manifest)
- [ ] `grep -rE "8thlayer\.onezero1\.ai" .` returns only the one intentional `directory_client.py` line