### PR TITLE
chore(setup-skill): default L2 endpoint example -> https://team-dw.8th-layer.ai

### DIFF
--- a/plugins/cq/crosstalk-mcp/README.md
+++ b/plugins/cq/crosstalk-mcp/README.md
@@ -82,7 +82,7 @@ A future model (Phase 3+) where the L2 itself drives delivery — long-poll, SSE
 - L2 endpoints (companion, shipped): [#124](https://github.com/OneZero1ai/8th-layer-agent/issues/124)
 - L2 idempotency support: commit `f0905f4`
 - claude-mux validation partner: standing by; will re-run Plan-21 scenario 4 against this package once draft is up
-- TeamDW endpoint for live testing: `http://team-dw--Alb-byUUELeYenuZ-1431880588.us-east-1.elb.amazonaws.com/api/v1/crosstalk/*`
+- TeamDW endpoint for live testing: `https://team-dw.8th-layer.ai/api/v1/crosstalk/*` (canonical; raw ALB hostname is internal-only)
 - Plan-21 scenario 4 (cutover gate): `crosstalk-enterprise/docs/plans/21-teamdw-test-orchestration.md`
 
 ## License


### PR DESCRIPTION
## Summary

Update the one URL reference in the **cq plugin source tree** that pointed new TeamDW developers at the raw ALB hostname; redirect them to the canonical `https://team-dw.8th-layer.ai` that just shipped in PR #49 (TLS, CloudFront, dedicated subdomain).

## Files modified

| File | Before | After |
|---|---|---|
| `plugins/cq/crosstalk-mcp/README.md` (line 85) | `http://team-dw--Alb-byUUELeYenuZ-1431880588.us-east-1.elb.amazonaws.com/api/v1/crosstalk/*` | `https://team-dw.8th-layer.ai/api/v1/crosstalk/*` (canonical; raw ALB hostname is internal-only) |

## Files intentionally LEFT alone

After auditing the full plugin tree (`plugins/cq/**` excluding `node_modules` / `.pytest_cache`), these references stay as-is:

- **`plugins/cq/.claude-plugin/plugin.json`** — `homepage` and `author.url` already point at `https://8thlayer.onezero1.ai` (corrected upstream in commit `92f1594`). Not a TeamDW URL — that is the marketing landing for the cq commons.
- **`plugins/cq/commands/consult-open.md` line 38** — runbook URL points at the old `crosstalk-enterprise` repo path. Stale, but it is a *runbook reference* (separate concern), not a TeamDW endpoint example. Out of scope for this PR; suggest filing as a follow-up.
- **`plugins/cq/skills/cq/SKILL.md`** — the cq protocol skill. No URL prompts; nothing to change.
- **`plugins/cq/scripts/bootstrap.py` / `cq_binary.py`** — binary bootstrap. Only URL references are GitHub release-asset URLs (correct) — no L2-endpoint prompts.
- **`plugins/cq/crosstalk-mcp/src/*.js`** — env-driven (`CROSSTALK_L2_URL`, `CQ_ADDR`); no hardcoded URLs.
- **Server-side dogfood references** (`server/backend/src/cq_server/network.py`, `docs/runbooks/cloudfront-spa-fallback-scoping.md` mentions of `https://8th-layer.ai/admin/api/l2/8th-layer/...`, `docs/onboarding/2026-05-05-bran-onboarding.md` mentions of `moscowmu-Alb-...`) — these are dogfood / internal-test L2s, *not* the plugin's setup-skill, and intentionally remain pointing at the test/internal URLs per the task constraints.

## UX gap noticed (not fixed here — proposing for separate issue)

**There is no setup-skill in the plugin source tree today.** The cq plugin currently relies on developers reading external runbook docs (e.g. `docs/runbooks/01-customer-onboarding-zero-to-peered.md` on the old repo) to set `CQ_ADDR` / `CQ_API_KEY` env vars. The closest in-plugin guidance is the deferred error message in `plugins/cq/commands/consult-open.md` lines 33-40 ("CQ_ADDR and/or CQ_API_KEY not set. See the runbook...").

The task description anticipated a multi-enterprise selector ("which enterprise are you joining? team-dw / 8th-layer / cq-fanboy / other") — that does not exist yet. **Proposing as a follow-up issue (not implemented in this PR per the explicit constraint to not implement without operator approval):**

- New `plugins/cq/skills/setup/SKILL.md` that walks a new developer through:
  1. Picking enterprise (`team-dw` -> default `https://team-dw.8th-layer.ai`; `8th-layer` -> dogfood path; `other` -> prompt for paste)
  2. Pasting / generating an API key
  3. Verifying with a `cq status` round-trip
- Validation regex / allowlist for entered URL — should accept `team-dw.8th-layer.ai` and `*.8th-layer.ai` subdomains, reject raw ALB hostnames with a warning.

If the operator approves, the follow-up branch can implement that on top of this URL hygiene fix.

## Trace-through (today, with this PR landed)

What a TeamDW developer sees today, in order:

1. They install the `8l-cq` plugin via marketplace (handled by plugin.json — fine).
2. They look for a setup walkthrough — find none in the plugin; fall back to repo `README.md` or the TeamDW runbook from PR #45.
3. They open `plugins/cq/crosstalk-mcp/README.md` while wiring crosstalk -> L2 dual-write. With this PR, line 85 now reads `https://team-dw.8th-layer.ai/api/v1/crosstalk/*` -> they paste that as `CROSSTALK_L2_URL`. Without this PR, they would have copied the raw ALB hostname (no TLS, internal-only, would break in production cutover).
4. They run their first `cq query` -> `consult-open.md` triggers if creds missing; it cites the old `crosstalk-enterprise` repo URL (separate stale-link concern, see above).

## Constraints respected

- Did NOT touch the plugin's auth logic, MCP server config, or hook code.
- Did NOT touch `marketplace.json` or its publisher.
- Did NOT touch operator-side `~/.claude-mux/profiles/8l-cq.json`.
- Branch name and file scope do not overlap with the in-flight #161 / #149 / #156 subagent branches.
- Pre-commit ran cleanly on the changed file (no detect-secrets activity.py drift to surface).

## Test plan

- [ ] CI green on `chore/setup-skill-team-dw-default-url`
- [ ] Manual: open `plugins/cq/crosstalk-mcp/README.md` rendered on GitHub; confirm the line-85 URL is the canonical branded one
- [ ] Operator decision: file follow-up issue for the proposed setup-skill (multi-enterprise selector + URL validation), or close as out-of-scope

Refs PR #49 (team-dw.8th-layer.ai standup), PR #45 (TeamDW developer runbook + gap audit).

Generated with Claude Code (Opus 4.7).
