### PR TITLE
fix(detect-secrets): pragma-allowlist Crockford ULID alphabet

### DIFF
--- a/server/backend/src/cq_server/activity.py
+++ b/server/backend/src/cq_server/activity.py
@@ -61,7 +61,7 @@ EVENT_TYPES: frozenset[str] = frozenset(
 DEFAULT_RETENTION_DAYS: int = 90
 
 
-_CROCKFORD_BASE32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+_CROCKFORD_BASE32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"  # pragma: allowlist secret
 
 
 def generate_activity_id() -> str:

--- a/server/backend/src/cq_server/activity_logger.py
+++ b/server/backend/src/cq_server/activity_logger.py
@@ -88,8 +88,7 @@ async def log_activity(
     """
     if event_type not in EVENT_TYPES:
         logger.warning(
-            "activity log: refusing to append unknown event_type %r "
-            "(expected one of %s)",
+            "activity log: refusing to append unknown event_type %r (expected one of %s)",
             event_type,
             sorted(EVENT_TYPES),
         )
@@ -115,9 +114,7 @@ async def log_activity(
                 tenant_group = aigrp.group()
                 persona = username
             else:
-                tenant_enterprise = str(
-                    user.get("enterprise_id") or aigrp.enterprise()
-                )
+                tenant_enterprise = str(user.get("enterprise_id") or aigrp.enterprise())
                 # ``group_id`` is column-NOT-NULL on the users table per
                 # migration 0001_phase6_step1, but defensive cast keeps
                 # the helper safe if a future schema makes it nullable.

--- a/server/backend/src/cq_server/activity_routes.py
+++ b/server/backend/src/cq_server/activity_routes.py
@@ -179,10 +179,7 @@ async def list_activity(
     if event_type is not None and event_type not in EVENT_TYPES:
         raise HTTPException(
             status_code=422,
-            detail=(
-                f"unknown event_type {event_type!r}; "
-                f"expected one of {sorted(EVENT_TYPES)}"
-            ),
+            detail=(f"unknown event_type {event_type!r}; expected one of {sorted(EVENT_TYPES)}"),
         )
 
     since_iso = _normalise_iso(since, field_name="since")
@@ -200,11 +197,7 @@ async def list_activity(
     )
 
     items = [ActivityRow(**row) for row in rows]
-    next_cursor = (
-        _encode_cursor(items[-1].ts, items[-1].id)
-        if len(items) == limit and items
-        else None
-    )
+    next_cursor = _encode_cursor(items[-1].ts, items[-1].id) if len(items) == limit and items else None
     # Defensive: if `len(items) == limit` but we know there aren't more
     # rows, the next call returns empty and the second-to-last cursor
     # naturally terminates. Cheap one extra round-trip on the boundary

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -25,10 +25,10 @@ from starlette.responses import FileResponse
 from . import aigrp
 from .activity_logger import log_activity, summary_first_60
 from .activity_routes import router as activity_router
-from .crosstalk_routes import router as crosstalk_router
 from .auth import require_admin
 from .auth import router as auth_router
 from .consults import router as consults_router
+from .crosstalk_routes import router as crosstalk_router
 from .db_url import resolve_sqlite_db_path
 from .deps import API_KEY_PEPPER_ENV, require_api_key
 from .embed import compose_text, embed_text

--- a/server/backend/src/cq_server/crosstalk_routes.py
+++ b/server/backend/src/cq_server/crosstalk_routes.py
@@ -104,8 +104,7 @@ class SendMessageRequest(BaseModel):
     message_id: str | None = Field(
         default=None,
         description=(
-            "Client-provided message_id (idempotency-key). If exists, "
-            "returns the existing record without inserting."
+            "Client-provided message_id (idempotency-key). If exists, returns the existing record without inserting."
         ),
     )
 
@@ -218,9 +217,7 @@ def _new_message_id() -> str:
     return f"msg_{secrets.token_hex(16)}"
 
 
-async def _resolve_caller(
-    username: str, store: SqliteStore
-) -> tuple[str, str, str]:
+async def _resolve_caller(username: str, store: SqliteStore) -> tuple[str, str, str]:
     """Return (enterprise_id, group_id, role) from caller's user row.
 
     Raises 401 if the user row is missing tenancy claims (defensive,
@@ -281,9 +278,7 @@ async def send_message(
     # Idempotency: if the message_id already exists, return the existing
     # record without inserting (covers retries on flaky L2 connectivity).
     if request.message_id is not None:
-        existing_thread = await store.get_crosstalk_thread(
-            thread_id=thread_id, tenant_enterprise=enterprise_id
-        )
+        existing_thread = await store.get_crosstalk_thread(thread_id=thread_id, tenant_enterprise=enterprise_id)
         if existing_thread is not None:
             existing_msgs = await store.list_crosstalk_messages(
                 thread_id=thread_id,
@@ -302,9 +297,7 @@ async def send_message(
     # tenant AND caller is a participant, this is an append. Otherwise
     # create the thread.
     existing = (
-        await store.get_crosstalk_thread(
-            thread_id=thread_id, tenant_enterprise=enterprise_id
-        )
+        await store.get_crosstalk_thread(thread_id=thread_id, tenant_enterprise=enterprise_id)
         if request.thread_id is not None
         else None
     )
@@ -365,9 +358,7 @@ async def reply_on_thread(
     """Reply on an existing thread. Caller must be a participant."""
     enterprise_id, group_id, role = await _resolve_caller(username, store)
 
-    thread = await store.get_crosstalk_thread(
-        thread_id=thread_id, tenant_enterprise=enterprise_id
-    )
+    thread = await store.get_crosstalk_thread(thread_id=thread_id, tenant_enterprise=enterprise_id)
     if thread is None:
         raise HTTPException(status_code=404, detail="Thread not found")
     if thread["status"] != "open":
@@ -457,17 +448,13 @@ async def get_thread(
     """Fetch one thread + its messages."""
     enterprise_id, _group_id, role = await _resolve_caller(username, store)
 
-    thread = await store.get_crosstalk_thread(
-        thread_id=thread_id, tenant_enterprise=enterprise_id
-    )
+    thread = await store.get_crosstalk_thread(thread_id=thread_id, tenant_enterprise=enterprise_id)
     if thread is None:
         raise HTTPException(status_code=404, detail="Thread not found")
     if username not in thread["participants"] and role != "admin":
         raise HTTPException(status_code=403, detail="Not a participant")
 
-    msgs = await store.list_crosstalk_messages(
-        thread_id=thread_id, tenant_enterprise=enterprise_id, limit=limit
-    )
+    msgs = await store.list_crosstalk_messages(thread_id=thread_id, tenant_enterprise=enterprise_id, limit=limit)
     return ThreadWithMessagesResponse(
         thread=CrosstalkThread(**thread),
         messages=[CrosstalkMessage(**m) for m in msgs],
@@ -485,9 +472,7 @@ async def close_thread(
     """Mark a thread closed. Caller must be a participant or admin."""
     enterprise_id, _group_id, role = await _resolve_caller(username, store)
 
-    thread = await store.get_crosstalk_thread(
-        thread_id=thread_id, tenant_enterprise=enterprise_id
-    )
+    thread = await store.get_crosstalk_thread(thread_id=thread_id, tenant_enterprise=enterprise_id)
     if thread is None:
         raise HTTPException(status_code=404, detail="Thread not found")
     if username not in thread["participants"] and role != "admin":

--- a/server/backend/src/cq_server/review.py
+++ b/server/backend/src/cq_server/review.py
@@ -147,9 +147,7 @@ async def _sweep_pending_review_ttl(store: "SqliteStore", enterprise_id: str) ->
 
     try:
         now_iso = _dt.now(UTC).isoformat()
-        await store.expire_pending_reviews(
-            enterprise_id=enterprise_id, now_iso=now_iso
-        )
+        await store.expire_pending_reviews(enterprise_id=enterprise_id, now_iso=now_iso)
     except Exception as exc:  # noqa: BLE001 — best-effort by design
         logging.getLogger(__name__).warning(
             "pending_review TTL sweep failed for enterprise=%s: %s",
@@ -206,15 +204,11 @@ async def approve_unit(
     # another admin transitioned the row between our SELECT above and
     # our UPDATE — the WHERE clause's terminal-state guard refuses the
     # second write. Re-read and 409 with the winning admin's outcome.
-    won = await store.set_review_status(
-        unit_id, "approved", username, enterprise_id=enterprise_id
-    )
+    won = await store.set_review_status(unit_id, "approved", username, enterprise_id=enterprise_id)
     if not won:
         current = await store.get_review_status(unit_id, enterprise_id=enterprise_id)
         terminal = current["status"] if current else "resolved"
-        raise HTTPException(
-            status_code=409, detail=f"Knowledge unit already {terminal}"
-        )
+        raise HTTPException(status_code=409, detail=f"Knowledge unit already {terminal}")
     updated = await store.get_review_status(unit_id, enterprise_id=enterprise_id)
     assert updated is not None  # Unit exists; we just wrote to it.
     await _hook_ku_event(store, unit_id, "approve", enterprise_id, username)
@@ -261,15 +255,11 @@ async def reject_unit(
     # Optimistic concurrency: see ``approve_unit`` for the rationale —
     # if another admin won the race we 409 with the terminal status
     # rather than silently overwriting their decision.
-    won = await store.set_review_status(
-        unit_id, target_status, username, enterprise_id=enterprise_id
-    )
+    won = await store.set_review_status(unit_id, target_status, username, enterprise_id=enterprise_id)
     if not won:
         current = await store.get_review_status(unit_id, enterprise_id=enterprise_id)
         terminal = current["status"] if current else "resolved"
-        raise HTTPException(
-            status_code=409, detail=f"Knowledge unit already {terminal}"
-        )
+        raise HTTPException(status_code=409, detail=f"Knowledge unit already {terminal}")
     updated = await store.get_review_status(unit_id, enterprise_id=enterprise_id)
     assert updated is not None  # Unit exists; we just wrote to it.
     await _hook_ku_event(store, unit_id, "reject", enterprise_id, username)
@@ -339,9 +329,7 @@ async def pending_review_queue(
     response (best-effort, same pattern as the activity-log writes).
     """
     enterprise_id = await _admin_enterprise(username, store)
-    items = await store.list_pending_review(
-        enterprise_id=enterprise_id, limit=limit, offset=offset
-    )
+    items = await store.list_pending_review(enterprise_id=enterprise_id, limit=limit, offset=offset)
     total = await store.count_pending_review(enterprise_id=enterprise_id)
     # Best-effort TTL sweep — runs after the response is sent so the
     # eventual on-disk transition lines up with the activity log


### PR DESCRIPTION
## Summary
- Adds `# pragma: allowlist secret` to the Crockford base32 alphabet constant in `activity.py` (its twin in `reflect.py` already carries the pragma).
- Foundational fix for #149 and #156 — both were stuck on detect-secrets CI failures pointing at this line.

## Why pragma over baseline
Inline pragma is the standard remediation detect-secrets itself recommends. Works regardless of `.secrets.baseline` state, robust to baseline drift between branches, and survives rebases without re-scanning.

## Test plan
- [x] `pre-commit run detect-secrets --files server/backend/src/cq_server/activity.py` — Passed
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)