### PR TITLE
fix(auth): require_api_key callers swap to get_current_user (closes #161)

### DIFF
--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -25,12 +25,12 @@ from starlette.responses import FileResponse
 from . import aigrp
 from .activity_logger import log_activity, summary_first_60
 from .activity_routes import router as activity_router
-from .auth import require_admin
+from .auth import get_current_user, require_admin
 from .auth import router as auth_router
 from .consults import router as consults_router
 from .crosstalk_routes import router as crosstalk_router
 from .db_url import resolve_sqlite_db_path
-from .deps import API_KEY_PEPPER_ENV, require_api_key
+from .deps import API_KEY_PEPPER_ENV
 from .embed import compose_text, embed_text
 from .embed import model_id as embed_model_id
 from .migrations import run_migrations
@@ -416,7 +416,7 @@ class AigrpLookupResponse(BaseModel):
 @api_router.post("/aigrp/lookup")
 async def aigrp_lookup(
     request: AigrpLookupRequest,
-    _username: str = Depends(require_api_key),
+    _username: str = Depends(get_current_user),
 ) -> AigrpLookupResponse:
     """Automatic-trigger lookup for AIGRP-pull (Phase 2).
 
@@ -1050,7 +1050,7 @@ class ActivePeersResponse(BaseModel):
 @api_router.post("/peers/heartbeat")
 async def peers_heartbeat(
     request: PeerHeartbeatRequest,
-    username: str = Depends(require_api_key),
+    username: str = Depends(get_current_user),
 ) -> PeerHeartbeatResponse:
     """Register or refresh a persona's presence on this L2.
 
@@ -1089,7 +1089,7 @@ async def peers_active(
     since_minutes: Annotated[int, Query(gt=0, le=24 * 60)] = PEER_ACTIVE_DEFAULT_WINDOW_MIN,
     include_self: Annotated[bool, Query()] = False,
     self_persona: Annotated[str | None, Query(alias="self_persona")] = None,
-    username: str = Depends(require_api_key),
+    username: str = Depends(get_current_user),
 ) -> ActivePeersResponse:
     """Return discoverable peers in the caller's Enterprise.
 
@@ -1398,7 +1398,7 @@ async def consents_revoke(
 async def query_semantic(
     q: Annotated[str, Query(min_length=1)],
     limit: Annotated[int, Query(gt=0, le=50)] = 10,
-    _username: str = Depends(require_api_key),
+    _username: str = Depends(get_current_user),
 ) -> list[SemanticHit]:
     """Embed `q` and return top-N approved KUs by cosine similarity."""
     store = _get_store()
@@ -1420,7 +1420,7 @@ async def query_units(
     frameworks: Annotated[list[str] | None, Query()] = None,
     pattern: Annotated[str | None, Query()] = None,
     limit: Annotated[int, Query(gt=0)] = 5,
-    username: str = Depends(require_api_key),
+    username: str = Depends(get_current_user),
 ) -> list[KnowledgeUnit]:
     """Search knowledge units by domain tags with relevance ranking.
 
@@ -1472,7 +1472,7 @@ async def query_units(
 async def propose_unit(
     request: ProposeRequest,
     background_tasks: BackgroundTasks,
-    username: str = Depends(require_api_key),
+    username: str = Depends(get_current_user),
 ) -> KnowledgeUnit:
     """Submit a new knowledge unit.
 
@@ -1494,8 +1494,8 @@ async def propose_unit(
     if user is None:
         # The auth layer accepted the bearer token but the user row is
         # gone (revocation race / cleanup). 401 is the right shape —
-        # ``require_api_key`` already 401'd if the key was invalid, so a
-        # caller hitting this branch has a half-deleted user.
+        # ``get_current_user`` already 401'd if the bearer was invalid,
+        # so a caller hitting this branch has a half-deleted user.
         raise HTTPException(status_code=401, detail="User not found")
     enterprise_id = user["enterprise_id"]
     group_id = user["group_id"]
@@ -1592,7 +1592,7 @@ async def propose_unit(
 async def confirm_unit(
     unit_id: str,
     background_tasks: BackgroundTasks,
-    username: str = Depends(require_api_key),
+    username: str = Depends(get_current_user),
 ) -> KnowledgeUnit:
     """Confirm a knowledge unit, boosting its confidence.
 
@@ -1619,7 +1619,7 @@ async def flag_unit(
     unit_id: str,
     request: FlagRequest,
     background_tasks: BackgroundTasks,
-    username: str = Depends(require_api_key),
+    username: str = Depends(get_current_user),
 ) -> KnowledgeUnit:
     """Flag a knowledge unit, reducing its confidence.
 
@@ -1645,7 +1645,7 @@ async def flag_unit(
 
 @api_router.get("/stats")
 async def stats(
-    username: str = Depends(require_api_key),
+    username: str = Depends(get_current_user),
 ) -> StatsResponse:
     """Return store statistics scoped to the caller's Enterprise.
 

--- a/server/backend/src/cq_server/auth.py
+++ b/server/backend/src/cq_server/auth.py
@@ -23,7 +23,7 @@ from typing import Any
 
 import bcrypt
 import jwt
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from . import aigrp
@@ -222,6 +222,7 @@ def _get_jwt_secret() -> str:
 
 async def get_current_user(
     request: Request,
+    background_tasks: BackgroundTasks,
     store: SqliteStore = Depends(get_store),
 ) -> str:
     """FastAPI dependency: authenticate the caller and return their username.
@@ -232,8 +233,14 @@ async def get_current_user(
     dispatch matches ``_resolve_caller`` so every route protected by
     this dep gets both bearer shapes for free.
 
+    For API-key callers, this also schedules a non-blocking
+    ``touch_api_key_last_used`` write — preserving the audit-trail
+    behavior of the pre-#161 ``require_api_key`` dep so observability
+    isn't lost when the JWT-fanout swap happens.
+
     Args:
         request: The incoming FastAPI request.
+        background_tasks: FastAPI background tasks used to record API-key usage.
         store: The store dependency, used to resolve API-key rows.
 
     Returns:
@@ -243,6 +250,8 @@ async def get_current_user(
         HTTPException: 401 on missing header or either-shape failure.
     """
     caller = await _resolve_caller(request, store)
+    if caller.auth_kind == "api_key" and caller.api_key_id is not None:
+        background_tasks.add_task(store.touch_api_key_last_used, caller.api_key_id)
     return caller.username
 
 

--- a/server/backend/src/cq_server/reflect.py
+++ b/server/backend/src/cq_server/reflect.py
@@ -31,7 +31,8 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
-from .deps import get_store, require_api_key
+from .auth import get_current_user
+from .deps import get_store
 from .store._sqlite import SqliteStore
 
 # Contract caps. ``CONTEXT_MAX_BYTES`` is the 1 MB hard cap from the
@@ -211,7 +212,7 @@ def _ensure_unrecognised_state_safe(state: str) -> str:
 @router.post("/submit", status_code=202, response_model=None)
 async def submit_reflection(
     body: ReflectSubmitRequest,
-    username: str = Depends(require_api_key),
+    username: str = Depends(get_current_user),
     store: SqliteStore = Depends(get_store),
 ) -> ReflectSubmitResponse | JSONResponse:
     """Enqueue a reflection job. See contract §"POST /api/v1/reflect/submit"."""
@@ -328,7 +329,7 @@ async def submit_reflection(
 @router.get("/status")
 async def get_status(
     submission_id: Annotated[str, Query(min_length=1)],
-    username: str = Depends(require_api_key),
+    username: str = Depends(get_current_user),
     store: SqliteStore = Depends(get_store),
 ) -> ReflectStatusResponse:
     """Return state for one submission. 404 when unknown.
@@ -359,7 +360,7 @@ async def get_status(
 )
 async def get_last(
     session_id: Annotated[str, Query(min_length=1, max_length=128, pattern=SESSION_ID_REGEX)],
-    username: str = Depends(require_api_key),
+    username: str = Depends(get_current_user),
     store: SqliteStore = Depends(get_store),
 ) -> ReflectStatusResponse | ReflectLastEmptyResponse:
     """Most-recent submission for a session-id within the caller's Enterprise.

--- a/server/backend/tests/test_admin_delete.py
+++ b/server/backend/tests/test_admin_delete.py
@@ -8,12 +8,31 @@ from typing import Any
 
 import bcrypt
 import pytest
+from fastapi import Depends, Request
 from fastapi.testclient import TestClient
 
 from cq_server.app import app
-from cq_server.deps import require_api_key
+from cq_server.auth import _resolve_caller, get_current_user
+from cq_server.deps import get_store, require_api_key
 
 TEST_USERNAME = "test-user"
+
+
+async def _smart_get_current_user(  # type: ignore[no-untyped-def]
+    request: Request,
+    store=Depends(get_store),  # noqa: B008 — FastAPI dep
+) -> str:
+    """Header-aware test override.
+
+    When the caller passes an Authorization header, fall through to the
+    live JWT/API-key path so admin-gated /review/* tests pin the
+    real caller. With no header, return ``TEST_USERNAME`` so the
+    auth-less /propose helper in this file continues to work.
+    """
+    if request.headers.get("Authorization"):
+        caller = await _resolve_caller(request, store)
+        return caller.username
+    return TEST_USERNAME
 
 
 @pytest.fixture()
@@ -22,6 +41,7 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
     monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
     monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
     app.dependency_overrides[require_api_key] = lambda: TEST_USERNAME
+    app.dependency_overrides[get_current_user] = _smart_get_current_user
     with TestClient(app) as c:
         from cq_server.app import _get_store
         from cq_server.auth import hash_password
@@ -31,6 +51,7 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
             store.sync.create_user(TEST_USERNAME, hash_password("test-pw"))
         yield c
     app.dependency_overrides.pop(require_api_key, None)
+    app.dependency_overrides.pop(get_current_user, None)
 
 
 def _propose_payload(**overrides: Any) -> dict[str, Any]:

--- a/server/backend/tests/test_app.py
+++ b/server/backend/tests/test_app.py
@@ -5,12 +5,34 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from fastapi import Depends, Request
 from fastapi.testclient import TestClient
 
 from cq_server.app import app
-from cq_server.deps import require_api_key
+from cq_server.auth import _resolve_caller, get_current_user
+from cq_server.deps import get_store, require_api_key
 
 TEST_USERNAME = "test-user"
+
+
+async def _smart_get_current_user(  # type: ignore[no-untyped-def]
+    request: Request,
+    store=Depends(get_store),  # noqa: B008 — FastAPI dep
+) -> str:
+    """Header-aware test override.
+
+    When the caller passed an Authorization header (real JWT or API key),
+    fall through to the live auth path so tests that exercise the
+    bearer-shape contract — TestReviewLifecycleEndToEnd,
+    TestApiKeyEnforcement — pin the right caller. When no header is
+    present, fall back to ``TEST_USERNAME`` so the legacy auth-less
+    helpers in this file (post-/propose without an explicit token)
+    continue to work.
+    """
+    if request.headers.get("Authorization"):
+        caller = await _resolve_caller(request, store)
+        return caller.username
+    return TEST_USERNAME
 
 
 @pytest.fixture()
@@ -19,6 +41,7 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
     monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
     monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
     app.dependency_overrides[require_api_key] = lambda: TEST_USERNAME
+    app.dependency_overrides[get_current_user] = _smart_get_current_user
     with TestClient(app) as c:
         # Endpoints that resolve tenancy from the user row (e.g. /query,
         # /peers/heartbeat) need the test user to exist. Seeded in the
@@ -31,15 +54,17 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
             store.sync.create_user(TEST_USERNAME, hash_password("test-pw"))
         yield c
     app.dependency_overrides.pop(require_api_key, None)
+    app.dependency_overrides.pop(get_current_user, None)
 
 
 @pytest.fixture()
 def enforced_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
-    """TestClient with real API key enforcement (no dep override)."""
+    """TestClient with real auth enforcement (no dep override)."""
     monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "test.db"))
     monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
     monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
     app.dependency_overrides.pop(require_api_key, None)
+    app.dependency_overrides.pop(get_current_user, None)
     with TestClient(app) as c:
         yield c
 

--- a/server/backend/tests/test_auth.py
+++ b/server/backend/tests/test_auth.py
@@ -9,7 +9,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from cq_server.app import app
-from cq_server.auth import create_token, hash_password, verify_password, verify_token
+from cq_server.auth import create_token, get_current_user, hash_password, verify_password, verify_token
 from cq_server.deps import require_api_key
 
 
@@ -19,9 +19,11 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
     monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
     monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
     app.dependency_overrides[require_api_key] = lambda: "test-user"
+    app.dependency_overrides[get_current_user] = lambda: "test-user"
     with TestClient(app) as c:
         yield c
     app.dependency_overrides.pop(require_api_key, None)
+    app.dependency_overrides.pop(get_current_user, None)
 
 
 def _seed_user(client: TestClient, username: str = "peter", password: str = "secret123") -> None:
@@ -187,6 +189,7 @@ def api_key_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[
     monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
     monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
     app.dependency_overrides.pop(require_api_key, None)
+    app.dependency_overrides.pop(get_current_user, None)
     with TestClient(app) as c:
         yield c
 

--- a/server/backend/tests/test_peers_active.py
+++ b/server/backend/tests/test_peers_active.py
@@ -20,6 +20,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from cq_server.app import _get_store, app
+from cq_server.auth import get_current_user
 from cq_server.deps import require_api_key
 
 ALICE = "alice"  # acme/engineering
@@ -56,6 +57,7 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
 
 def _heartbeat(client: TestClient, *, as_user: str, persona: str, discoverable: bool = True) -> None:
     app.dependency_overrides[require_api_key] = lambda: as_user
+    app.dependency_overrides[get_current_user] = lambda: as_user
     try:
         client.post(
             "/api/v1/peers/heartbeat",
@@ -63,6 +65,7 @@ def _heartbeat(client: TestClient, *, as_user: str, persona: str, discoverable: 
         )
     finally:
         app.dependency_overrides.pop(require_api_key, None)
+        app.dependency_overrides.pop(get_current_user, None)
 
 
 def _set_last_seen(persona: str, when: datetime) -> None:
@@ -77,10 +80,12 @@ def _set_last_seen(persona: str, when: datetime) -> None:
 
 def _list_active(client: TestClient, *, as_user: str, **params: object) -> dict:
     app.dependency_overrides[require_api_key] = lambda: as_user
+    app.dependency_overrides[get_current_user] = lambda: as_user
     try:
         resp = client.get("/api/v1/peers/active", params=params)
     finally:
         app.dependency_overrides.pop(require_api_key, None)
+        app.dependency_overrides.pop(get_current_user, None)
     assert resp.status_code == 200, resp.text
     return resp.json()
 

--- a/server/backend/tests/test_peers_heartbeat.py
+++ b/server/backend/tests/test_peers_heartbeat.py
@@ -20,6 +20,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from cq_server.app import _get_store, app
+from cq_server.auth import get_current_user
 from cq_server.deps import require_api_key
 
 ALICE = "alice"
@@ -50,10 +51,12 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
 
 def _override_api_key(username: str) -> None:
     app.dependency_overrides[require_api_key] = lambda: username
+    app.dependency_overrides[get_current_user] = lambda: username
 
 
 def _clear_override() -> None:
     app.dependency_overrides.pop(require_api_key, None)
+    app.dependency_overrides.pop(get_current_user, None)
 
 
 class TestHeartbeatUpsert:
@@ -191,7 +194,7 @@ class TestExpertiseDomainsRoundtrip:
 
 class TestAuthRequired:
     def test_no_api_key_returns_401(self, client: TestClient) -> None:
-        # No override; the require_api_key dep should reject.
+        # No override; the get_current_user dep should reject.
         resp = client.post(
             "/api/v1/peers/heartbeat",
             json={"persona": "persona-naked", "discoverable": True},

--- a/server/backend/tests/test_reflect.py
+++ b/server/backend/tests/test_reflect.py
@@ -25,6 +25,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from cq_server.app import app
+from cq_server.auth import get_current_user
 from cq_server.deps import require_api_key
 
 ALICE_USERNAME = "alice-reflect"
@@ -46,6 +47,7 @@ def alice_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Te
     # override to 0 when they want to bypass for sequential calls.
     monkeypatch.setenv("REFLECT_RATE_LIMIT_PER_HOURS", "4")
     app.dependency_overrides[require_api_key] = lambda: ALICE_USERNAME
+    app.dependency_overrides[get_current_user] = lambda: ALICE_USERNAME
     with TestClient(app) as client:
         from cq_server.app import _get_store
         from cq_server.auth import hash_password
@@ -69,6 +71,7 @@ def alice_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Te
                 )
         yield client
     app.dependency_overrides.pop(require_api_key, None)
+    app.dependency_overrides.pop(get_current_user, None)
 
 
 def _submit_payload(**overrides: Any) -> dict[str, Any]:
@@ -225,6 +228,7 @@ class TestStatus:
         # Flip the auth override to Bob without rebuilding the client
         # (same DB, same TestClient).
         app.dependency_overrides[require_api_key] = lambda: BOB_USERNAME
+        app.dependency_overrides[get_current_user] = lambda: BOB_USERNAME
         try:
             bob_resp = alice_client.get(
                 "/api/v1/reflect/status",
@@ -233,6 +237,7 @@ class TestStatus:
             assert bob_resp.status_code == 404
         finally:
             app.dependency_overrides[require_api_key] = lambda: ALICE_USERNAME
+            app.dependency_overrides[get_current_user] = lambda: ALICE_USERNAME
 
 
 class TestLast:
@@ -274,6 +279,7 @@ class TestLast:
 
         # Bob queries /last for "shared-name" — should see null shape.
         app.dependency_overrides[require_api_key] = lambda: BOB_USERNAME
+        app.dependency_overrides[get_current_user] = lambda: BOB_USERNAME
         try:
             resp = alice_client.get(
                 "/api/v1/reflect/last",
@@ -284,6 +290,7 @@ class TestLast:
             assert body["submission_id"] is None
         finally:
             app.dependency_overrides[require_api_key] = lambda: ALICE_USERNAME
+            app.dependency_overrides[get_current_user] = lambda: ALICE_USERNAME
 
 
 class TestRouterMounting:

--- a/server/backend/tests/test_review.py
+++ b/server/backend/tests/test_review.py
@@ -16,6 +16,13 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
     monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "test.db"))
     monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
     monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    # The require_api_key override is retained for any callsite that
+    # still routes through it (vestigial — none of the routes the review
+    # tests touch use it post-#161, but harmless to leave in place).
+    # Note: get_current_user is NOT overridden — these tests log in for
+    # real and pass JWTs in Authorization headers, and the
+    # ``test_*_requires_auth`` cases assert 401-on-missing-header
+    # semantics that an override would break.
     app.dependency_overrides[require_api_key] = lambda: "test-user"
     with TestClient(app) as c:
         from cq_server.app import _get_store
@@ -65,7 +72,7 @@ def _auth_header(token: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
-def _propose(client: TestClient, **overrides: Any) -> dict[str, Any]:
+def _propose(client: TestClient, token: str | None = None, **overrides: Any) -> dict[str, Any]:
     defaults: dict[str, Any] = {
         "domains": ["api", "testing"],
         "insight": {
@@ -74,7 +81,8 @@ def _propose(client: TestClient, **overrides: Any) -> dict[str, Any]:
             "action": "Use schema-aware assertions in API tests.",
         },
     }
-    resp = client.post("/propose", json={**defaults, **overrides})
+    headers = _auth_header(token) if token else _auth_header(_login(client))
+    resp = client.post("/propose", json={**defaults, **overrides}, headers=headers)
     assert resp.status_code == 201
     return resp.json()
 
@@ -125,9 +133,9 @@ class TestApprove:
 
     def test_approved_unit_appears_in_query(self, client: TestClient) -> None:
         token = _login(client)
-        unit = _propose(client, domains=["searchable"])
+        unit = _propose(client, token=token, domains=["searchable"])
         client.post(f"/review/{unit['id']}/approve", headers=_auth_header(token))
-        resp = client.get("/query", params={"domains": ["searchable"]})
+        resp = client.get("/query", params={"domains": ["searchable"]}, headers=_auth_header(token))
         assert len(resp.json()) == 1
 
 
@@ -142,9 +150,9 @@ class TestReject:
 
     def test_rejected_unit_not_in_query(self, client: TestClient) -> None:
         token = _login(client)
-        unit = _propose(client, domains=["hidden"])
+        unit = _propose(client, token=token, domains=["hidden"])
         client.post(f"/review/{unit['id']}/reject", headers=_auth_header(token))
-        resp = client.get("/query", params={"domains": ["hidden"]})
+        resp = client.get("/query", params={"domains": ["hidden"]}, headers=_auth_header(token))
         assert len(resp.json()) == 0
 
 


### PR DESCRIPTION
## Summary

Closes #161 — `require_api_key` rejected JWT Bearer tokens. PR #99 introduced `get_current_user` (accepts both JWT and API-key bearers) but left 12 user-facing endpoints stuck on the API-key-only dep, so JWT-authenticated sessions could hit `/auth/me` but not `/propose`, `/query`, `/confirm`, `/flag`, `/stats`, `/peers/*`, `/aigrp/lookup`, `/reflect/*` or `/query/semantic`.

This PR swaps all 12 callsites (the issue body said 13; an actual `grep -n` for `Depends(require_api_key)` returned 12 — line 1497 in app.py was a comment reference, not a callsite). `require_api_key` itself is preserved in `deps.py` for any future API-key-only routes.

## Per-endpoint decision table

All 12 are mixed-auth (JWT OR API key). None are kept API-key-only — every callsite is interactive/user-facing and resolves tenancy from the authenticated user's row, so JWT works equivalently.

| File:line | Endpoint | Decision | Rationale |
|---|---|---|---|
| `app.py:419` | `POST /aigrp/lookup` | mixed-auth | Auto-trigger semantic lookup fired by harness; interactive sessions running with JWT must still get suggestions. |
| `app.py:1053` | `POST /peers/heartbeat` | mixed-auth | Persona presence registration; interactive Claude Code sessions register via JWT. |
| `app.py:1092` | `GET /peers/active` | mixed-auth | Discoverable-peers list scoped by caller's enterprise; same threat surface as API-key path. |
| `app.py:1401` | `GET /query/semantic` | mixed-auth | Semantic search; tenancy resolved from caller's user row. |
| `app.py:1423` | `GET /query` | mixed-auth | Domain-tag search; the original endpoint cited in #161. |
| `app.py:1475` | `POST /propose` | mixed-auth | The original bug report — proposes blocked for JWT callers. |
| `app.py:1595` | `POST /confirm/{unit_id}` | mixed-auth | Confirmation increments confidence; routine user action. |
| `app.py:1622` | `POST /flag/{unit_id}` | mixed-auth | Flag decreases confidence; routine user action. |
| `app.py:1648` | `GET /stats` | mixed-auth | Enterprise-scoped aggregates; no API-key-only justification. |
| `reflect.py:214` | `POST /reflect/submit` | mixed-auth | Reflection enqueue; user-initiated. |
| `reflect.py:331` | `GET /reflect/status` | mixed-auth | Read-only status query; cross-Enterprise isolation enforced inside the route. |
| `reflect.py:362` | `GET /reflect/last` | mixed-auth | Read-only last-submission lookup. |

## Side effect preservation

Pre-fix, `require_api_key` scheduled a non-blocking `touch_api_key_last_used` write so audit trails reflected key usage. The new `get_current_user` delegated to `_resolve_caller` for validation but did NOT replicate that side effect — the regression was hidden because PR #99 only migrated `/auth/me`. Fix: `get_current_user` now schedules the same background task when `caller.auth_kind == "api_key"`. JWT callers correctly skip the touch (no `last_used` to update). Pinned by the existing `test_last_used_at_updates_after_request` test, which now passes.

## 8l-reviewer findings

### HIGH — JWT path bypasses rate-limiting applied to API-key path

- **Reviewer's question:** if `require_api_key` enforces per-key rate limits, JWT callers now bypass them.
- **My response:** `require_api_key` does NOT enforce rate limits. `grep -n "rate\|throttle\|limit" server/backend/src/cq_server/deps.py` returns nothing. The HIGH was speculative; finding is moot. Rate limiting in this codebase lives at the app/route level (e.g. `REFLECT_RATE_LIMIT_PER_HOURS` in `reflect.py`) and operates on `session_id`, not bearer kind — so the swap doesn't change limit behavior.

### MEDIUM — `/peers/heartbeat` widened from API-key-only to JWT may weaken machine-to-machine auth expectation

- **Reviewer's question:** if `/peers/heartbeat` is intended for backend processes only, JWT support widens the trust model.
- **My response:** Product intent is mixed-auth. The architecture treats interactive Claude Code sessions as the primary `peers/heartbeat` caller. Both bearer kinds resolve tenancy (`enterprise_id`/`group_id`) from the authenticated user row — the body never carries scope. JWT TTL (24h) is bounded; per-L2 secrets (H-6) plus `iss`/`aud` pinning bound a leaked token to one L2.

### MEDIUM — `touch_api_key_last_used` guard relies on `caller.api_key_id is not None`

- **Reviewer's question:** if `_resolve_caller` ever returns `auth_kind="api_key"` with `api_key_id=None`, the touch silently skips.
- **My response:** `_resolve_caller` always populates `api_key_id` from `row["id"]` on the API-key path (auth.py:328). The `is not None` check is defensive belt-and-suspenders. Adding a warning log for a "should never happen" branch felt like noise without a payoff path.

## Test plan

Test commands and outputs:

```
$ uv run pytest server/backend/tests/ --no-header -q
664 passed, 5 skipped, 6 warnings in 170.01s

$ uv run pytest server/backend/tests/test_propose_tenancy_regression.py \
                server/backend/tests/test_auto_approve_propose.py \
                server/backend/tests/test_reflect.py --no-header -q
27 passed in 12.78s

$ pre-commit run --files <10 modified files>
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
Detect secrets...........................................................Passed
ty (server/backend)......................................................Passed
```

(The repo-wide pre-commit run flags pre-existing issues in unmodified files — `test_quality.py` E501 long lines, `test_auto_approve_propose.py:59` and `test_activity_log_instrumentation.py:133` detect-secrets false positives. Those are baseline state, unrelated to this PR.)

- [x] Full test suite green (664 passed, 5 skipped)
- [x] Targeted propose/reflect regression suites green
- [x] pre-commit clean on all 10 modified files
- [x] 8l-reviewer self-review completed; findings addressed in PR body
- [x] `require_api_key` preserved in deps.py per constraint

## Risk assessment

- `/peers/heartbeat` and `/peers/active`: now reachable by any user with a valid JWT in the same enterprise. Pre-fix only callers with API keys could register/list presence. The expanded set is the intended surface (Claude Code interactive sessions), so this is the bug-fix's whole point — flagging here for visibility.
- `/aigrp/lookup`: same as above. Used by harness on every prompt; both bearer kinds work equivalently.
- All other endpoints: pure unblock — no caller previously authenticated via JWT would have succeeded, so widening doesn't surprise any existing legitimate caller.
- No tenancy-isolation regression: every route resolves `enterprise_id`/`group_id` from `store.get_user(username)`, never from request body, so the swap doesn't change scope resolution.

Filed by cq-fanboy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
