### PR TITLE
feat(frontend): apply 8th-Layer brand theme to L2 admin UI (#169)

### DIFF
--- a/server/frontend/index.html
+++ b/server/frontend/index.html
@@ -4,13 +4,19 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#040810" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <!--
+      8th-Layer brand stack: Fraunces (display, light), Inter (body),
+      IBM Plex Mono (eyebrows / IDs / counts). JetBrains Mono is kept for
+      backward compat with the network/NOC components which still reference it.
+    -->
     <link
-      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,200;9..144,300;9..144,400&family=Inter:wght@300;400;500;600&family=IBM+Plex+Mono:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
-    <title>cq</title>
+    <title>8th-Layer.ai · Layer 8 admin</title>
   </head>
   <body>
     <div id="root"></div>

--- a/server/frontend/src/components/ConfidenceBadge.tsx
+++ b/server/frontend/src/components/ConfidenceBadge.tsx
@@ -1,8 +1,10 @@
 export function ConfidenceBadge({ confidence }: { confidence: number }) {
   return (
-    <span className="text-sm text-gray-500">
-      Confidence:{" "}
-      <strong className="text-gray-800">{confidence.toFixed(2)}</strong>
+    <span className="text-sm text-[var(--ink-mute)]">
+      <span className="eyebrow">Confidence</span>{" "}
+      <strong className="font-mono-brand text-[var(--ink)]">
+        {confidence.toFixed(2)}
+      </strong>
     </span>
   )
 }

--- a/server/frontend/src/components/DomainTags.tsx
+++ b/server/frontend/src/components/DomainTags.tsx
@@ -1,10 +1,13 @@
 import type { Selection } from "../types"
 
 const TAG_STYLES: Record<string, string> = {
-  neutral: "bg-indigo-100 text-indigo-700",
-  approve: "bg-green-100 text-green-700",
-  reject: "bg-red-100 text-red-700",
-  skip: "bg-slate-100 text-slate-700",
+  neutral:
+    "bg-[color-mix(in_srgb,var(--violet)_12%,transparent)] text-[var(--violet)] border border-[color-mix(in_srgb,var(--violet)_22%,transparent)]",
+  approve:
+    "bg-[color-mix(in_srgb,var(--emerald)_12%,transparent)] text-[var(--emerald)] border border-[color-mix(in_srgb,var(--emerald)_24%,transparent)]",
+  reject:
+    "bg-[color-mix(in_srgb,var(--rose)_12%,transparent)] text-[var(--rose)] border border-[color-mix(in_srgb,var(--rose)_24%,transparent)]",
+  skip: "bg-[var(--surface-hover)] text-[var(--ink-dim)] border border-[var(--rule-strong)]",
 }
 
 interface Props {
@@ -19,7 +22,7 @@ export function DomainTags({ domains, variant }: Props) {
       {[...domains].sort().map((d) => (
         <span
           key={d}
-          className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${style}`}
+          className={`rounded-full px-2.5 py-0.5 font-mono-brand text-[10px] uppercase tracking-[0.14em] ${style}`}
         >
           {d}
         </span>

--- a/server/frontend/src/components/DragIndicators.tsx
+++ b/server/frontend/src/components/DragIndicators.tsx
@@ -2,9 +2,24 @@ import type { DragState } from "../hooks/useCardDrag"
 import { BADGE_APPEAR_RATIO } from "../hooks/useCardDrag"
 
 const INDICATORS = {
-  approve: { symbol: "\u2713", bg: "bg-green-600", label: "Approve" },
-  reject: { symbol: "\u2715", bg: "bg-red-600", label: "Reject" },
-  skip: { symbol: "\u2014", bg: "bg-slate-600", label: "Skip" },
+  approve: {
+    symbol: "✓",
+    bg: "bg-[var(--emerald)] text-[#04140c]",
+    label: "Approve",
+    color: "text-[var(--emerald)]",
+  },
+  reject: {
+    symbol: "✕",
+    bg: "bg-[var(--rose)] text-[#1a0a10]",
+    label: "Reject",
+    color: "text-[var(--rose)]",
+  },
+  skip: {
+    symbol: "—",
+    bg: "bg-[var(--ink-dim)] text-[var(--bg-via)]",
+    label: "Skip",
+    color: "text-[var(--ink-dim)]",
+  },
 } as const
 
 interface Props {
@@ -34,11 +49,13 @@ export function DragIndicators({ drag }: Props) {
         }}
       >
         <div
-          className={`w-10 h-10 ${INDICATORS.approve.bg} rounded-full flex items-center justify-center text-white text-lg`}
+          className={`w-10 h-10 ${INDICATORS.approve.bg} rounded-full flex items-center justify-center text-lg font-semibold shadow-lg`}
         >
           {INDICATORS.approve.symbol}
         </div>
-        <span className="text-xs font-semibold text-green-600">
+        <span
+          className={`font-mono-brand text-[10px] uppercase tracking-[0.18em] ${INDICATORS.approve.color}`}
+        >
           {INDICATORS.approve.label}
         </span>
       </div>
@@ -52,11 +69,13 @@ export function DragIndicators({ drag }: Props) {
         }}
       >
         <div
-          className={`w-10 h-10 ${INDICATORS.reject.bg} rounded-full flex items-center justify-center text-white text-lg`}
+          className={`w-10 h-10 ${INDICATORS.reject.bg} rounded-full flex items-center justify-center text-lg font-semibold shadow-lg`}
         >
           {INDICATORS.reject.symbol}
         </div>
-        <span className="text-xs font-semibold text-red-600">
+        <span
+          className={`font-mono-brand text-[10px] uppercase tracking-[0.18em] ${INDICATORS.reject.color}`}
+        >
           {INDICATORS.reject.label}
         </span>
       </div>
@@ -70,11 +89,13 @@ export function DragIndicators({ drag }: Props) {
         }}
       >
         <div
-          className={`w-10 h-10 ${INDICATORS.skip.bg} rounded-full flex items-center justify-center text-white text-lg`}
+          className={`w-10 h-10 ${INDICATORS.skip.bg} rounded-full flex items-center justify-center text-lg font-semibold shadow-lg`}
         >
           {INDICATORS.skip.symbol}
         </div>
-        <span className="text-xs font-semibold text-slate-600">
+        <span
+          className={`font-mono-brand text-[10px] uppercase tracking-[0.18em] ${INDICATORS.skip.color}`}
+        >
           {INDICATORS.skip.label}
         </span>
       </div>
@@ -88,11 +109,13 @@ export function DragIndicators({ drag }: Props) {
         }}
       >
         <div
-          className={`w-10 h-10 ${INDICATORS.skip.bg} rounded-full flex items-center justify-center text-white text-lg`}
+          className={`w-10 h-10 ${INDICATORS.skip.bg} rounded-full flex items-center justify-center text-lg font-semibold shadow-lg`}
         >
           {INDICATORS.skip.symbol}
         </div>
-        <span className="text-xs font-semibold text-slate-600">
+        <span
+          className={`font-mono-brand text-[10px] uppercase tracking-[0.18em] ${INDICATORS.skip.color}`}
+        >
           {INDICATORS.skip.label}
         </span>
       </div>

--- a/server/frontend/src/components/FilteredListModal.tsx
+++ b/server/frontend/src/components/FilteredListModal.tsx
@@ -78,7 +78,7 @@ export function FilteredListModal({ filter, onClose, onSelectUnit }: Props) {
         tabIndex={-1}
         aria-hidden="true"
         onClick={onClose}
-        className="absolute inset-0 bg-black/40 cursor-default"
+        className="absolute inset-0 bg-black/65 backdrop-blur-sm cursor-default"
       />
       <div
         ref={dialogRef}
@@ -86,28 +86,33 @@ export function FilteredListModal({ filter, onClose, onSelectUnit }: Props) {
         aria-modal="true"
         aria-labelledby={MODAL_TITLE_ID}
         tabIndex={-1}
-        className="relative bg-white rounded-lg shadow-xl w-full max-w-2xl mx-4 max-h-[90vh] flex flex-col outline-none"
+        className="relative brand-surface-raised w-full max-w-2xl mx-4 max-h-[90vh] flex flex-col outline-none shadow-[0_30px_80px_-20px_rgba(0,0,0,0.7)]"
       >
-        <div className="flex items-center justify-between p-4 border-b border-gray-200">
-          <h2
-            id={MODAL_TITLE_ID}
-            className="text-lg font-semibold text-gray-900"
-          >
-            {filter.title}
-          </h2>
+        <div className="flex items-center justify-between p-5 border-b border-[var(--rule)]">
+          <div>
+            <p className="eyebrow">Filtered list</p>
+            <h2
+              id={MODAL_TITLE_ID}
+              className="font-display text-xl text-[var(--ink)] mt-0.5"
+            >
+              {filter.title}
+            </h2>
+          </div>
           <button
             type="button"
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 text-xl leading-none"
+            className="text-[var(--ink-mute)] hover:text-[var(--ink)] text-xl leading-none transition-colors"
             aria-label="Close"
           >
-            &times;
+            ×
           </button>
         </div>
 
-        <div className="flex-1 overflow-y-auto p-4">
+        <div className="flex-1 overflow-y-auto p-5">
           {error && (
-            <p className="text-red-600 text-sm text-center py-4">{error}</p>
+            <p className="text-[var(--rose)] text-sm text-center py-4">
+              {error}
+            </p>
           )}
 
           {!items && !error && (
@@ -115,16 +120,24 @@ export function FilteredListModal({ filter, onClose, onSelectUnit }: Props) {
               {[1, 2, 3].map((i) => (
                 <div
                   key={i}
-                  className="h-16 animate-pulse bg-gray-100 rounded-lg"
+                  className="h-16 animate-pulse bg-[var(--surface-hover)] rounded-lg"
                 />
               ))}
             </div>
           )}
 
           {items && items.length === 0 && (
-            <p className="text-gray-400 text-sm text-center py-8">
-              No knowledge units found.
-            </p>
+            <div className="flex flex-col items-center justify-center py-12 gap-3">
+              <span
+                aria-hidden="true"
+                className="font-display text-3xl text-[var(--ink-faint)]"
+              >
+                ∅
+              </span>
+              <span className="eyebrow text-[var(--cyan)]">
+                No knowledge units found
+              </span>
+            </div>
           )}
 
           {items && items.length > 0 && (
@@ -133,18 +146,18 @@ export function FilteredListModal({ filter, onClose, onSelectUnit }: Props) {
                 <button
                   type="button"
                   key={item.knowledge_unit.id}
-                  className="w-full text-left p-3 rounded-lg border border-gray-200 hover:border-indigo-300 hover:bg-indigo-50/50 transition-colors"
+                  className="w-full text-left p-3 rounded-lg border border-[var(--rule)] bg-[var(--surface)] hover:border-[var(--cyan)] hover:bg-[var(--surface-hover)] transition-colors"
                   onClick={() => onSelectUnit(item.knowledge_unit.id)}
                 >
                   <div className="flex items-center gap-2 mb-1">
                     <StatusBadge status={item.status} />
-                    <span className="text-sm font-medium text-gray-900 truncate">
+                    <span className="text-sm font-medium text-[var(--ink)] truncate">
                       {item.knowledge_unit.insight.summary}
                     </span>
                   </div>
                   <div className="flex items-center gap-3">
                     <DomainTags domains={item.knowledge_unit.domains} />
-                    <span className="text-xs text-gray-400 ml-auto shrink-0">
+                    <span className="font-mono-brand text-[11px] text-[var(--ink-faint)] ml-auto shrink-0 tabular-nums">
                       {confidenceLabel(item.knowledge_unit.evidence.confidence)}
                     </span>
                   </div>

--- a/server/frontend/src/components/KnowledgeUnitModal.tsx
+++ b/server/frontend/src/components/KnowledgeUnitModal.tsx
@@ -11,10 +11,10 @@ interface Props {
 }
 
 function confidenceColor(c: number): string {
-  if (c < 0.3) return "text-red-600"
-  if (c < 0.5) return "text-amber-600"
-  if (c < 0.7) return "text-yellow-500"
-  return "text-green-600"
+  if (c < 0.3) return "text-[var(--rose)]"
+  if (c < 0.5) return "text-[var(--gold)]"
+  if (c < 0.7) return "text-[var(--gold)]"
+  return "text-[var(--emerald)]"
 }
 
 const MODAL_TITLE_ID = "ku-modal-title"
@@ -63,7 +63,7 @@ export function KnowledgeUnitModal({ unitId, onClose }: Props) {
         tabIndex={-1}
         aria-hidden="true"
         onClick={onClose}
-        className="absolute inset-0 bg-black/40 cursor-default"
+        className="absolute inset-0 bg-black/65 backdrop-blur-sm cursor-default"
       />
       <div
         ref={dialogRef}
@@ -71,15 +71,15 @@ export function KnowledgeUnitModal({ unitId, onClose }: Props) {
         aria-modal="true"
         aria-labelledby={item ? MODAL_TITLE_ID : undefined}
         tabIndex={-1}
-        className="relative bg-white rounded-lg shadow-xl w-full max-w-lg mx-4 max-h-[90vh] overflow-y-auto outline-none"
+        className="relative brand-surface-raised w-full max-w-lg mx-4 max-h-[90vh] overflow-y-auto outline-none shadow-[0_30px_80px_-20px_rgba(0,0,0,0.7)]"
       >
         {error && (
           <div className="p-6 text-center">
-            <p className="text-red-600 text-sm">{error}</p>
+            <p className="text-[var(--rose)] text-sm">{error}</p>
             <button
               type="button"
               onClick={onClose}
-              className="mt-3 text-sm text-gray-500 hover:text-gray-700"
+              className="mt-3 font-mono-brand text-[11px] uppercase tracking-[0.2em] text-[var(--ink-mute)] hover:text-[var(--ink)] transition-colors"
             >
               Close
             </button>
@@ -88,40 +88,43 @@ export function KnowledgeUnitModal({ unitId, onClose }: Props) {
 
         {!item && !error && (
           <div className="p-6 space-y-3">
-            <div className="h-4 w-32 animate-pulse bg-gray-200 rounded" />
-            <div className="h-6 w-48 animate-pulse bg-gray-200 rounded" />
-            <div className="h-16 w-full animate-pulse bg-gray-200 rounded" />
+            <div className="h-3 w-32 animate-pulse bg-[var(--rule-strong)] rounded" />
+            <div className="h-6 w-48 animate-pulse bg-[var(--rule-strong)] rounded" />
+            <div className="h-16 w-full animate-pulse bg-[var(--rule-strong)] rounded" />
           </div>
         )}
 
         {item && (
-          <div className="p-6 space-y-4">
+          <div className="p-6 space-y-5">
             <div className="flex items-start justify-between gap-3">
-              <h2
-                id={MODAL_TITLE_ID}
-                className="text-lg font-semibold text-gray-900"
-              >
-                {item.knowledge_unit.insight.summary}
-              </h2>
+              <div>
+                <p className="eyebrow mb-1.5">Knowledge unit</p>
+                <h2
+                  id={MODAL_TITLE_ID}
+                  className="font-display text-xl text-[var(--ink)] leading-snug"
+                >
+                  {item.knowledge_unit.insight.summary}
+                </h2>
+              </div>
               <button
                 type="button"
                 onClick={onClose}
-                className="text-gray-400 hover:text-gray-600 text-xl leading-none shrink-0"
+                className="text-[var(--ink-mute)] hover:text-[var(--ink)] text-xl leading-none shrink-0 transition-colors"
                 aria-label="Close"
               >
-                &times;
+                ×
               </button>
             </div>
 
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 flex-wrap">
               <StatusBadge status={item.status} />
               {item.reviewed_by && (
-                <span className="text-xs text-gray-500">
+                <span className="font-mono-brand text-[10px] uppercase tracking-[0.16em] text-[var(--ink-mute)]">
                   by {item.reviewed_by}
                 </span>
               )}
               {item.reviewed_at && (
-                <span className="text-xs text-gray-400">
+                <span className="font-mono-brand text-[10px] text-[var(--ink-faint)]">
                   {timeAgo(item.reviewed_at)}
                 </span>
               )}
@@ -129,35 +132,29 @@ export function KnowledgeUnitModal({ unitId, onClose }: Props) {
 
             <DomainTags domains={item.knowledge_unit.domains} />
 
-            <p className="text-gray-600 leading-relaxed">
+            <p className="text-[var(--ink-dim)] leading-relaxed">
               {item.knowledge_unit.insight.detail}
             </p>
 
-            <div className="border-l-3 rounded-r-lg px-4 py-3 bg-indigo-50 border-indigo-500">
-              <span className="text-xs font-semibold uppercase tracking-wide text-indigo-500">
-                Action
-              </span>
-              <p className="text-gray-800 text-sm mt-1">
+            <div className="border-l-2 rounded-r-lg px-4 py-3 bg-[color-mix(in_srgb,var(--cyan)_8%,transparent)] border-[var(--cyan)]">
+              <span className="eyebrow text-[var(--cyan)]">Action</span>
+              <p className="text-[var(--ink)] text-sm mt-1.5 leading-relaxed">
                 {item.knowledge_unit.insight.action}
               </p>
             </div>
 
-            <div className="grid grid-cols-2 gap-3 text-sm">
-              <div className="bg-gray-50 rounded-lg p-3">
-                <span className="text-xs text-gray-500 uppercase">
-                  Confidence
-                </span>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="rounded-lg p-3 bg-[var(--surface)] border border-[var(--rule)]">
+                <span className="eyebrow">Confidence</span>
                 <p
-                  className={`font-semibold ${confidenceColor(item.knowledge_unit.evidence.confidence)}`}
+                  className={`font-display font-light text-2xl mt-1 ${confidenceColor(item.knowledge_unit.evidence.confidence)} tabular-nums`}
                 >
                   {item.knowledge_unit.evidence.confidence.toFixed(2)}
                 </p>
               </div>
-              <div className="bg-gray-50 rounded-lg p-3">
-                <span className="text-xs text-gray-500 uppercase">
-                  Confirmations
-                </span>
-                <p className="font-semibold text-gray-800">
+              <div className="rounded-lg p-3 bg-[var(--surface)] border border-[var(--rule)]">
+                <span className="eyebrow">Confirmations</span>
+                <p className="font-display font-light text-2xl mt-1 text-[var(--ink)] tabular-nums">
                   {item.knowledge_unit.evidence.confirmations}
                 </p>
               </div>
@@ -165,28 +162,28 @@ export function KnowledgeUnitModal({ unitId, onClose }: Props) {
 
             {(item.knowledge_unit.context.languages.length > 0 ||
               item.knowledge_unit.context.frameworks.length > 0) && (
-              <div className="text-sm text-gray-500">
+              <div className="text-sm text-[var(--ink-mute)]">
                 {item.knowledge_unit.context.languages.length > 0 && (
                   <span>
-                    Languages:{" "}
+                    <span className="eyebrow mr-1">Languages</span>
                     {item.knowledge_unit.context.languages.join(", ")}
                   </span>
                 )}
                 {item.knowledge_unit.context.languages.length > 0 &&
                   item.knowledge_unit.context.frameworks.length > 0 && (
-                    <span className="mx-2">&middot;</span>
+                    <span className="mx-2 text-[var(--ink-faint)]">·</span>
                   )}
                 {item.knowledge_unit.context.frameworks.length > 0 && (
                   <span>
-                    Frameworks:{" "}
+                    <span className="eyebrow mr-1">Frameworks</span>
                     {item.knowledge_unit.context.frameworks.join(", ")}
                   </span>
                 )}
               </div>
             )}
 
-            <div className="flex items-center justify-between text-xs text-gray-400 pt-2 border-t border-gray-100">
-              <span className="font-mono">{item.knowledge_unit.id}</span>
+            <div className="flex items-center justify-between font-mono-brand text-[10px] text-[var(--ink-faint)] pt-3 border-t border-[var(--rule)]">
+              <span className="truncate">{item.knowledge_unit.id}</span>
               {item.knowledge_unit.evidence.first_observed && (
                 <span>
                   {timeAgo(item.knowledge_unit.evidence.first_observed)}

--- a/server/frontend/src/components/Layout.tsx
+++ b/server/frontend/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react"
 import { Link, Outlet, useLocation } from "react-router"
 import { api } from "../api"
 import { useAuth } from "../auth"
+import { Wordmark } from "./Wordmark"
 
 export function Layout() {
   const { username, logout } = useAuth()
@@ -29,41 +30,48 @@ export function Layout() {
     return (
       <Link
         to={path}
-        className={`px-3 py-1 text-sm font-medium whitespace-nowrap ${
+        className={`relative font-mono-brand text-[11px] uppercase tracking-[0.22em] py-1 whitespace-nowrap transition-colors ${
           active
-            ? "border-b-2 border-indigo-500 font-semibold text-gray-900"
-            : "text-gray-500 hover:text-gray-900"
+            ? "text-[var(--ink)]"
+            : "text-[var(--ink-mute)] hover:text-[var(--ink-dim)]"
         }`}
       >
         {label}
         {path === "/review" && pendingCount > 0 && (
-          <span className="ml-1.5 inline-flex items-center justify-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
+          <span className="ml-2 inline-flex items-center justify-center rounded-full px-1.5 py-0.5 text-[10px] font-mono-brand text-[var(--gold)] bg-[color-mix(in_srgb,var(--gold)_14%,transparent)] border border-[color-mix(in_srgb,var(--gold)_28%,transparent)]">
             {pendingCount}
           </span>
+        )}
+        {active && (
+          <span className="absolute -bottom-px left-0 right-0 h-px bg-gradient-to-r from-transparent via-[var(--cyan)] to-transparent" />
         )}
       </Link>
     )
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 overflow-x-hidden">
-      <nav className="bg-white border-b border-gray-200">
-        <div className="max-w-2xl mx-auto px-4 py-3 flex items-center justify-between">
-          <div className="flex items-center gap-3 md:gap-6">
-            <span className="text-lg font-bold text-indigo-600">cq</span>
+    <div className="min-h-screen overflow-x-hidden">
+      <nav className="border-b border-[var(--rule)] bg-[color-mix(in_srgb,var(--bg-via)_85%,transparent)] backdrop-blur sticky top-0 z-20">
+        <div
+          className={`${wide ? "w-full px-6" : "max-w-3xl mx-auto px-4"} py-3 flex items-center justify-between`}
+        >
+          <div className="flex items-center gap-3 md:gap-7">
+            <Link to="/dashboard" className="mr-2">
+              <Wordmark size="md" />
+            </Link>
             {navLink("/review", "Review")}
             {navLink("/dashboard", "Dashboard")}
             {navLink("/network", "Network")}
             {navLink("/settings/api-keys", "API Keys")}
           </div>
-          <div className="flex items-center gap-3">
-            <span className="hidden md:inline text-sm text-gray-500">
+          <div className="flex items-center gap-4">
+            <span className="hidden md:inline font-mono-brand text-[11px] uppercase tracking-[0.18em] text-[var(--ink-mute)]">
               {username}
             </span>
             <button
               type="button"
               onClick={logout}
-              className="text-sm text-gray-400 hover:text-gray-700"
+              className="font-mono-brand text-[11px] uppercase tracking-[0.18em] text-[var(--ink-faint)] hover:text-[var(--rose)] transition-colors"
             >
               Logout
             </button>
@@ -71,7 +79,7 @@ export function Layout() {
         </div>
       </nav>
       <main
-        className={wide ? "w-full px-0 py-0" : "max-w-2xl mx-auto py-8 px-4"}
+        className={wide ? "w-full px-0 py-0" : "max-w-3xl mx-auto py-10 px-4"}
       >
         <Outlet context={{ setPendingCount }} />
       </main>

--- a/server/frontend/src/components/ReviewActions.tsx
+++ b/server/frontend/src/components/ReviewActions.tsx
@@ -7,6 +7,38 @@ interface Props {
   disabled: boolean
 }
 
+// Brand-mapped action button styles. Each row is [base, selected, deemphasized].
+const STYLES = {
+  reject: {
+    selected:
+      "bg-[var(--rose)] text-[#1a0a10] ring-2 ring-[color-mix(in_srgb,var(--rose)_45%,transparent)]",
+    base: "bg-[color-mix(in_srgb,var(--rose)_10%,transparent)] text-[var(--rose)] border border-[color-mix(in_srgb,var(--rose)_28%,transparent)] hover:bg-[color-mix(in_srgb,var(--rose)_18%,transparent)]",
+    dim: "bg-[color-mix(in_srgb,var(--rose)_6%,transparent)] text-[var(--rose)] border border-[color-mix(in_srgb,var(--rose)_18%,transparent)] opacity-40",
+  },
+  skip: {
+    selected:
+      "bg-[var(--ink-dim)] text-[var(--bg-via)] ring-2 ring-[color-mix(in_srgb,var(--ink-dim)_30%,transparent)]",
+    base: "bg-[var(--surface-hover)] text-[var(--ink-dim)] border border-[var(--rule-strong)] hover:bg-[color-mix(in_srgb,var(--ink-dim)_10%,transparent)]",
+    dim: "bg-[var(--surface)] text-[var(--ink-mute)] border border-[var(--rule)] opacity-40",
+  },
+  approve: {
+    selected:
+      "bg-[var(--emerald)] text-[#04140c] ring-2 ring-[color-mix(in_srgb,var(--emerald)_45%,transparent)]",
+    base: "bg-[color-mix(in_srgb,var(--emerald)_10%,transparent)] text-[var(--emerald)] border border-[color-mix(in_srgb,var(--emerald)_28%,transparent)] hover:bg-[color-mix(in_srgb,var(--emerald)_18%,transparent)]",
+    dim: "bg-[color-mix(in_srgb,var(--emerald)_6%,transparent)] text-[var(--emerald)] border border-[color-mix(in_srgb,var(--emerald)_18%,transparent)] opacity-40",
+  },
+} as const
+
+function buttonClass(
+  variant: keyof typeof STYLES,
+  selection: Selection,
+): string {
+  const s = STYLES[variant]
+  if (selection === variant) return s.selected
+  if (selection) return s.dim
+  return s.base
+}
+
 export function ReviewActions({
   selection,
   onSelect,
@@ -14,77 +46,50 @@ export function ReviewActions({
   disabled,
 }: Props) {
   return (
-    <div className="max-w-xl mx-auto mt-4 hidden pointer-fine:flex flex-col items-center gap-3">
+    <div className="max-w-xl mx-auto mt-6 hidden pointer-fine:flex flex-col items-center gap-3">
       <div className="flex gap-3 justify-center">
         <button
           type="button"
           onClick={() => {
-            if (selection === "reject") {
-              onConfirm()
-            } else {
-              onSelect("reject")
-            }
+            if (selection === "reject") onConfirm()
+            else onSelect("reject")
           }}
           disabled={disabled}
-          className={`px-8 py-2.5 rounded-lg font-semibold text-sm transition-all duration-200 disabled:opacity-50 ${
-            selection === "reject"
-              ? "bg-red-600 text-white ring-3 ring-red-200"
-              : selection
-                ? "bg-red-100 text-red-600 opacity-40"
-                : "bg-red-100 text-red-600"
-          }`}
+          className={`px-7 py-2.5 rounded-lg font-mono-brand text-[11px] uppercase tracking-[0.18em] transition-all duration-200 disabled:opacity-50 ${buttonClass("reject", selection)}`}
         >
-          {selection === "reject" ? "Confirm Reject" : "\u2190 Reject"}
+          {selection === "reject" ? "Confirm Reject" : "← Reject"}
         </button>
         <button
           type="button"
           onClick={() => {
-            if (selection === "skip") {
-              onConfirm()
-            } else {
-              onSelect("skip")
-            }
+            if (selection === "skip") onConfirm()
+            else onSelect("skip")
           }}
           disabled={disabled}
-          className={`px-6 py-2.5 rounded-lg font-semibold text-sm transition-all duration-200 disabled:opacity-50 ${
-            selection === "skip"
-              ? "bg-slate-600 text-white ring-3 ring-slate-200"
-              : selection
-                ? "bg-slate-100 text-slate-600 opacity-40"
-                : "bg-slate-100 text-slate-600"
-          }`}
+          className={`px-5 py-2.5 rounded-lg font-mono-brand text-[11px] uppercase tracking-[0.18em] transition-all duration-200 disabled:opacity-50 ${buttonClass("skip", selection)}`}
         >
-          {selection === "skip" ? "Confirm Skip" : "\u2191\u2193 Skip"}
+          {selection === "skip" ? "Confirm Skip" : "↑↓ Skip"}
         </button>
         <button
           type="button"
           onClick={() => {
-            if (selection === "approve") {
-              onConfirm()
-            } else {
-              onSelect("approve")
-            }
+            if (selection === "approve") onConfirm()
+            else onSelect("approve")
           }}
           disabled={disabled}
-          className={`px-8 py-2.5 rounded-lg font-semibold text-sm transition-all duration-200 disabled:opacity-50 ${
-            selection === "approve"
-              ? "bg-green-600 text-white ring-3 ring-green-200"
-              : selection
-                ? "bg-green-100 text-green-600 opacity-40"
-                : "bg-green-100 text-green-600"
-          }`}
+          className={`px-7 py-2.5 rounded-lg font-mono-brand text-[11px] uppercase tracking-[0.18em] transition-all duration-200 disabled:opacity-50 ${buttonClass("approve", selection)}`}
         >
-          {selection === "approve" ? "Confirm Approve" : "Approve \u2192"}
+          {selection === "approve" ? "Confirm Approve" : "Approve →"}
         </button>
       </div>
       <p
-        className={`text-center text-xs ${
-          selection ? "text-gray-500 font-medium" : "text-gray-400"
+        className={`text-center font-mono-brand text-[10px] uppercase tracking-[0.18em] ${
+          selection ? "text-[var(--ink-dim)]" : "text-[var(--ink-faint)]"
         }`}
       >
         {selection
-          ? "Click again or press Space/Enter to confirm \u00b7 Esc to cancel"
-          : "Arrow keys to select \u00b7 Space/Enter to confirm"}
+          ? "Click again or press Space/Enter to confirm · Esc to cancel"
+          : "Arrow keys to select · Space/Enter to confirm"}
       </p>
     </div>
   )

--- a/server/frontend/src/components/ReviewCard.tsx
+++ b/server/frontend/src/components/ReviewCard.tsx
@@ -17,24 +17,29 @@ interface Props {
 }
 
 const CARD_STYLES: Record<string, string> = {
-  neutral: "border-gray-200 bg-white",
-  approve: "border-green-300 bg-green-50",
-  reject: "border-red-300 bg-red-50",
-  skip: "border-slate-400 bg-slate-50",
+  neutral: "border-[var(--rule-strong)] bg-[var(--surface-raised)]",
+  approve:
+    "border-[color-mix(in_srgb,var(--emerald)_60%,transparent)] bg-[color-mix(in_srgb,var(--emerald)_8%,transparent)]",
+  reject:
+    "border-[color-mix(in_srgb,var(--rose)_60%,transparent)] bg-[color-mix(in_srgb,var(--rose)_8%,transparent)]",
+  skip: "border-[var(--rule-strong)] bg-[var(--surface-hover)]",
 }
 
 const ACTION_BOX_STYLES: Record<string, string> = {
-  neutral: "bg-indigo-50 border-indigo-500 text-indigo-500",
-  approve: "bg-green-50 border-green-500 text-green-600",
-  reject: "bg-red-50 border-red-500 text-red-600",
-  skip: "bg-slate-50 border-slate-400 text-slate-500",
+  neutral:
+    "bg-[color-mix(in_srgb,var(--cyan)_8%,transparent)] border-[var(--cyan)] text-[var(--cyan)]",
+  approve:
+    "bg-[color-mix(in_srgb,var(--emerald)_10%,transparent)] border-[var(--emerald)] text-[var(--emerald)]",
+  reject:
+    "bg-[color-mix(in_srgb,var(--rose)_10%,transparent)] border-[var(--rose)] text-[var(--rose)]",
+  skip: "bg-[var(--surface-hover)] border-[var(--rule-strong)] text-[var(--ink-dim)]",
 }
 
 function confidenceColor(c: number): string {
-  if (c < 0.3) return "text-red-600"
-  if (c < 0.5) return "text-amber-600"
-  if (c < 0.7) return "text-yellow-500"
-  return "text-green-600"
+  if (c < 0.3) return "text-[var(--rose)]"
+  if (c < 0.5) return "text-[var(--gold)]"
+  if (c < 0.7) return "text-[var(--gold)]"
+  return "text-[var(--emerald)]"
 }
 
 export const ReviewCard = forwardRef<HTMLDivElement, Props>(function ReviewCard(
@@ -56,51 +61,59 @@ export const ReviewCard = forwardRef<HTMLDivElement, Props>(function ReviewCard(
     : drag.isFlyingOff
       ? `transform ${FLY_OFF_MS}ms ease-in, box-shadow ${FLY_OFF_MS}ms ease-in`
       : `transform ${SNAP_BACK_MS}ms ease-out, box-shadow ${SNAP_BACK_MS}ms ease-out`
-  const shadow = `0 ${4 * shadowScale}px ${20 * shadowScale}px rgba(0,0,0,${0.08 * shadowScale})`
+  // Slightly stronger shadow on dark for the floating-card effect.
+  const shadow = `0 ${4 * shadowScale}px ${28 * shadowScale}px rgba(0,0,0,${0.45 * shadowScale}), 0 0 0 1px rgba(255,255,255,0.02)`
 
   return (
     <div
       ref={ref}
-      className={`relative z-0 border-2 rounded-lg p-6 max-w-xl mx-auto select-none touch-none ${cardStyle}`}
+      className={`relative z-0 border rounded-2xl p-7 max-w-xl mx-auto select-none touch-none backdrop-blur-sm ${cardStyle}`}
       style={{ transform, transition, boxShadow: shadow }}
       {...pointerHandlers}
     >
-      <div className="flex items-center justify-between mb-3">
+      <div className="flex items-center justify-between mb-4">
         <DomainTags domains={unit.domains} variant={activeState} />
         {unit.evidence.first_observed && (
-          <span className="text-xs text-gray-400">
+          <span className="font-mono-brand text-[10px] uppercase tracking-[0.18em] text-[var(--ink-faint)]">
             {timeAgo(unit.evidence.first_observed)}
           </span>
         )}
       </div>
 
-      <h2 className="text-lg font-semibold text-gray-900 mb-2">
+      <h2 className="font-display text-2xl text-[var(--ink)] mb-3 leading-snug">
         {unit.insight.summary}
       </h2>
 
-      <p className="text-gray-600 mb-3 leading-relaxed">
+      <p className="text-[var(--ink-dim)] mb-5 leading-relaxed text-[15px]">
         {unit.insight.detail}
       </p>
 
       <div
-        className={`border-l-3 rounded-r-lg px-4 py-3 mb-6 ${actionBoxStyle}`}
+        className={`border-l-2 rounded-r-lg px-4 py-3 mb-6 ${actionBoxStyle}`}
       >
-        <span className="text-xs font-semibold uppercase tracking-wide">
+        <span
+          className="eyebrow"
+          style={{ color: "currentcolor", opacity: 0.85 }}
+        >
           Action
         </span>
-        <p className="text-gray-800 text-sm mt-1">{unit.insight.action}</p>
+        <p className="text-[var(--ink)] text-sm mt-1.5 leading-relaxed">
+          {unit.insight.action}
+        </p>
       </div>
 
-      <div className="flex gap-4 text-sm text-gray-500">
-        <span>
-          Confidence:{" "}
-          <strong className={confidenceColor(unit.evidence.confidence)}>
+      <div className="flex gap-6 text-sm border-t border-[var(--rule)] pt-4">
+        <span className="text-[var(--ink-mute)]">
+          <span className="eyebrow mr-1">Confidence</span>
+          <strong
+            className={`font-mono-brand ${confidenceColor(unit.evidence.confidence)}`}
+          >
             {unit.evidence.confidence.toFixed(2)}
           </strong>
         </span>
-        <span>
-          Confirmations:{" "}
-          <strong className="text-gray-800">
+        <span className="text-[var(--ink-mute)]">
+          <span className="eyebrow mr-1">Confirmations</span>
+          <strong className="font-mono-brand text-[var(--ink)]">
             {unit.evidence.confirmations}
           </strong>
         </span>

--- a/server/frontend/src/components/StatusBadge.tsx
+++ b/server/frontend/src/components/StatusBadge.tsx
@@ -1,13 +1,21 @@
+/**
+ * Status pill — proposed / approved / rejected. Uses the brand palette tokens
+ * (--gold, --emerald, --rose) so it harmonises in either theme.
+ */
+
 const STYLES: Record<string, string> = {
-  proposed: "bg-amber-100 text-amber-800",
-  approved: "bg-green-100 text-green-800",
-  rejected: "bg-red-100 text-red-800",
+  proposed:
+    "bg-[color-mix(in_srgb,var(--gold)_14%,transparent)] text-[var(--gold)] border border-[color-mix(in_srgb,var(--gold)_28%,transparent)]",
+  approved:
+    "bg-[color-mix(in_srgb,var(--emerald)_14%,transparent)] text-[var(--emerald)] border border-[color-mix(in_srgb,var(--emerald)_30%,transparent)]",
+  rejected:
+    "bg-[color-mix(in_srgb,var(--rose)_14%,transparent)] text-[var(--rose)] border border-[color-mix(in_srgb,var(--rose)_30%,transparent)]",
 }
 
 export function StatusBadge({ status }: { status: string }) {
   return (
     <span
-      className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${STYLES[status] ?? "bg-gray-100 text-gray-800"}`}
+      className={`inline-block rounded-full px-2 py-0.5 font-mono-brand text-[10px] uppercase tracking-[0.16em] ${STYLES[status] ?? "bg-[var(--surface-hover)] text-[var(--ink-dim)] border border-[var(--rule)]"}`}
     >
       {status}
     </span>

--- a/server/frontend/src/components/Wordmark.tsx
+++ b/server/frontend/src/components/Wordmark.tsx
@@ -1,0 +1,48 @@
+/**
+ * Placeholder 8th-Layer.ai wordmark.
+ *
+ * The final logo is still in concepting (see crosstalk-enterprise/docs/brand/
+ * logo-concepts-2026-05-08.md). Until then we ship a typographic mark in
+ * Fraunces — the "8" sits in the display face, "L" in mono — as a visually
+ * distinctive, license-free placeholder. Fully replaceable when an SVG lands.
+ */
+
+interface Props {
+  size?: "sm" | "md" | "lg"
+  variant?: "full" | "compact"
+}
+
+const SIZES = {
+  sm: { mark: "text-base", word: "text-xs" },
+  md: { mark: "text-2xl", word: "text-sm" },
+  lg: { mark: "text-5xl", word: "text-base" },
+} as const
+
+export function Wordmark({ size = "md", variant = "full" }: Props) {
+  const s = SIZES[size]
+  return (
+    <span
+      role="img"
+      aria-label="8th-Layer.ai"
+      className="inline-flex items-center gap-2 select-none"
+    >
+      <span
+        aria-hidden="true"
+        className={`font-display ${s.mark} text-[var(--ink)] leading-none`}
+        style={{
+          fontVariantNumeric: "tabular-nums",
+          fontWeight: 200,
+          letterSpacing: "-0.04em",
+        }}
+      >
+        8
+      </span>
+      <span
+        aria-hidden="true"
+        className={`font-mono-brand ${s.word} text-[var(--ink-dim)] uppercase tracking-[0.22em]`}
+      >
+        {variant === "compact" ? "L8" : "8TH·LAYER"}
+      </span>
+    </span>
+  )
+}

--- a/server/frontend/src/index.css
+++ b/server/frontend/src/index.css
@@ -1,2 +1,217 @@
+/*
+ * 8th-Layer.ai theme — Layer 8 admin UI tokens.
+ *
+ * Upstream cq theme is light-mode; the 8th-Layer fork is dark with a vertical
+ * radial gradient backdrop. Switch via the `data-theme` attribute on <html>:
+ *   data-theme="8th-layer"     (default; set in main.tsx from VITE_THEME)
+ *   data-theme="mainline-cq"   (fallback / A-B; preserves upstream visuals)
+ *
+ * License-wise this is a derivative of the mainline cq frontend (Apache-2.0).
+ * See ../../../NOTICE and FORK_DELTA.md.
+ */
+
 @import "tailwindcss";
 @custom-variant pointer-fine (@media (pointer: fine));
+
+/* ── 8th-Layer brand tokens ─────────────────────────────────────────────── */
+:root[data-theme="8th-layer"] {
+  --bg-from: #0a0612;
+  --bg-via: #07070b;
+  --bg-to: #040810;
+
+  --ink: #e6e6e6;
+  --ink-dim: rgba(230, 230, 230, 0.65);
+  --ink-mute: rgba(230, 230, 230, 0.42);
+  --ink-faint: rgba(230, 230, 230, 0.28);
+
+  --rule: rgba(255, 255, 255, 0.06);
+  --rule-strong: rgba(255, 255, 255, 0.14);
+
+  --cyan: #5bd0ff;
+  --violet: #a685ff;
+  --emerald: #10b981;
+  --gold: #fcd34d;
+  --rose: #ff5c7c;
+
+  --surface: rgba(255, 255, 255, 0.025);
+  --surface-raised: rgba(255, 255, 255, 0.04);
+  --surface-hover: rgba(255, 255, 255, 0.06);
+
+  --font-display: "Fraunces", ui-serif, Georgia, serif;
+  --font-body: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, "JetBrains Mono", monospace;
+
+  --backdrop: radial-gradient(
+    120% 80% at 50% 0%,
+    #1a0e2c 0%,
+    var(--bg-from) 38%,
+    var(--bg-via) 64%,
+    var(--bg-to) 100%
+  );
+}
+
+/* ── mainline-cq fallback (light, neutral) ──────────────────────────────── */
+:root[data-theme="mainline-cq"] {
+  --bg-from: #f9fafb;
+  --bg-via: #ffffff;
+  --bg-to: #ffffff;
+
+  --ink: #111827;
+  --ink-dim: #4b5563;
+  --ink-mute: #6b7280;
+  --ink-faint: #9ca3af;
+
+  --rule: #e5e7eb;
+  --rule-strong: #d1d5db;
+
+  --cyan: #4f46e5;
+  --violet: #7c3aed;
+  --emerald: #16a34a;
+  --gold: #f59e0b;
+  --rose: #dc2626;
+
+  --surface: #ffffff;
+  --surface-raised: #ffffff;
+  --surface-hover: #f3f4f6;
+
+  --font-display: ui-sans-serif, system-ui, sans-serif;
+  --font-body: ui-sans-serif, system-ui, sans-serif;
+  --font-mono: ui-monospace, "JetBrains Mono", monospace;
+
+  --backdrop: #f9fafb;
+}
+
+/* Default when no data-theme set (SSR / pre-hydration). Mirror 8th-layer. */
+:root:not([data-theme]) {
+  --bg-from: #0a0612;
+  --bg-via: #07070b;
+  --bg-to: #040810;
+  --ink: #e6e6e6;
+  --ink-dim: rgba(230, 230, 230, 0.65);
+  --ink-mute: rgba(230, 230, 230, 0.42);
+  --ink-faint: rgba(230, 230, 230, 0.28);
+  --rule: rgba(255, 255, 255, 0.06);
+  --rule-strong: rgba(255, 255, 255, 0.14);
+  --cyan: #5bd0ff;
+  --violet: #a685ff;
+  --emerald: #10b981;
+  --gold: #fcd34d;
+  --rose: #ff5c7c;
+  --surface: rgba(255, 255, 255, 0.025);
+  --surface-raised: rgba(255, 255, 255, 0.04);
+  --surface-hover: rgba(255, 255, 255, 0.06);
+  --font-display: "Fraunces", ui-serif, Georgia, serif;
+  --font-body: "Inter", system-ui, sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, monospace;
+  --backdrop: radial-gradient(
+    120% 80% at 50% 0%,
+    #1a0e2c 0%,
+    var(--bg-from) 38%,
+    var(--bg-via) 64%,
+    var(--bg-to) 100%
+  );
+}
+
+/* ── Body / global type ─────────────────────────────────────────────────── */
+html,
+body {
+  background: var(--backdrop);
+  background-attachment: fixed;
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-weight: 400;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+:root[data-theme="mainline-cq"],
+:root[data-theme="mainline-cq"] body {
+  background: var(--bg-via);
+}
+
+/* Typography helpers — exposed as tailwind utilities via @utility. */
+@utility font-display {
+  font-family: var(--font-display);
+  font-weight: 300;
+  letter-spacing: -0.01em;
+}
+
+@utility font-body-brand {
+  font-family: var(--font-body);
+}
+
+@utility font-mono-brand {
+  font-family: var(--font-mono);
+}
+
+/* Eyebrow — IBM Plex Mono uppercase, used for "Confidence", "Action", section labels. */
+@utility eyebrow {
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+
+/* ── Brand surface utilities ────────────────────────────────────────────── */
+
+@utility brand-surface {
+  background-color: var(--surface);
+  border: 1px solid var(--rule);
+  border-radius: 0.75rem;
+}
+
+@utility brand-surface-raised {
+  background-color: var(--surface-raised);
+  border: 1px solid var(--rule);
+  border-radius: 0.75rem;
+}
+
+@utility brand-input {
+  background-color: var(--surface);
+  border: 1px solid var(--rule-strong);
+  border-radius: 0.5rem;
+  color: var(--ink);
+  font-family: var(--font-body);
+  padding: 0.5rem 0.75rem;
+  outline: none;
+  transition:
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+  &:focus {
+    border-color: var(--cyan);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--cyan) 25%, transparent);
+  }
+}
+
+/* Subtle scrollbars to fit the dark aesthetic. */
+:root[data-theme="8th-layer"] ::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+:root[data-theme="8th-layer"] ::-webkit-scrollbar-track {
+  background: transparent;
+}
+:root[data-theme="8th-layer"] ::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 4px;
+}
+:root[data-theme="8th-layer"] ::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.16);
+}
+
+/* Selection. */
+:root[data-theme="8th-layer"] ::selection {
+  background: color-mix(in srgb, var(--cyan) 35%, transparent);
+  color: var(--ink);
+}
+
+/* Native autofill harmonisation in dark. */
+:root[data-theme="8th-layer"] input:-webkit-autofill,
+:root[data-theme="8th-layer"] input:-webkit-autofill:hover,
+:root[data-theme="8th-layer"] input:-webkit-autofill:focus {
+  -webkit-text-fill-color: var(--ink);
+  -webkit-box-shadow: 0 0 0 1000px var(--bg-via) inset;
+  caret-color: var(--ink);
+}

--- a/server/frontend/src/main.tsx
+++ b/server/frontend/src/main.tsx
@@ -3,6 +3,13 @@ import { createRoot } from "react-dom/client"
 import "./index.css"
 import App from "./App"
 
+// Theme selection — driven by VITE_THEME at build time. Defaults to the
+// 8th-Layer brand theme; set VITE_THEME=mainline-cq to fall back to the
+// upstream cq look (useful for A/B during migration).
+const theme = (import.meta.env.VITE_THEME as string | undefined) ?? "8th-layer"
+const validTheme = theme === "mainline-cq" ? "mainline-cq" : "8th-layer"
+document.documentElement.setAttribute("data-theme", validTheme)
+
 const rootElement = document.getElementById("root")
 if (!rootElement) {
   throw new Error("Root element #root not found in document")

--- a/server/frontend/src/pages/ApiKeysPage.tsx
+++ b/server/frontend/src/pages/ApiKeysPage.tsx
@@ -24,17 +24,22 @@ function statusLabel(key: ApiKeyPublic): string {
 }
 
 function statusBadgeClasses(key: ApiKeyPublic): string {
-  if (key.revoked_at) return "bg-red-100 text-red-700"
-  if (key.is_expired) return "bg-gray-200 text-gray-600"
-  return "bg-green-100 text-green-700"
+  if (key.revoked_at)
+    return "bg-[color-mix(in_srgb,var(--rose)_14%,transparent)] text-[var(--rose)] border border-[color-mix(in_srgb,var(--rose)_30%,transparent)]"
+  if (key.is_expired)
+    return "bg-[var(--surface-hover)] text-[var(--ink-mute)] border border-[var(--rule-strong)]"
+  return "bg-[color-mix(in_srgb,var(--emerald)_14%,transparent)] text-[var(--emerald)] border border-[color-mix(in_srgb,var(--emerald)_30%,transparent)]"
 }
 
 function expiryUrgencyClasses(key: ApiKeyPublic): string {
-  if (key.revoked_at || key.is_expired) return "bg-gray-100 text-gray-500"
+  if (key.revoked_at || key.is_expired)
+    return "bg-[var(--surface-hover)] text-[var(--ink-mute)]"
   const remaining = secondsUntil(key.expires_at)
-  if (remaining <= DAY_SECONDS) return "bg-red-100 text-red-700"
-  if (remaining <= WEEK_SECONDS) return "bg-amber-100 text-amber-700"
-  return "bg-green-100 text-green-700"
+  if (remaining <= DAY_SECONDS)
+    return "bg-[color-mix(in_srgb,var(--rose)_14%,transparent)] text-[var(--rose)]"
+  if (remaining <= WEEK_SECONDS)
+    return "bg-[color-mix(in_srgb,var(--gold)_14%,transparent)] text-[var(--gold)]"
+  return "bg-[color-mix(in_srgb,var(--emerald)_14%,transparent)] text-[var(--emerald)]"
 }
 
 function expiryLabel(key: ApiKeyPublic): string {
@@ -187,25 +192,40 @@ export function ApiKeysPage() {
     setCopied(true)
   }
 
+  // Brand button styles. A primary cyan-tinted CTA, a destructive rose CTA,
+  // and a subtle ghost button that maps to the dark surface tokens.
+  const primaryBtn =
+    "rounded-md bg-[color-mix(in_srgb,var(--cyan)_18%,transparent)] border border-[color-mix(in_srgb,var(--cyan)_45%,transparent)] px-4 py-2 font-mono-brand text-[11px] uppercase tracking-[0.2em] text-[var(--cyan)] hover:bg-[color-mix(in_srgb,var(--cyan)_28%,transparent)] disabled:opacity-50 transition-all"
+  const destructiveBtn =
+    "rounded-md bg-[color-mix(in_srgb,var(--rose)_18%,transparent)] border border-[color-mix(in_srgb,var(--rose)_45%,transparent)] px-4 py-2 font-mono-brand text-[11px] uppercase tracking-[0.2em] text-[var(--rose)] hover:bg-[color-mix(in_srgb,var(--rose)_28%,transparent)] disabled:opacity-50 transition-all"
+  const ghostBtn =
+    "rounded-md border border-[var(--rule-strong)] bg-[var(--surface)] px-4 py-2 font-mono-brand text-[11px] uppercase tracking-[0.2em] text-[var(--ink-dim)] hover:bg-[var(--surface-hover)] disabled:opacity-50 transition-all"
+
   return (
     <div className="space-y-8">
       <section>
-        <h1 className="text-2xl font-semibold text-gray-900">API Keys</h1>
-        <p className="mt-2 text-sm text-gray-600">
+        <p className="eyebrow">Settings</p>
+        <h1 className="font-display text-3xl text-[var(--ink)] mt-1">
+          API Keys
+        </h1>
+        <p className="mt-3 text-sm text-[var(--ink-dim)] leading-relaxed max-w-prose">
           API keys let agents act on your behalf. Give each key a name and an
           expiry; attach optional labels to group or filter keys later. The full
           key is shown only once at creation.
         </p>
       </section>
 
-      <section className="rounded-lg border border-gray-200 bg-white p-6">
-        <h2 className="text-lg font-medium text-gray-900">Create a new key</h2>
+      <section className="brand-surface-raised p-6">
+        <p className="eyebrow">Mint key</p>
+        <h2 className="font-display text-xl text-[var(--ink)] mt-1">
+          Create a new key
+        </h2>
         <form
           onSubmit={handleCreate}
-          className="mt-4 grid gap-4 md:grid-cols-2"
+          className="mt-5 grid gap-4 md:grid-cols-2"
         >
           <label className="flex flex-col text-sm">
-            <span className="text-gray-700">Name</span>
+            <span className="eyebrow mb-1.5">Name</span>
             <input
               type="text"
               required
@@ -213,11 +233,11 @@ export function ApiKeysPage() {
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="e.g. laptop-mcp"
-              className="mt-1 rounded-md border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:outline-none"
+              className="brand-input"
             />
           </label>
           <label className="flex flex-col text-sm">
-            <span className="text-gray-700">TTL</span>
+            <span className="eyebrow mb-1.5">TTL</span>
             <input
               type="text"
               required
@@ -226,58 +246,64 @@ export function ApiKeysPage() {
               onChange={(e) => setTtl(e.target.value)}
               maxLength={16}
               aria-invalid={ttl.length > 0 && !ttlIsValid}
-              className="mt-1 rounded-md border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:outline-none"
+              className="brand-input font-mono-brand"
             />
             <datalist id="ttl-suggestions">
               {TTL_SUGGESTIONS.map((s) => (
                 <option key={s} value={s} />
               ))}
             </datalist>
-            <span className="mt-1 text-xs text-gray-500">
-              e.g. <code>30s</code>, <code>15m</code>, <code>2h</code>,{" "}
-              <code>90d</code> (max 365d).
+            <span className="mt-1.5 text-xs text-[var(--ink-mute)]">
+              e.g.{" "}
+              <code className="font-mono-brand text-[var(--ink-dim)]">30s</code>
+              ,{" "}
+              <code className="font-mono-brand text-[var(--ink-dim)]">15m</code>
+              ,{" "}
+              <code className="font-mono-brand text-[var(--ink-dim)]">2h</code>,{" "}
+              <code className="font-mono-brand text-[var(--ink-dim)]">90d</code>{" "}
+              (max 365d).
             </span>
           </label>
           <label className="flex flex-col text-sm md:col-span-2">
-            <span className="text-gray-700">Labels (optional)</span>
+            <span className="eyebrow mb-1.5">Labels (optional)</span>
             <input
               type="text"
               value={labelsInput}
               onChange={(e) => setLabelsInput(e.target.value)}
               placeholder="comma-separated, e.g. mcp, claude, personal"
-              className="mt-1 rounded-md border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:outline-none"
+              className="brand-input"
             />
           </label>
           <div className="md:col-span-2">
             <button
               type="submit"
               disabled={creating || name.trim() === "" || !ttlIsValid || atCap}
-              className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700 disabled:opacity-50"
+              className={primaryBtn}
             >
               {creating ? "Creating…" : "Create key"}
             </button>
             {atCap && (
-              <p className="mt-2 text-xs text-amber-700 md:col-span-2">
+              <p className="mt-2 text-xs text-[var(--gold)] font-mono-brand uppercase tracking-[0.16em]">
                 You have the maximum of {MAX_ACTIVE_KEYS} active keys. Revoke
                 one to create another.
               </p>
             )}
           </div>
         </form>
-        {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+        {error && <p className="mt-3 text-sm text-[var(--rose)]">{error}</p>}
       </section>
 
       <section>
         <div className="flex flex-wrap items-center gap-3">
-          <h2 className="shrink-0 text-lg font-medium text-gray-900">
+          <h2 className="shrink-0 font-display text-xl text-[var(--ink)]">
             Your keys
-            <span className="ml-2 text-sm font-normal text-gray-500">
+            <span className="ml-3 font-mono-brand text-[11px] uppercase tracking-[0.18em] text-[var(--ink-mute)]">
               {activeCount} of {MAX_ACTIVE_KEYS} active
             </span>
           </h2>
           <fieldset
             aria-label="Filter keys"
-            className="inline-flex shrink-0 overflow-hidden rounded-lg border border-gray-200 bg-white text-sm"
+            className="inline-flex shrink-0 overflow-hidden rounded-lg border border-[var(--rule-strong)] bg-[var(--surface)] text-sm"
           >
             {(
               [
@@ -291,10 +317,10 @@ export function ApiKeysPage() {
                 type="button"
                 onClick={() => setFilter(value)}
                 aria-pressed={filter === value}
-                className={`px-3 py-1.5 ${
+                className={`px-3 py-1.5 font-mono-brand text-[11px] uppercase tracking-[0.16em] transition-colors ${
                   filter === value
-                    ? "bg-indigo-600 text-white"
-                    : "text-gray-700 hover:bg-gray-50"
+                    ? "bg-[color-mix(in_srgb,var(--cyan)_22%,transparent)] text-[var(--cyan)]"
+                    : "text-[var(--ink-dim)] hover:bg-[var(--surface-hover)]"
                 }`}
               >
                 {label}
@@ -307,15 +333,26 @@ export function ApiKeysPage() {
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search name or label…"
             aria-label="Search keys"
-            className="min-w-40 flex-1 rounded-lg border border-gray-200 bg-white px-3 py-1.5 text-sm focus:border-indigo-500 focus:outline-none"
+            className="brand-input min-w-40 flex-1 text-sm"
           />
         </div>
         {loading ? (
-          <p className="mt-4 text-sm text-gray-500">Loading…</p>
+          <p className="mt-4 text-sm text-[var(--ink-mute)]">Loading…</p>
         ) : keys.length === 0 ? (
-          <p className="mt-4 text-sm text-gray-500">No API keys yet.</p>
+          <div className="mt-6 brand-surface flex flex-col items-center justify-center py-12 gap-3">
+            <span
+              aria-hidden="true"
+              className="font-display text-3xl text-[var(--ink-faint)]"
+            >
+              ∅
+            </span>
+            <span className="eyebrow text-[var(--cyan)]">No API keys yet</span>
+            <span className="text-sm text-[var(--ink-mute)]">
+              Mint one above to give an agent access.
+            </span>
+          </div>
         ) : filteredKeys.length === 0 ? (
-          <p className="mt-4 text-sm text-gray-500">
+          <p className="mt-4 text-sm text-[var(--ink-mute)]">
             No keys match the current filter.
           </p>
         ) : (
@@ -325,28 +362,28 @@ export function ApiKeysPage() {
               return (
                 <li
                   key={key.id}
-                  className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm"
+                  className="overflow-hidden rounded-xl border border-[var(--rule)] bg-[var(--surface-raised)]"
                 >
                   <button
                     type="button"
                     onClick={() => toggleExpanded(key.id)}
                     aria-expanded={isOpen}
                     aria-controls={`apikey-details-${key.id}`}
-                    className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left hover:bg-gray-50"
+                    className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left hover:bg-[var(--surface-hover)] transition-colors"
                   >
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
-                        <h3 className="truncate text-base font-semibold text-gray-900">
+                        <h3 className="truncate font-display text-base text-[var(--ink)]">
                           {key.name}
                         </h3>
-                        <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-600">
+                        <code className="rounded bg-[var(--surface-hover)] border border-[var(--rule)] px-1.5 py-0.5 font-mono-brand text-[11px] text-[var(--ink-mute)]">
                           {key.prefix}…
                         </code>
                       </div>
                       <div className="mt-1.5">
                         <span className="group relative inline-block">
                           <span
-                            className={`inline-flex cursor-help items-center rounded-full px-2 py-0.5 text-xs font-medium ${expiryUrgencyClasses(
+                            className={`inline-flex cursor-help items-center rounded-full px-2 py-0.5 font-mono-brand text-[10px] uppercase tracking-[0.16em] ${expiryUrgencyClasses(
                               key,
                             )}`}
                           >
@@ -354,7 +391,7 @@ export function ApiKeysPage() {
                           </span>
                           <span
                             role="tooltip"
-                            className="pointer-events-none invisible absolute bottom-full left-1/2 z-20 mb-1 -translate-x-1/2 whitespace-nowrap rounded bg-gray-900 px-2 py-1 text-xs text-white opacity-0 transition-opacity group-hover:visible group-hover:opacity-100"
+                            className="pointer-events-none invisible absolute bottom-full left-1/2 z-20 mb-1 -translate-x-1/2 whitespace-nowrap rounded bg-[var(--bg-via)] border border-[var(--rule-strong)] px-2 py-1 text-xs text-[var(--ink)] opacity-0 transition-opacity group-hover:visible group-hover:opacity-100"
                           >
                             {expiryTooltip(key)}
                           </span>
@@ -363,7 +400,7 @@ export function ApiKeysPage() {
                     </div>
                     <div className="flex items-center gap-3">
                       <span
-                        className={`rounded-full px-2 py-0.5 text-xs font-medium ${statusBadgeClasses(
+                        className={`rounded-full px-2 py-0.5 font-mono-brand text-[10px] uppercase tracking-[0.16em] ${statusBadgeClasses(
                           key,
                         )}`}
                       >
@@ -371,7 +408,7 @@ export function ApiKeysPage() {
                       </span>
                       <svg
                         aria-hidden="true"
-                        className={`h-4 w-4 text-gray-400 transition-transform ${isOpen ? "rotate-180" : ""}`}
+                        className={`h-4 w-4 text-[var(--ink-mute)] transition-transform ${isOpen ? "rotate-180" : ""}`}
                         viewBox="0 0 20 20"
                         fill="currentColor"
                       >
@@ -387,18 +424,16 @@ export function ApiKeysPage() {
                   {isOpen && (
                     <div
                       id={`apikey-details-${key.id}`}
-                      className="border-t border-gray-200 bg-gray-50/60 px-5 py-4"
+                      className="border-t border-[var(--rule)] bg-[color-mix(in_srgb,var(--bg-from)_40%,transparent)] px-5 py-4"
                     >
                       {key.labels.length > 0 && (
                         <div className="mb-4">
-                          <div className="text-xs uppercase tracking-wide text-gray-400">
-                            Labels
-                          </div>
-                          <div className="mt-1 flex flex-wrap gap-1">
+                          <div className="eyebrow">Labels</div>
+                          <div className="mt-1.5 flex flex-wrap gap-1">
                             {key.labels.map((label) => (
                               <span
                                 key={label}
-                                className="rounded-full bg-indigo-50 px-2 py-0.5 text-xs text-indigo-700"
+                                className="rounded-full bg-[color-mix(in_srgb,var(--violet)_12%,transparent)] border border-[color-mix(in_srgb,var(--violet)_22%,transparent)] px-2 py-0.5 font-mono-brand text-[10px] uppercase tracking-[0.14em] text-[var(--violet)]"
                               >
                                 {label}
                               </span>
@@ -408,26 +443,20 @@ export function ApiKeysPage() {
                       )}
                       <dl className="grid grid-cols-2 gap-x-6 gap-y-3 text-sm sm:grid-cols-3">
                         <div>
-                          <dt className="text-xs uppercase tracking-wide text-gray-400">
-                            TTL
-                          </dt>
-                          <dd className="mt-0.5 font-mono text-gray-800">
+                          <dt className="eyebrow">TTL</dt>
+                          <dd className="mt-0.5 font-mono-brand text-[var(--ink)]">
                             {key.ttl}
                           </dd>
                         </div>
                         <div>
-                          <dt className="text-xs uppercase tracking-wide text-gray-400">
-                            Created
-                          </dt>
-                          <dd className="mt-0.5 text-gray-700">
+                          <dt className="eyebrow">Created</dt>
+                          <dd className="mt-0.5 text-[var(--ink-dim)]">
                             {timeAgo(key.created_at)}
                           </dd>
                         </div>
                         <div>
-                          <dt className="text-xs uppercase tracking-wide text-gray-400">
-                            Last used
-                          </dt>
-                          <dd className="mt-0.5 text-gray-700">
+                          <dt className="eyebrow">Last used</dt>
+                          <dd className="mt-0.5 text-[var(--ink-dim)]">
                             {key.last_used_at
                               ? timeAgo(key.last_used_at)
                               : "never"}
@@ -441,11 +470,11 @@ export function ApiKeysPage() {
                             onClick={() =>
                               setRevokePrompt({ id: key.id, name: key.name })
                             }
-                            className="inline-flex items-center gap-1.5 rounded-lg border border-red-200 bg-white px-3 py-1.5 text-sm font-medium text-red-700 hover:bg-red-50"
+                            className="inline-flex items-center gap-1.5 rounded-lg border border-[color-mix(in_srgb,var(--rose)_28%,transparent)] bg-[color-mix(in_srgb,var(--rose)_8%,transparent)] px-3 py-1.5 font-mono-brand text-[10px] uppercase tracking-[0.18em] text-[var(--rose)] hover:bg-[color-mix(in_srgb,var(--rose)_18%,transparent)] transition-colors"
                           >
                             <svg
                               aria-hidden="true"
-                              className="h-4 w-4"
+                              className="h-3.5 w-3.5"
                               viewBox="0 0 20 20"
                               fill="currentColor"
                             >
@@ -473,35 +502,33 @@ export function ApiKeysPage() {
           role="dialog"
           aria-modal="true"
           aria-labelledby="created-key-heading"
-          className="fixed inset-0 z-10 flex items-center justify-center bg-black/40 p-4"
+          className="fixed inset-0 z-30 flex items-center justify-center bg-black/65 backdrop-blur-sm p-4"
         >
-          <div className="w-full max-w-lg rounded-lg bg-white p-6 shadow-xl">
+          <div className="w-full max-w-lg brand-surface-raised p-6 shadow-[0_30px_80px_-20px_rgba(0,0,0,0.7)]">
+            <p className="eyebrow">New key minted</p>
             <h3
               id="created-key-heading"
-              className="text-lg font-semibold text-gray-900"
+              className="font-display text-xl text-[var(--ink)] mt-1"
             >
               Your new API key
             </h3>
-            <p className="mt-2 text-sm text-gray-600">
+            <p className="mt-2 text-sm text-[var(--ink-dim)]">
               Copy this token now. It will not be shown again.
             </p>
-            <div className="mt-4 flex items-center gap-2 rounded-md bg-gray-100 p-3">
-              <code className="flex-1 break-all text-sm">
+            <div className="mt-4 flex items-center gap-2 rounded-lg bg-[var(--bg-via)] border border-[var(--rule-strong)] p-3">
+              <code className="flex-1 break-all font-mono-brand text-sm text-[var(--cyan)]">
                 {createdKey.token}
               </code>
-              <button
-                type="button"
-                onClick={copyToken}
-                className="rounded-lg bg-indigo-600 px-3 py-1.5 text-sm font-semibold text-white hover:bg-indigo-700"
-              >
+              <button type="button" onClick={copyToken} className={primaryBtn}>
                 {copied ? "Copied" : "Copy"}
               </button>
             </div>
-            <label className="mt-4 flex items-center gap-2 text-sm text-gray-700">
+            <label className="mt-4 flex items-center gap-2 text-sm text-[var(--ink-dim)]">
               <input
                 type="checkbox"
                 checked={acknowledged}
                 onChange={(e) => setAcknowledged(e.target.checked)}
+                className="accent-[var(--cyan)]"
               />
               I have copied this token and saved it securely.
             </label>
@@ -510,7 +537,7 @@ export function ApiKeysPage() {
                 type="button"
                 onClick={() => setCreatedKey(null)}
                 disabled={!acknowledged}
-                className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700 disabled:opacity-50"
+                className={primaryBtn}
               >
                 Done
               </button>
@@ -524,16 +551,17 @@ export function ApiKeysPage() {
           role="dialog"
           aria-modal="true"
           aria-labelledby="revoke-key-heading"
-          className="fixed inset-0 z-10 flex items-center justify-center bg-black/40 p-4"
+          className="fixed inset-0 z-30 flex items-center justify-center bg-black/65 backdrop-blur-sm p-4"
         >
-          <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+          <div className="w-full max-w-md brand-surface-raised p-6 shadow-[0_30px_80px_-20px_rgba(0,0,0,0.7)]">
+            <p className="eyebrow text-[var(--rose)]">Destructive</p>
             <h3
               id="revoke-key-heading"
-              className="text-lg font-semibold text-gray-900"
+              className="font-display text-xl text-[var(--ink)] mt-1"
             >
               Revoke &ldquo;{revokePrompt.name}&rdquo;?
             </h3>
-            <p className="mt-2 text-sm text-gray-600">
+            <p className="mt-2 text-sm text-[var(--ink-dim)]">
               Clients using this key will start receiving 401 responses
               immediately. This cannot be undone.
             </p>
@@ -542,7 +570,7 @@ export function ApiKeysPage() {
                 type="button"
                 onClick={() => setRevokePrompt(null)}
                 disabled={revoking}
-                className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+                className={ghostBtn}
               >
                 Cancel
               </button>
@@ -550,7 +578,7 @@ export function ApiKeysPage() {
                 type="button"
                 onClick={confirmRevoke}
                 disabled={revoking}
-                className="rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-700 disabled:opacity-50"
+                className={destructiveBtn}
               >
                 {revoking ? "Revoking…" : "Revoke"}
               </button>

--- a/server/frontend/src/pages/DashboardPage.tsx
+++ b/server/frontend/src/pages/DashboardPage.tsx
@@ -20,10 +20,33 @@ import type { ReviewStatsResponse } from "../types"
 import { timeAgo } from "../utils"
 
 const CONFIDENCE_COLORS: Record<string, string> = {
-  "0.0-0.3": "bg-red-200",
-  "0.3-0.6": "bg-amber-200",
-  "0.6-0.8": "bg-green-200",
-  "0.8-1.0": "bg-green-400",
+  "0.0-0.3": "bg-[color-mix(in_srgb,var(--rose)_55%,transparent)]",
+  "0.3-0.6": "bg-[color-mix(in_srgb,var(--gold)_55%,transparent)]",
+  "0.6-0.8": "bg-[color-mix(in_srgb,var(--emerald)_45%,transparent)]",
+  "0.8-1.0": "bg-[var(--emerald)]",
+}
+
+// Brand-tuned recharts palette: cyan / emerald / rose to mirror the apex SPA.
+const CHART_COLORS = {
+  proposed: "#5bd0ff", // var(--cyan)
+  approved: "#10b981", // var(--emerald)
+  rejected: "#ff5c7c", // var(--rose)
+  axis: "rgba(230,230,230,0.42)",
+  grid: "rgba(255,255,255,0.06)",
+}
+
+function EmptyGlyph({ label }: { label: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-10 gap-3">
+      <span
+        aria-hidden="true"
+        className="font-display text-3xl text-[var(--ink-faint)]"
+      >
+        ∅
+      </span>
+      <span className="eyebrow text-[var(--cyan)]">{label}</span>
+    </div>
+  )
 }
 
 export function DashboardPage() {
@@ -60,20 +83,14 @@ export function DashboardPage() {
       <div className="space-y-6">
         <div className="grid grid-cols-3 gap-4">
           {[1, 2, 3].map((i) => (
-            <div
-              key={i}
-              className="bg-white rounded-lg border border-gray-200 p-4"
-            >
-              <div className="h-4 w-16 animate-pulse bg-gray-200 rounded mb-2" />
-              <div className="h-8 w-12 animate-pulse bg-gray-200 rounded" />
+            <div key={i} className="brand-surface p-4">
+              <div className="h-3 w-16 animate-pulse bg-[var(--rule-strong)] rounded mb-2" />
+              <div className="h-8 w-12 animate-pulse bg-[var(--rule-strong)] rounded" />
             </div>
           ))}
         </div>
         {[1, 2].map((i) => (
-          <div
-            key={i}
-            className="bg-white rounded-lg border border-gray-200 p-4 h-40 animate-pulse bg-gray-100"
-          />
+          <div key={i} className="brand-surface h-40 animate-pulse" />
         ))}
       </div>
     )
@@ -82,93 +99,107 @@ export function DashboardPage() {
   return (
     <div className="space-y-6">
       {error && (
-        <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-center">
-          <p className="text-red-600 text-sm font-medium">{error}</p>
+        <div className="rounded-xl border border-[color-mix(in_srgb,var(--rose)_40%,transparent)] bg-[color-mix(in_srgb,var(--rose)_10%,transparent)] p-4 text-center">
+          <p className="text-[var(--rose)] font-mono-brand text-[11px] uppercase tracking-[0.18em]">
+            {error}
+          </p>
         </div>
       )}
 
       {stats && (
         <>
+          {/* Count tiles. */}
           <div className="grid grid-cols-3 gap-4">
             <Link
               to="/review"
-              className="bg-white rounded-lg border border-gray-200 p-4 text-center hover:border-amber-300 transition-colors"
+              className="brand-surface-raised p-5 text-center hover:border-[var(--gold)] transition-colors group"
             >
-              <p className="text-3xl font-bold text-amber-500">
+              <p className="font-display font-light text-4xl text-[var(--gold)] tabular-nums">
                 {stats.counts.pending}
               </p>
-              <p className="text-xs text-gray-500 uppercase mt-1">Pending</p>
+              <p className="eyebrow mt-2 group-hover:text-[var(--gold)] transition-colors">
+                Pending
+              </p>
             </Link>
-            <div className="bg-white rounded-lg border border-gray-200 p-4 text-center">
-              <p className="text-3xl font-bold text-green-600">
+            <div className="brand-surface-raised p-5 text-center">
+              <p className="font-display font-light text-4xl text-[var(--emerald)] tabular-nums">
                 {stats.counts.approved}
               </p>
-              <p className="text-xs text-gray-500 uppercase mt-1">Approved</p>
+              <p className="eyebrow mt-2">Approved</p>
             </div>
             <button
               type="button"
-              className="bg-white rounded-lg border border-gray-200 p-4 text-center hover:border-red-300 transition-colors w-full"
+              className="brand-surface-raised p-5 text-center hover:border-[var(--rose)] transition-colors group w-full"
               onClick={() =>
                 setListFilter({ title: "Rejected", status: "rejected" })
               }
             >
-              <p className="text-3xl font-bold text-red-600">
+              <p className="font-display font-light text-4xl text-[var(--rose)] tabular-nums">
                 {stats.counts.rejected}
               </p>
-              <p className="text-xs text-gray-500 uppercase mt-1">Rejected</p>
+              <p className="eyebrow mt-2 group-hover:text-[var(--rose)] transition-colors">
+                Rejected
+              </p>
             </button>
           </div>
 
+          {/* Domains + confidence. */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="bg-white rounded-lg border border-gray-200 p-4">
-              <h3 className="text-xs font-semibold text-gray-500 uppercase mb-3">
-                Domains
-              </h3>
+            <div className="brand-surface-raised p-5">
+              <h3 className="eyebrow mb-4">Domains</h3>
               <div className="space-y-3 max-h-48 overflow-y-auto">
-                {Object.entries(stats.domains)
-                  .sort(([, a], [, b]) => b - a)
-                  .map(([domain, count]) => {
-                    const maxCount = Math.max(...Object.values(stats.domains))
-                    return (
-                      <button
-                        type="button"
-                        key={domain}
-                        className="flex items-center gap-3 w-full text-left rounded hover:bg-indigo-50 transition-colors -mx-1 px-1"
-                        onClick={() =>
-                          setListFilter({
-                            title: `Domain: ${domain}`,
-                            domain,
-                            status: "approved",
-                          })
-                        }
-                      >
-                        <span className="text-sm text-gray-700 w-24 truncate">
-                          {domain}
-                        </span>
-                        <div className="flex-1 h-1.5 bg-gray-100 rounded-full overflow-hidden">
-                          <div
-                            className="h-full bg-indigo-500 rounded-full"
-                            style={{ width: `${(count / maxCount) * 100}%` }}
-                          />
-                        </div>
-                        <span className="text-xs text-gray-400 w-6 text-right">
-                          {count}
-                        </span>
-                      </button>
-                    )
-                  })}
+                {Object.entries(stats.domains).length === 0 ? (
+                  <EmptyGlyph label="No domains yet" />
+                ) : (
+                  Object.entries(stats.domains)
+                    .sort(([, a], [, b]) => b - a)
+                    .map(([domain, count]) => {
+                      const maxCount = Math.max(...Object.values(stats.domains))
+                      return (
+                        <button
+                          type="button"
+                          key={domain}
+                          className="flex items-center gap-3 w-full text-left rounded hover:bg-[var(--surface-hover)] transition-colors -mx-1 px-1 py-1"
+                          onClick={() =>
+                            setListFilter({
+                              title: `Domain: ${domain}`,
+                              domain,
+                              status: "approved",
+                            })
+                          }
+                        >
+                          <span className="text-sm text-[var(--ink-dim)] w-24 truncate">
+                            {domain}
+                          </span>
+                          <div className="flex-1 h-1 bg-[var(--rule)] rounded-full overflow-hidden">
+                            <div
+                              className="h-full bg-gradient-to-r from-[var(--violet)] to-[var(--cyan)] rounded-full"
+                              style={{ width: `${(count / maxCount) * 100}%` }}
+                            />
+                          </div>
+                          <span className="font-mono-brand text-[11px] text-[var(--ink-mute)] w-6 text-right tabular-nums">
+                            {count}
+                          </span>
+                        </button>
+                      )
+                    })
+                )}
               </div>
             </div>
 
-            <div className="bg-white rounded-lg border border-gray-200 p-4">
-              <h3 className="text-xs font-semibold text-gray-500 uppercase mb-3">
-                Confidence
-              </h3>
+            <div className="brand-surface-raised p-5">
+              <h3 className="eyebrow mb-4">Confidence</h3>
               {(() => {
                 const maxCount = Math.max(
                   ...Object.values(stats.confidence_distribution),
                   1,
                 )
+                const totalConfidence = Object.values(
+                  stats.confidence_distribution,
+                ).reduce((a, b) => a + b, 0)
+                if (totalConfidence === 0) {
+                  return <EmptyGlyph label="No data yet" />
+                }
                 return (
                   <div className="flex gap-2">
                     {Object.entries(stats.confidence_distribution).map(
@@ -179,7 +210,7 @@ export function DashboardPage() {
                           <button
                             type="button"
                             key={bucket}
-                            className="flex-1 flex flex-col items-center gap-1 rounded hover:bg-gray-50 transition-colors cursor-pointer"
+                            className="flex-1 flex flex-col items-center gap-1 rounded hover:bg-[var(--surface-hover)] transition-colors cursor-pointer disabled:cursor-default"
                             disabled={count === 0}
                             onClick={() =>
                               setListFilter({
@@ -190,12 +221,12 @@ export function DashboardPage() {
                               })
                             }
                           >
-                            <span className="text-xs text-gray-500 font-medium">
+                            <span className="font-mono-brand text-[11px] text-[var(--ink-dim)] tabular-nums">
                               {count}
                             </span>
                             <div className="w-full h-24 flex items-end">
                               <div
-                                className={`w-full rounded-t ${CONFIDENCE_COLORS[bucket] ?? "bg-gray-200"}`}
+                                className={`w-full rounded-t ${CONFIDENCE_COLORS[bucket] ?? "bg-[var(--rule-strong)]"}`}
                                 style={{
                                   height:
                                     maxCount > 0
@@ -205,7 +236,7 @@ export function DashboardPage() {
                                 }}
                               />
                             </div>
-                            <span className="text-[10px] text-gray-500 truncate w-full text-center">
+                            <span className="font-mono-brand text-[10px] text-[var(--ink-faint)] truncate w-full text-center tabular-nums">
                               {bucket}
                             </span>
                           </button>
@@ -218,25 +249,45 @@ export function DashboardPage() {
             </div>
           </div>
 
-          <div className="bg-white rounded-lg border border-gray-200 p-4">
-            <h3 className="text-xs font-semibold text-gray-500 uppercase mb-3">
-              Submissions
-            </h3>
+          {/* Submissions trend. */}
+          <div className="brand-surface-raised p-5">
+            <h3 className="eyebrow mb-4">Submissions</h3>
             {trendData.length === 0 ? (
-              <p className="text-gray-400 text-sm text-center py-8">
-                No submission data yet
-              </p>
+              <EmptyGlyph label="No submission data yet" />
             ) : (
-              <ResponsiveContainer width="100%" height={200}>
+              <ResponsiveContainer width="100%" height={220}>
                 <LineChart data={trendData}>
-                  <XAxis dataKey="date" tick={{ fontSize: 10 }} />
-                  <YAxis tick={{ fontSize: 10 }} allowDecimals={false} />
-                  <Tooltip />
-                  <Legend wrapperStyle={{ fontSize: 11 }} />
+                  <XAxis
+                    dataKey="date"
+                    tick={{ fontSize: 10, fill: CHART_COLORS.axis }}
+                    stroke={CHART_COLORS.grid}
+                  />
+                  <YAxis
+                    tick={{ fontSize: 10, fill: CHART_COLORS.axis }}
+                    stroke={CHART_COLORS.grid}
+                    allowDecimals={false}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      background: "rgba(7,7,11,0.95)",
+                      border: "1px solid rgba(255,255,255,0.14)",
+                      borderRadius: "8px",
+                      fontSize: 12,
+                      color: "#e6e6e6",
+                    }}
+                    labelStyle={{ color: "#e6e6e6" }}
+                  />
+                  <Legend
+                    wrapperStyle={{
+                      fontSize: 11,
+                      color: CHART_COLORS.axis,
+                      paddingTop: "8px",
+                    }}
+                  />
                   <Line
                     type="monotone"
                     dataKey="proposed"
-                    stroke="#eab308"
+                    stroke={CHART_COLORS.proposed}
                     strokeWidth={2}
                     dot={trendData.length <= 7}
                     name="Submitted"
@@ -244,7 +295,7 @@ export function DashboardPage() {
                   <Line
                     type="monotone"
                     dataKey="approved"
-                    stroke="#22c55e"
+                    stroke={CHART_COLORS.approved}
                     strokeWidth={2}
                     dot={trendData.length <= 7}
                     name="Approved"
@@ -252,7 +303,7 @@ export function DashboardPage() {
                   <Line
                     type="monotone"
                     dataKey="rejected"
-                    stroke="#ef4444"
+                    stroke={CHART_COLORS.rejected}
                     strokeWidth={2}
                     dot={trendData.length <= 7}
                     name="Rejected"
@@ -262,16 +313,15 @@ export function DashboardPage() {
             )}
           </div>
 
-          <div className="bg-white rounded-lg border border-gray-200 p-4">
-            <h3 className="text-xs font-semibold text-gray-500 uppercase mb-3">
-              Recent Activity
-            </h3>
-            <div className="max-h-60 overflow-y-auto">
+          {/* Recent activity. */}
+          <div className="brand-surface-raised p-5">
+            <h3 className="eyebrow mb-4">Recent Activity</h3>
+            <div className="max-h-72 overflow-y-auto">
               {stats.recent_activity.length === 0 ? (
-                <p className="text-gray-400 text-sm">No activity yet</p>
+                <EmptyGlyph label="No activity yet" />
               ) : (
                 <ul>
-                  <li className="grid grid-cols-[5rem_1fr_5rem_4rem] gap-3 border-b border-gray-200 py-1.5 text-[10px] font-semibold text-gray-400 uppercase">
+                  <li className="grid grid-cols-[5rem_1fr_5rem_4rem] gap-3 border-b border-[var(--rule)] py-1.5 eyebrow">
                     <span>Status</span>
                     <span>Summary</span>
                     <span className="text-right">Reviewer</span>
@@ -282,18 +332,18 @@ export function DashboardPage() {
                       <button
                         type="button"
                         onClick={() => setSelectedUnitId(event.unit_id)}
-                        className="grid grid-cols-[5rem_1fr_5rem_4rem] gap-3 items-center w-full text-left border-b border-gray-50 last:border-0 cursor-pointer hover:bg-gray-50 transition-colors py-2"
+                        className="grid grid-cols-[5rem_1fr_5rem_4rem] gap-3 items-center w-full text-left border-b border-[var(--rule)] last:border-0 cursor-pointer hover:bg-[var(--surface-hover)] transition-colors py-2.5"
                       >
                         <span>
                           <StatusBadge status={event.type} />
                         </span>
-                        <span className="text-sm text-gray-700 truncate min-w-0">
+                        <span className="text-sm text-[var(--ink-dim)] truncate min-w-0">
                           {event.summary}
                         </span>
-                        <span className="text-xs text-gray-400 whitespace-nowrap text-right">
+                        <span className="font-mono-brand text-[10px] uppercase tracking-[0.14em] text-[var(--ink-mute)] whitespace-nowrap text-right">
                           {event.reviewed_by ?? ""}
                         </span>
-                        <span className="text-xs text-gray-400 whitespace-nowrap text-right">
+                        <span className="font-mono-brand text-[10px] text-[var(--ink-faint)] whitespace-nowrap text-right">
                           {event.timestamp ? timeAgo(event.timestamp) : ""}
                         </span>
                       </button>

--- a/server/frontend/src/pages/LoginPage.tsx
+++ b/server/frontend/src/pages/LoginPage.tsx
@@ -1,5 +1,6 @@
 import { type FormEvent, useState } from "react"
 import { useAuth } from "../auth"
+import { Wordmark } from "../components/Wordmark"
 
 export function LoginPage() {
   const { login } = useAuth()
@@ -22,45 +23,55 @@ export function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
-      <form
-        onSubmit={handleSubmit}
-        className="bg-white p-8 rounded-lg shadow-sm border border-gray-200 w-full max-w-sm"
-      >
-        <h1 className="text-3xl font-bold mb-6 text-center text-indigo-600">
-          cq
-        </h1>
-        {error && (
-          <p className="text-red-600 text-sm mb-4 text-center">{error}</p>
-        )}
-        <label className="block mb-4">
-          <span className="text-sm font-medium text-gray-700">Username</span>
-          <input
-            type="text"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-            className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:ring-indigo-500"
-            required
-          />
-        </label>
-        <label className="block mb-6">
-          <span className="text-sm font-medium text-gray-700">Password</span>
-          <input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:ring-indigo-500"
-            required
-          />
-        </label>
-        <button
-          type="submit"
-          disabled={loading}
-          className="w-full bg-indigo-600 text-white py-2 rounded-lg font-medium hover:bg-indigo-700 disabled:opacity-50"
+    <div className="min-h-screen flex items-center justify-center px-4">
+      <div className="w-full max-w-sm">
+        <div className="flex flex-col items-center gap-6 mb-8">
+          <Wordmark size="lg" />
+          <p className="eyebrow">Layer 8 · Admin Console</p>
+        </div>
+        <form
+          onSubmit={handleSubmit}
+          className="brand-surface-raised p-7 backdrop-blur-sm shadow-[0_24px_60px_-24px_rgba(0,0,0,0.6)]"
         >
-          {loading ? "Signing in..." : "Sign in"}
-        </button>
-      </form>
+          {error && (
+            <p className="mb-4 rounded-md border border-[color-mix(in_srgb,var(--rose)_40%,transparent)] bg-[color-mix(in_srgb,var(--rose)_8%,transparent)] px-3 py-2 text-center text-sm text-[var(--rose)]">
+              {error}
+            </p>
+          )}
+          <label className="block mb-4">
+            <span className="eyebrow block mb-1.5">Username</span>
+            <input
+              type="text"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              autoComplete="username"
+              className="brand-input w-full"
+              required
+            />
+          </label>
+          <label className="block mb-7">
+            <span className="eyebrow block mb-1.5">Password</span>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              autoComplete="current-password"
+              className="brand-input w-full"
+              required
+            />
+          </label>
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full rounded-md bg-[color-mix(in_srgb,var(--cyan)_18%,transparent)] border border-[color-mix(in_srgb,var(--cyan)_45%,transparent)] py-2.5 font-mono-brand text-[11px] uppercase tracking-[0.22em] text-[var(--cyan)] hover:bg-[color-mix(in_srgb,var(--cyan)_28%,transparent)] disabled:opacity-50 transition-all"
+          >
+            {loading ? "Signing in…" : "Sign in"}
+          </button>
+        </form>
+        <p className="mt-6 text-center font-mono-brand text-[10px] uppercase tracking-[0.2em] text-[var(--ink-faint)]">
+          8th-layer.ai · semantic knowledge layer
+        </p>
+      </div>
     </div>
   )
 }

--- a/server/frontend/src/pages/NetworkPage.tsx
+++ b/server/frontend/src/pages/NetworkPage.tsx
@@ -361,7 +361,7 @@ export function NetworkPage({ initialData }: NetworkPageProps = {}) {
   return (
     <DesktopOnlyGate>
       <div
-        className="relative flex flex-col bg-[#04040f]"
+        className="relative flex flex-col bg-[var(--bg-to)]"
         style={{ height: "calc(100vh - 49px)" }}
       >
         <TopBar

--- a/server/frontend/src/pages/ReviewPage.tsx
+++ b/server/frontend/src/pages/ReviewPage.tsx
@@ -152,7 +152,7 @@ export function ReviewPage() {
   if (loading) {
     return (
       <div className="flex justify-center mt-16">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-indigo-500 border-t-transparent" />
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-[var(--cyan)] border-t-transparent" />
       </div>
     )
   }
@@ -161,26 +161,31 @@ export function ReviewPage() {
     const total = sessionApproved + sessionRejected
     const hasSkipped = skippedIds.current.size > 0
     return (
-      <div className="max-w-xl mx-auto border-2 border-gray-200 rounded-lg bg-white p-10 text-center mt-8">
-        <div className="text-4xl mb-3">{hasSkipped ? "\u23ed" : "\u2713"}</div>
-        <h2 className="text-lg font-semibold text-gray-900 mb-1">
+      <div className="max-w-xl mx-auto brand-surface-raised p-10 text-center mt-8 backdrop-blur-sm">
+        <div className="text-5xl mb-3 text-[var(--cyan)] font-display font-light">
+          {hasSkipped ? "\u21b7" : "\u2713"}
+        </div>
+        <p className="eyebrow mb-2">Review queue</p>
+        <h2 className="font-display text-2xl text-[var(--ink)] mb-2">
           {hasSkipped ? "All remaining skipped" : "All caught up"}
         </h2>
         {hasSkipped && (
-          <p className="text-gray-500">
+          <p className="text-[var(--ink-dim)]">
             {skippedIds.current.size} skipped{" "}
             {skippedIds.current.size === 1 ? "item" : "items"} still pending
           </p>
         )}
         {total > 0 && (
           <>
-            <p className="text-gray-500">You've reviewed {total} KUs today</p>
-            <div className="flex gap-4 justify-center mt-3 text-sm">
-              <span className="text-red-600 font-medium">
+            <p className="text-[var(--ink-dim)]">
+              You've reviewed {total} KUs today
+            </p>
+            <div className="flex gap-4 justify-center mt-3 font-mono-brand text-[11px] uppercase tracking-[0.18em]">
+              <span className="text-[var(--rose)]">
                 {sessionRejected} rejected
               </span>
-              <span className="text-gray-300">{"\u00b7"}</span>
-              <span className="text-green-600 font-medium">
+              <span className="text-[var(--ink-faint)]">\u00b7</span>
+              <span className="text-[var(--emerald)]">
                 {sessionApproved} approved
               </span>
             </div>
@@ -193,16 +198,16 @@ export function ReviewPage() {
               skippedIds.current.clear()
               fetchNext()
             }}
-            className="inline-block mt-5 text-sm font-medium text-indigo-500 hover:text-indigo-700"
+            className="inline-block mt-5 font-mono-brand text-[11px] uppercase tracking-[0.2em] text-[var(--cyan)] hover:text-[var(--ink)] transition-colors"
           >
             Review skipped items
           </button>
         )}
         <Link
           to="/dashboard"
-          className="inline-block mt-5 text-sm font-medium text-indigo-500 ml-4"
+          className="inline-block mt-5 font-mono-brand text-[11px] uppercase tracking-[0.2em] text-[var(--cyan)] hover:text-[var(--ink)] ml-4 transition-colors"
         >
-          View dashboard {"\u2192"}
+          View dashboard \u2192
         </Link>
       </div>
     )
@@ -211,7 +216,7 @@ export function ReviewPage() {
   return (
     <div>
       {conflictMessage && (
-        <p className="text-center text-amber-600 text-sm font-medium mb-3">
+        <p className="text-center text-[var(--gold)] font-mono-brand text-[11px] uppercase tracking-[0.18em] mb-3">
           {conflictMessage}
         </p>
       )}
@@ -234,7 +239,7 @@ export function ReviewPage() {
       />
 
       {error && (
-        <p className="text-center text-red-600 text-sm mt-3">{error}</p>
+        <p className="text-center text-[var(--rose)] text-sm mt-3">{error}</p>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary

- Re-skin the cq-server admin SPA (Login, Dashboard, Review, Network, API Keys) into the 8th-Layer.ai brand: dark radial-gradient backdrop, Fraunces display + Inter body + IBM Plex Mono eyebrows, cyan/violet/emerald/gold/rose accent palette per the issue body.
- Theme is driven by CSS custom properties on `<html data-theme=...>`; `main.tsx` reads `VITE_THEME` (default `8th-layer`, fallback `mainline-cq`) so the upstream cq look stays available for A/B during migration.
- Tailwind v4 `@utility` blocks expose semantic helpers (`font-display`, `font-mono-brand`, `eyebrow`, `brand-surface`, `brand-surface-raised`, `brand-input`) so future surfaces stay consistent without touching `index.css`.
- New `Wordmark` placeholder component (Fraunces "8" + IBM Plex Mono "8TH·LAYER") replaces the inline `cq` text mark; trivially swappable when the final logo SVG lands.

## Files changed

| Surface | Files |
|---|---|
| Theme tokens | `src/index.css`, `src/main.tsx`, `index.html` |
| Brand wordmark | `src/components/Wordmark.tsx` (new) |
| Top nav | `src/components/Layout.tsx` |
| Login | `src/pages/LoginPage.tsx` |
| Dashboard | `src/pages/DashboardPage.tsx` |
| Review | `src/pages/ReviewPage.tsx`, `src/components/ReviewCard.tsx`, `src/components/ReviewActions.tsx`, `src/components/DragIndicators.tsx` |
| API Keys | `src/pages/ApiKeysPage.tsx` |
| Network | `src/pages/NetworkPage.tsx` (token alignment only — already dark) |
| Shared chrome | `src/components/StatusBadge.tsx`, `src/components/DomainTags.tsx`, `src/components/ConfidenceBadge.tsx`, `src/components/FilteredListModal.tsx`, `src/components/KnowledgeUnitModal.tsx` |

No backend, no cq-plugin, no route or component-structure changes.

## Build delta

|  | Baseline | After | Delta |
|---|---|---|---|
| CSS (gzip) | 8.77 KB | 9.98 KB | +1.21 KB |
| JS  (gzip) | 248.24 KB | 250.07 KB | +1.83 KB |

Small delta — tokens compress well, no new runtime deps.

## Visual diff (text descriptions)

- **Login** — full-bleed dark gradient; centered Wordmark above a `LAYER 8 · ADMIN CONSOLE` eyebrow; raised glass panel with mono-eyebrow input labels and a cyan-tinted "Sign in" button.
- **Top nav** — sticky translucent bar over the gradient; Wordmark on the left; mono-tracked uppercase nav links with a cyan gradient underline on the active route; pending-count chip in gold; `LOGOUT` ghosts to rose on hover.
- **Dashboard** — three count tiles render the numbers in light-weight Fraunces (gold/emerald/rose); domain bars use a violet→cyan gradient; confidence histogram bars carry the same accent palette; recharts retuned to dark axes/grid + brand line colors; "No submission data yet" replaced with a styled empty state (∅ glyph + cyan eyebrow); recent-activity rows table has mono micro-type and dark hover.
- **Review** — KU card is a dark glass surface with token-tinted borders that respond to selection (cyan idle, emerald approve, rose reject); summary in Fraunces; "Action" eyebrow + body inside a cyan-bordered callout; confirmation-state buttons use solid emerald/rose with the inverse text; drag indicators carry brand colors.
- **Network** — already shipped dark in the NOC aesthetic; outer container switched from hard-coded `#04040f` to `var(--bg-to)` so it sits on the same gradient as the rest of the app.
- **API Keys** — page eyebrow + Fraunces title; mint form uses `brand-input`; key rows are dark glass with prefix code chips, mono-tracked status/expiry pills (emerald/gold/rose by urgency); revoke + mint-success modals are token-styled with backdrop blur.
- **Empty states** — Dashboard, Review-empty, ApiKeys-empty, FilteredList-empty all converted to the same `∅` + cyan-eyebrow pattern.

## Theme switching

```sh
# default
pnpm build

# fall back to upstream cq look (light, neutral)
VITE_THEME=mainline-cq pnpm build
```

`data-theme` guards the radial gradient, dark scrollbars, autofill harmonisation. The fallback path keeps the app fully usable in light surfaces.

## Risk assessment

- **Low** — frontend-only, no API/contract changes, no route changes; all 23 unit tests pass unchanged.
- One theming caveat: Recharts `Tooltip` / `Legend` are styled inline (props), so the dark coloring relies on those props sticking on minor recharts upgrades.
- Wordmark is a deliberate placeholder; swapping in the final SVG is a one-component change and cannot regress other surfaces.
- The 561-line `ApiKeysPage.tsx` had its render tree rewritten extensively (button styles, surfaces, badges) but no logic, props, or DOM order changed — `ApiKeysPage.test.tsx` still passes.

## Test plan

- [ ] Visual sanity-check on engineering L2 (`https://engineering.8th-layer-corp.8th-layer.ai`) once the next image build lands.
- [ ] Visual sanity-check on sga L2 to confirm theme is uniform across deployments.
- [ ] Build with `VITE_THEME=mainline-cq`, confirm light fallback renders.
- [ ] Smoke-test on a 1280-wide viewport (Network page minimum), Login on mobile breakpoint.

Refs #168 #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)