### PR TITLE
feat(phase-1.0d): wire enterprise_root + pair_secret into AIGRP runtime (#178)

### DIFF
--- a/server/backend/src/cq_server/aigrp/__init__.py
+++ b/server/backend/src/cq_server/aigrp/__init__.py
@@ -36,6 +36,14 @@ from ._legacy import (
     self_l2_id,
     self_url,
 )
+from .runtime import (
+    bootstrap_root_if_needed,
+    derive_bearer_token,
+    invalidate_pair_cache,
+    is_first_deploy_runtime,
+    runtime_root_present,
+    verify_bearer_against_peer,
+)
 
 __all__ = [
     "BLOOM_BITS",
@@ -44,15 +52,21 @@ __all__ = [
     "aigrp_enabled",
     "bloom_contains",
     "bloom_matches_any",
+    "bootstrap_root_if_needed",
     "compute_centroid",
     "compute_domain_bloom",
+    "derive_bearer_token",
     "enterprise",
     "group",
+    "invalidate_pair_cache",
     "is_first_deploy",
+    "is_first_deploy_runtime",
     "now_iso",
     "require_forwarder_identity",
     "require_peer_key",
+    "runtime_root_present",
     "seed_peer_url",
     "self_l2_id",
     "self_url",
+    "verify_bearer_against_peer",
 ]

--- a/server/backend/src/cq_server/aigrp/_legacy.py
+++ b/server/backend/src/cq_server/aigrp/_legacy.py
@@ -54,8 +54,17 @@ BLOOM_HASHES = 5
 
 
 def is_first_deploy() -> bool:
-    """Return True iff this L2 is the genesis node for its Enterprise."""
-    return os.environ.get("CQ_AIGRP_IS_FIRST_DEPLOY", "false").lower() == "true"
+    """Return True iff this L2 is the genesis node for its Enterprise.
+
+    Phase 1.0d — defers to ``runtime.is_first_deploy_runtime`` which honours
+    the legacy env when set but otherwise determines genesis status from
+    the presence of a seed-peer URL. Imported lazily to avoid the
+    runtime → _legacy import cycle.
+    """
+    # Lazy import: runtime imports from this module.
+    from . import runtime as _runtime
+
+    return _runtime.is_first_deploy_runtime()
 
 
 def seed_peer_url() -> str:
@@ -88,32 +97,86 @@ def self_l2_id() -> str:
 
 
 def aigrp_enabled() -> bool:
-    """Disable AIGRP entirely when no peer key is configured.
+    """Disable AIGRP entirely when no peer key + no Enterprise root configured.
 
-    Lets the cq Remote run in legacy single-L2 mode (e.g., the existing
-    `mvp` stack with no AIGRP wiring) without crashing or hammering /aigrp
-    against itself.
+    Phase 1.0d — pair-secret runtime makes AIGRP usable WITHOUT
+    ``CQ_AIGRP_PEER_KEY`` as long as the Enterprise root is reachable in
+    SSM. The legacy env var stays a valid signal for back-compat (cross-
+    Enterprise aggregator + legacy single-L2 stacks); presence of either
+    flips the loop on. Single-L2 ``mvp`` stacks with neither still get
+    the AIGRP-disabled fast-path.
     """
-    return bool(os.environ.get("CQ_AIGRP_PEER_KEY"))
+    if os.environ.get("CQ_AIGRP_PEER_KEY"):
+        return True
+    # Lazy import — avoids cost on hot module load when AIGRP is disabled.
+    from . import runtime as _runtime
+
+    try:
+        return _runtime.runtime_root_present()
+    except Exception:  # noqa: BLE001 — defensive; bad config shouldn't crash boot
+        logger.exception("aigrp_enabled: runtime_root_present probe raised; treating as disabled")
+        return False
 
 
 def require_peer_key(request: Request) -> None:
-    """FastAPI dependency: validate the shared EnterprisePeerKey on /aigrp/* calls."""
-    expected = os.environ.get("CQ_AIGRP_PEER_KEY", "")
-    if not expected:
-        raise HTTPException(status_code=503, detail="AIGRP not configured on this L2")
+    """FastAPI dependency: validate the caller's authority on /aigrp/* calls.
+
+    Phase 1.0d — accepts EITHER:
+
+    1. Pair-secret bearer (intra-Enterprise, Decision 28). The caller
+       declares its identity in ``X-8L-Forwarder-L2-Id``; we derive the
+       expected bearer from ``HMAC(pair_secret, "aigrp-bearer-v1")`` and
+       constant-time compare. Both sides compute the same value because
+       ``pair_secret`` is HKDF-derived from the Enterprise root with a
+       lex-canonical info string.
+
+    2. Legacy shared bearer (``CQ_AIGRP_PEER_KEY``). Used by the cross-
+       Enterprise aggregator (``network.py``) and during the cutover
+       window before every sibling is on the new image. Falls through to
+       this path when (a) no forwarder header, OR (b) the forwarder
+       declares a different Enterprise (cross-Enterprise call), OR (c)
+       the pair-secret bearer didn't match — so a transient SSM/KMS
+       failure on this L2 doesn't dark-out the legacy path.
+
+    401 on auth failure; 503 only when neither auth mode is configured at
+    all (no env, no Enterprise root reachable).
+    """
     auth = request.headers.get("authorization", "")
     if not auth.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="missing peer key")
     presented = auth[7:]
-    # constant-time compare
-    if len(presented) != len(expected):
+
+    # Mode 1 — pair-secret. Only attempted when forwarder header present
+    # AND declares same Enterprise. Cross-Enterprise headers (aggregator)
+    # legitimately differ, so we skip mode 1 there.
+    declared = request.headers.get(FORWARDER_HEADER, "").strip()
+    if declared:
+        declared_enterprise, sep, _ = declared.partition("/")
+        if sep and declared_enterprise == enterprise() and declared != self_l2_id():
+            from . import runtime as _runtime
+
+            if _runtime.verify_bearer_against_peer(declared, presented):
+                return  # authorised via pair-secret
+
+    # Mode 2 — legacy shared bearer.
+    legacy = os.environ.get("CQ_AIGRP_PEER_KEY", "")
+    if legacy:
+        # constant-time compare
+        if len(presented) == len(legacy):
+            diff = 0
+            for a, b in zip(presented, legacy, strict=True):
+                diff |= ord(a) ^ ord(b)
+            if diff == 0:
+                return  # authorised via legacy bearer
         raise HTTPException(status_code=401, detail="invalid peer key")
-    diff = 0
-    for a, b in zip(presented, expected, strict=True):
-        diff |= ord(a) ^ ord(b)
-    if diff != 0:
+
+    # Neither mode configured / matched.
+    # If forwarder header was present and intra-Enterprise but mode 1 failed,
+    # surface 401 (caller possesses neither secret); if no forwarder + no
+    # legacy, AIGRP simply isn't configured here — 503.
+    if declared:
         raise HTTPException(status_code=401, detail="invalid peer key")
+    raise HTTPException(status_code=503, detail="AIGRP not configured on this L2")
 
 
 # SEC-CRIT #34 — forward-endpoint identity binding.

--- a/server/backend/src/cq_server/aigrp/enterprise_root.py
+++ b/server/backend/src/cq_server/aigrp/enterprise_root.py
@@ -56,6 +56,17 @@ def _ttl_sec() -> int:
 
 
 def _param_path(enterprise_id: str) -> str:
+    """Return the SSM SecureString path for ``enterprise_id``.
+
+    Phase 1.0d — operators can override the path via
+    ``CQ_ENTERPRISE_ROOT_SSM_PATH`` (e.g. when the SSM hierarchy in their
+    account collides with our default). When set, the override is used
+    verbatim; the ``enterprise_id`` slash check is bypassed because the
+    operator owns the path entirely. Empty / unset → default scheme.
+    """
+    override = os.environ.get("CQ_ENTERPRISE_ROOT_SSM_PATH", "").strip()
+    if override:
+        return override
     if not enterprise_id or "/" in enterprise_id:
         # SSM treats "/" as a path separator; an enterprise id with a slash
         # would either silently fan out under another path or 400 on PUT.

--- a/server/backend/src/cq_server/aigrp/runtime.py
+++ b/server/backend/src/cq_server/aigrp/runtime.py
@@ -1,0 +1,242 @@
+"""AIGRP runtime wiring — bridges enterprise_root + pair_secret into HTTP auth.
+
+Phase 1.0d (Decision 28). Replaces the per-stack ``CQ_AIGRP_PEER_KEY`` shared
+secret with HKDF-derived per-pair secrets so two L2s under the same Enterprise
+authenticate cross-L2 traffic without shipping the same Secrets Manager value
+to both stacks.
+
+Wire format on intra-Enterprise calls (between sibling L2s):
+
+    X-8L-Forwarder-L2-Id: <sender_l2_id>            # already required
+    Authorization: Bearer <bearer_token>            # NEW shape
+
+where ``bearer_token = base64url(HMAC-SHA256(pair_secret, b"aigrp-bearer-v1"))``
+and ``pair_secret`` is HKDF-derived from the Enterprise root + lex-canonical
+pair name. Both sides compute the same token; receiver constant-time compares.
+
+This is a transport-layer authenticator — message-body integrity is provided
+separately by the AIGRP envelope (``aigrp.envelope``) for endpoints that opt
+into envelope mode. Existing ``/aigrp/*`` endpoints keep their legacy body
+shapes; the bearer is the only auth shift.
+
+Backwards compatibility:
+- The cross-Enterprise aggregator path (network.py) keeps using the per-
+  Enterprise legacy ``CQ_AIGRP_PEER_KEY`` because aggregator + fleet do NOT
+  share an Enterprise root. ``require_peer_key`` falls back to legacy bearer
+  when (a) no forwarder header, OR (b) the forwarder declares a different
+  Enterprise, OR (c) the new pair-secret bearer doesn't match.
+- During the cutover window, an L2 that has ``CQ_AIGRP_PEER_KEY`` set will
+  accept either form. Once every sibling has been redeployed with the runtime
+  wired, the legacy env var can be unset (operator-driven).
+
+First-boot bootstrap:
+- ``CQ_ENTERPRISE_ROOT_BOOTSTRAP=true`` flips on the genesis-L2 path:
+  startup mints a 32-byte random root and PUTs it to SSM if absent. Set this
+  on the *first* L2 you stand up in an Enterprise; leave default ``false``
+  on every subsequent L2.
+- ``CQ_AIGRP_IS_FIRST_DEPLOY`` env var is no longer required — runtime
+  determines genesis status by SSM presence.
+"""
+
+from __future__ import annotations
+
+import base64
+import hmac
+import logging
+import os
+import threading
+import time
+from typing import TYPE_CHECKING
+
+from . import _legacy, enterprise_root, pair_secret
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+# Versioned constant — bump when the bearer-token derivation shape changes.
+_BEARER_INFO = b"aigrp-bearer-v1"
+
+# Per-pair secret cache. Keyed by ``(enterprise_id, peer_l2_id)``.
+# Wiped when the Enterprise root cache is invalidated (rotation flow).
+_pair_cache: dict[tuple[str, str], bytes] = {}
+_pair_cache_lock = threading.Lock()
+_pair_cache_ttl_sec = 300  # match enterprise_root default
+_pair_cache_meta: dict[tuple[str, str], float] = {}
+
+
+def invalidate_pair_cache() -> None:
+    """Drop all cached pair-secrets. Tests + rotation flow call this."""
+    with _pair_cache_lock:
+        _pair_cache.clear()
+        _pair_cache_meta.clear()
+
+
+def _bootstrap_enabled() -> bool:
+    return os.environ.get("CQ_ENTERPRISE_ROOT_BOOTSTRAP", "false").lower() == "true"
+
+
+def _bootstrap_kms_key_id() -> str:
+    """KMS key id/ARN/alias for first-boot mint. Required when bootstrap=true."""
+    return os.environ.get("CQ_ENTERPRISE_ROOT_KMS_KEY_ID", "")
+
+
+def bootstrap_root_if_needed() -> bool:
+    """First-boot helper — mint Enterprise root in SSM iff missing AND bootstrap=true.
+
+    Idempotent: subsequent boots find the param already, take no action. Safe
+    to call on every L2 startup; only the genesis L2 (with bootstrap=true)
+    will succeed on first call, others log + skip.
+
+    Returns:
+        True iff a root was minted (genesis path); False otherwise (already
+        present, or bootstrap disabled).
+    """
+    if not _bootstrap_enabled():
+        return False
+    enterprise_id = _legacy.enterprise()
+    try:
+        enterprise_root.get_enterprise_root(enterprise_id)
+        # Param exists — nothing to do.
+        logger.info("aigrp bootstrap: Enterprise root already present for %s; skipping mint", enterprise_id)
+        return False
+    except Exception as exc:  # noqa: BLE001 — we want to mint on any read failure
+        # boto3 raises ClientError for ParameterNotFound; we catch broadly here
+        # because if SSM is broken for any reason, attempting the PUT is the
+        # right thing — PUT will surface the real error if e.g. KMS perms are
+        # missing.
+        logger.info("aigrp bootstrap: Enterprise root absent for %s (%s); attempting mint", enterprise_id, exc)
+    kms_key_id = _bootstrap_kms_key_id()
+    if not kms_key_id:
+        logger.error(
+            "aigrp bootstrap: CQ_ENTERPRISE_ROOT_BOOTSTRAP=true but "
+            "CQ_ENTERPRISE_ROOT_KMS_KEY_ID is empty; refusing to mint"
+        )
+        return False
+    enterprise_root.bootstrap_enterprise_root(enterprise_id, kms_key_id, overwrite=False)
+    logger.warning("aigrp bootstrap: minted fresh Enterprise root for %s (genesis L2)", enterprise_id)
+    return True
+
+
+def runtime_root_present() -> bool:
+    """True iff the Enterprise root is reachable via SSM right now.
+
+    Used to compute ``is_first_deploy_runtime`` — a runtime replacement
+    for the static ``CQ_AIGRP_IS_FIRST_DEPLOY`` env. Catches all exceptions
+    because *any* failure to read the root means we can't claim genesis
+    status; safer to treat as "not genesis" and run normal bootstrap path.
+    """
+    try:
+        enterprise_root.get_enterprise_root(_legacy.enterprise())
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def is_first_deploy_runtime() -> bool:
+    """Runtime equivalent of the legacy ``CQ_AIGRP_IS_FIRST_DEPLOY`` env.
+
+    The L2 is "first deploy" when no peer relationship has yet been
+    established — operationally, when no seed peer is configured AND we
+    just minted (or are about to mint) the Enterprise root. This is the
+    signal AIGRP bootstrap loop uses to skip the seed-fetch step.
+
+    Falls back to the legacy env if explicitly set (transition aid).
+    """
+    legacy_env = os.environ.get("CQ_AIGRP_IS_FIRST_DEPLOY", "").lower()
+    if legacy_env in ("true", "false"):
+        return legacy_env == "true"
+    # Runtime determination: genesis when no seed peer URL configured.
+    # The Enterprise root presence isn't enough by itself — second L2 in an
+    # Enterprise also finds the root present; what distinguishes genesis is
+    # the lack of a seed peer to bootstrap from.
+    return not _legacy.seed_peer_url()
+
+
+def _pair_secret_for_peer(peer_l2_id: str) -> bytes:
+    """Return the cached or freshly-derived 32-byte pair-secret for ``peer_l2_id``.
+
+    Caches by ``(self_enterprise, peer_l2_id)``. Cache TTL == enterprise_root
+    cache TTL so a root rotation lands within one window.
+
+    Raises whatever ``enterprise_root.get_enterprise_root`` raises on read
+    failure (ClientError, ValueError) — caller decides 401 vs 503.
+    """
+    enterprise_id = _legacy.enterprise()
+    self_id = _legacy.self_l2_id()
+    if peer_l2_id == self_id:
+        raise ValueError(f"refusing to derive pair-secret with self ({self_id!r})")
+    key = (enterprise_id, peer_l2_id)
+    now = time.monotonic()
+    with _pair_cache_lock:
+        cached = _pair_cache.get(key)
+        meta = _pair_cache_meta.get(key, 0.0)
+        if cached is not None and (now - meta) < _pair_cache_ttl_sec:
+            return cached
+    root = enterprise_root.get_enterprise_root(enterprise_id)
+    secret = pair_secret.derive_pair_secret(root, self_id, peer_l2_id)
+    with _pair_cache_lock:
+        _pair_cache[key] = secret
+        _pair_cache_meta[key] = now
+    return secret
+
+
+def _bearer_for_secret(secret: bytes) -> str:
+    """Compute the b64url HMAC bearer token from a pair-secret.
+
+    Both sides of an intra-Enterprise call compute the same token because
+    ``derive_pair_secret`` is symmetric (lex-canonical) and the HMAC info
+    string is fixed. The token is therefore equally valid as the
+    Authorization value going either direction — it only authenticates
+    "the caller possesses the pair-secret", not direction.
+    """
+    mac = hmac.new(secret, _BEARER_INFO, "sha256").digest()
+    return base64.urlsafe_b64encode(mac).rstrip(b"=").decode("ascii")
+
+
+def derive_bearer_token(peer_l2_id: str) -> str:
+    """Caller-side: build the Authorization-Bearer value for a peer.
+
+    Used by the consults forwarder + AIGRP poll loop when calling a sibling
+    L2 inside the same Enterprise. The receiver derives the same token from
+    its end and constant-time compares.
+
+    Raises:
+        ValueError: if ``peer_l2_id`` is empty or equals self.
+        Exception: any underlying SSM/KMS error from the root fetch — caller
+            translates to 503.
+    """
+    if not peer_l2_id:
+        raise ValueError("peer_l2_id required")
+    secret = _pair_secret_for_peer(peer_l2_id)
+    return _bearer_for_secret(secret)
+
+
+def verify_bearer_against_peer(peer_l2_id: str, presented_bearer: str) -> bool:
+    """Receiver-side: constant-time compare presented bearer against expected.
+
+    Returns True on match, False on mismatch / derivation failure. Errors
+    from SSM/KMS are swallowed and rendered as False — receiver fails closed
+    rather than 5xx-ing on a transient infra error (caller will retry, and
+    a real misconfig surfaces as a sustained 401 rather than a noisy 5xx).
+    """
+    if not presented_bearer or not peer_l2_id:
+        return False
+    try:
+        secret = _pair_secret_for_peer(peer_l2_id)
+    except Exception:  # noqa: BLE001
+        logger.exception("aigrp pair-secret derive failed for peer=%s; treating as auth failure", peer_l2_id)
+        return False
+    expected = _bearer_for_secret(secret)
+    return hmac.compare_digest(expected, presented_bearer)
+
+
+__all__ = [
+    "bootstrap_root_if_needed",
+    "derive_bearer_token",
+    "invalidate_pair_cache",
+    "is_first_deploy_runtime",
+    "runtime_root_present",
+    "verify_bearer_against_peer",
+]

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -80,6 +80,26 @@ def _get_store() -> SqliteStore:
     return _store
 
 
+def _aigrp_outbound_bearer(peer_l2_id: str | None) -> str:
+    """Resolve the bearer for an outbound /aigrp/* call.
+
+    Phase 1.0d: when ``peer_l2_id`` is a known sibling under our
+    Enterprise, derive the per-pair bearer from the Enterprise root
+    (Decision 28). Falls back to the legacy ``CQ_AIGRP_PEER_KEY`` env
+    when the peer is unknown (e.g. seed bootstrap before we have the
+    seed's L2 id) OR derivation fails.
+    """
+    if peer_l2_id and peer_l2_id != aigrp.self_l2_id():
+        peer_enterprise, sep, _ = peer_l2_id.partition("/")
+        if sep and peer_enterprise == aigrp.enterprise():
+            try:
+                return aigrp.derive_bearer_token(peer_l2_id)
+            except Exception:  # noqa: BLE001
+                # Falls through to legacy below — log via root logger.
+                pass
+    return os.environ.get("CQ_AIGRP_PEER_KEY", "")
+
+
 async def _aigrp_bootstrap_and_poll(store: SqliteStore) -> None:
     """Bootstrap into the Enterprise mesh on first start, then poll
     every known peer's /aigrp/signature on a 5-min interval forever.
@@ -94,7 +114,12 @@ async def _aigrp_bootstrap_and_poll(store: SqliteStore) -> None:
 
     log = logging.getLogger("aigrp")
     poll_interval = int(os.environ.get("CQ_AIGRP_POLL_INTERVAL_SEC", "300"))
+    # Phase 1.0d — first-deploy is now runtime-determined (no seed peer),
+    # not a hardcoded env. Genesis L2 has no seed_peer_url, skips bootstrap.
     needs_bootstrap = (not aigrp.is_first_deploy()) and bool(aigrp.seed_peer_url())
+    # Optional: seed L2 id for pair-secret bearer on the bootstrap call.
+    # When unset, legacy bearer is used (operator transition).
+    seed_l2_id = os.environ.get("CQ_AIGRP_SEED_PEER_L2_ID", "").strip() or None
 
     async def _try_bootstrap() -> bool:
         """Hit the seed's /aigrp/hello and absorb its peer table.
@@ -125,7 +150,8 @@ async def _aigrp_bootstrap_and_poll(store: SqliteStore) -> None:
                 data=hello_payload,
                 headers={
                     "content-type": "application/json",
-                    "authorization": f"Bearer {os.environ.get('CQ_AIGRP_PEER_KEY', '')}",
+                    "authorization": f"Bearer {_aigrp_outbound_bearer(seed_l2_id)}",
+                    aigrp.FORWARDER_HEADER: aigrp.self_l2_id(),
                 },
             )
             with urllib.request.urlopen(req, timeout=10) as resp:
@@ -161,12 +187,17 @@ async def _aigrp_bootstrap_and_poll(store: SqliteStore) -> None:
     #    pending; gives self-healing if the seed was down at start.
     import base64
 
-    def _rehello_peer(peer_endpoint: str) -> None:
+    def _rehello_peer(peer_endpoint: str, peer_l2_id: str | None = None) -> None:
         """Re-send hello to a known peer so they pick up our pubkey.
 
         Sprint 4 (#44) — re-hello on every poll cycle, idempotent on the
         receiver. This is the recovery path for a peer that joined
         before this L2 generated its key, or whose row was rebuilt.
+
+        Phase 1.0d — when ``peer_l2_id`` is known (call sites in the
+        poll loop have it), the Authorization bearer is derived from
+        the per-pair secret. Bootstrap first-hello calls without a
+        known peer fall back to legacy bearer.
         """
         from . import forward_sign
 
@@ -186,7 +217,8 @@ async def _aigrp_bootstrap_and_poll(store: SqliteStore) -> None:
                 data=payload,
                 headers={
                     "content-type": "application/json",
-                    "authorization": f"Bearer {os.environ.get('CQ_AIGRP_PEER_KEY', '')}",
+                    "authorization": f"Bearer {_aigrp_outbound_bearer(peer_l2_id)}",
+                    aigrp.FORWARDER_HEADER: aigrp.self_l2_id(),
                 },
             )
             with urllib.request.urlopen(req, timeout=5):
@@ -206,12 +238,16 @@ async def _aigrp_bootstrap_and_poll(store: SqliteStore) -> None:
                 if not p["endpoint_url"]:
                     continue
                 # Sprint 4 — push our pubkey to this peer (cheap, idempotent).
-                _rehello_peer(p["endpoint_url"])
+                # Phase 1.0d — pass peer's l2_id so we derive the per-pair bearer.
+                _rehello_peer(p["endpoint_url"], p["l2_id"])
                 try:
                     req = urllib.request.Request(
                         f"{p['endpoint_url'].rstrip('/')}/api/v1/aigrp/signature",
                         method="GET",
-                        headers={"authorization": f"Bearer {os.environ.get('CQ_AIGRP_PEER_KEY', '')}"},
+                        headers={
+                            "authorization": f"Bearer {_aigrp_outbound_bearer(p['l2_id'])}",
+                            aigrp.FORWARDER_HEADER: aigrp.self_l2_id(),
+                        },
                     )
                     with urllib.request.urlopen(req, timeout=10) as resp:
                         sig = json.loads(resp.read())
@@ -285,6 +321,18 @@ async def lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
     _store = SqliteStore(db_path=db_path)
     app_instance.state.store = _store
     app_instance.state.api_key_pepper = pepper
+
+    # Phase 1.0d — first-boot Enterprise root mint (Decision 28).
+    # No-op when CQ_ENTERPRISE_ROOT_BOOTSTRAP=false (default) or when the
+    # SSM param already exists. Genesis L2s set the env at deploy time.
+    try:
+        aigrp.bootstrap_root_if_needed()
+    except Exception:  # noqa: BLE001 — boot must not crash on bootstrap failure
+        # Logged inside the helper; surface here only if we want to fail
+        # closed. We don't — the L2 still serves AIGRP-disabled paths.
+        import logging as _logging
+
+        _logging.getLogger("aigrp").exception("bootstrap_root_if_needed raised; continuing")
 
     aigrp_task = None
     if aigrp.aigrp_enabled():
@@ -646,7 +694,8 @@ async def aigrp_hello(
                     data=announce_payload,
                     headers={
                         "content-type": "application/json",
-                        "authorization": f"Bearer {os.environ.get('CQ_AIGRP_PEER_KEY', '')}",
+                        "authorization": f"Bearer {_aigrp_outbound_bearer(p['l2_id'])}",
+                        aigrp.FORWARDER_HEADER: aigrp.self_l2_id(),
                     },
                 )
                 try:

--- a/server/backend/src/cq_server/consults.py
+++ b/server/backend/src/cq_server/consults.py
@@ -158,9 +158,42 @@ def _self_l2_id() -> str:
     return f"{aigrp_mod.enterprise()}/{aigrp_mod.group()}"
 
 
-def _build_forward_headers(peer_key: str, payload: dict[str, Any]) -> dict[str, str]:
+def _bearer_for_target(target_l2_id: str) -> str:
+    """Resolve the Authorization-Bearer value for an outbound cross-L2 call.
+
+    Phase 1.0d preference:
+
+    1. Pair-secret bearer (intra-Enterprise, Decision 28). Tries
+       ``aigrp.derive_bearer_token`` first when ``target_l2_id`` is a
+       sibling under our Enterprise. Any SSM/KMS read failure falls
+       through to the legacy bearer — operator can still recover by
+       leaving ``CQ_AIGRP_PEER_KEY`` set during cutover.
+    2. Legacy ``CQ_AIGRP_PEER_KEY`` env var (cross-Enterprise + cutover
+       fallback).
+
+    Returns an empty string if neither path resolves; caller surfaces 503.
+    """
+    self_id = _self_l2_id()
+    if target_l2_id and target_l2_id != self_id:
+        target_enterprise, sep, _ = target_l2_id.partition("/")
+        if sep and target_enterprise == aigrp_mod.enterprise():
+            try:
+                return aigrp_mod.derive_bearer_token(target_l2_id)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "consults forward: pair-secret derive failed for target=%s; "
+                    "falling back to legacy CQ_AIGRP_PEER_KEY",
+                    target_l2_id,
+                )
+    return os.environ.get("CQ_AIGRP_PEER_KEY", "")
+
+
+def _build_forward_headers(target_l2_id: str, payload: dict[str, Any]) -> dict[str, str]:
     """Compose authorization + forwarder-identity + (sprint 4) signature
     headers for outbound /consults/forward-* calls.
+
+    Phase 1.0d — bearer is per-target (HKDF-derived pair-secret) when the
+    target is an intra-Enterprise sibling; legacy shared bearer otherwise.
 
     The signature header is omitted when no L2 keypair is available on
     disk — receivers fall back to legacy unsigned mode (until they flip
@@ -168,9 +201,10 @@ def _build_forward_headers(peer_key: str, payload: dict[str, Any]) -> dict[str, 
     """
     from . import forward_sign
 
+    bearer = _bearer_for_target(target_l2_id)
     forwarder_id = _self_l2_id()
     headers = {
-        "authorization": f"Bearer {peer_key}",
+        "authorization": f"Bearer {bearer}",
         aigrp_mod.FORWARDER_HEADER: forwarder_id,
     }
     sig = forward_sign.sign_forward_request(payload, forwarder_id)
@@ -191,10 +225,11 @@ def _forward_request(target: dict[str, Any], payload: dict[str, Any]) -> None:
     request body is signed and the sig travels in ``X-8L-Forwarder-Sig``.
     """
     base = target["endpoint_url"].rstrip("/")
-    peer_key = os.environ.get("CQ_AIGRP_PEER_KEY", "")
-    if not peer_key:
-        raise HTTPException(503, detail="cross-L2 routing requires CQ_AIGRP_PEER_KEY")
-    headers = _build_forward_headers(peer_key, payload)
+    headers = _build_forward_headers(target["l2_id"], payload)
+    if not headers["authorization"].removeprefix("Bearer ").strip():
+        raise HTTPException(
+            503, detail="cross-L2 routing requires either Enterprise root SSM access or CQ_AIGRP_PEER_KEY"
+        )
     try:
         with httpx.Client(timeout=L2_FORWARD_TIMEOUT) as client:
             r = client.post(
@@ -229,10 +264,11 @@ def _forward_message(target: dict[str, Any], payload: dict[str, Any]) -> None:
     Sprint 4 (#44) — same Ed25519 signature treatment as forward-request.
     """
     base = target["endpoint_url"].rstrip("/")
-    peer_key = os.environ.get("CQ_AIGRP_PEER_KEY", "")
-    if not peer_key:
-        raise HTTPException(503, detail="cross-L2 routing requires CQ_AIGRP_PEER_KEY")
-    headers = _build_forward_headers(peer_key, payload)
+    headers = _build_forward_headers(target["l2_id"], payload)
+    if not headers["authorization"].removeprefix("Bearer ").strip():
+        raise HTTPException(
+            503, detail="cross-L2 routing requires either Enterprise root SSM access or CQ_AIGRP_PEER_KEY"
+        )
     try:
         with httpx.Client(timeout=L2_FORWARD_TIMEOUT) as client:
             r = client.post(

--- a/server/backend/tests/test_aigrp_enterprise_root.py
+++ b/server/backend/tests/test_aigrp_enterprise_root.py
@@ -129,3 +129,20 @@ class TestPathValidation:
     def test_empty_id_rejected(self) -> None:
         with pytest.raises(ValueError, match="non-empty"):
             enterprise_root._param_path("")
+
+
+class TestPathOverride:
+    """Phase 1.0d — operators can pin the SSM path via env."""
+
+    def test_env_override_used_verbatim(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CQ_ENTERPRISE_ROOT_SSM_PATH", "/custom/path/acme-root")
+        assert enterprise_root._param_path("acme") == "/custom/path/acme-root"
+
+    def test_env_override_bypasses_slash_check(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Operator's override path can contain slashes — we trust them.
+        monkeypatch.setenv("CQ_ENTERPRISE_ROOT_SSM_PATH", "/foo/bar/baz")
+        assert enterprise_root._param_path("acme") == "/foo/bar/baz"
+
+    def test_empty_override_falls_back_to_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CQ_ENTERPRISE_ROOT_SSM_PATH", "")
+        assert enterprise_root._param_path("acme") == "/8th-layer/aigrp/enterprise-root/acme"

--- a/server/backend/tests/test_aigrp_runtime.py
+++ b/server/backend/tests/test_aigrp_runtime.py
@@ -1,0 +1,363 @@
+"""Phase 1.0d (Decision 28) — AIGRP runtime wiring tests.
+
+Covers the bridge between ``enterprise_root`` (SSM-backed root) and
+``pair_secret`` (HKDF derivation) into the HTTP auth path.
+
+Acceptance: two L2s under the same Enterprise but different Groups,
+seeded with the SAME Enterprise root, derive matching bearer tokens
+without any shared per-stack secret.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from fastapi import HTTPException
+from fastapi import Request as FastApiRequest
+
+from cq_server import aigrp
+from cq_server.aigrp import _legacy, enterprise_root, runtime
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Wipe AIGRP env so each test starts from a known state.
+    for k in (
+        "CQ_AIGRP_PEER_KEY",
+        "CQ_AIGRP_IS_FIRST_DEPLOY",
+        "CQ_AIGRP_SEED_PEER_URL",
+        "CQ_ENTERPRISE_ROOT_BOOTSTRAP",
+        "CQ_ENTERPRISE_ROOT_KMS_KEY_ID",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    # Default identity for the running L2.
+    monkeypatch.setenv("CQ_ENTERPRISE", "8th-layer-corp")
+    monkeypatch.setenv("CQ_GROUP", "engineering")
+    enterprise_root.invalidate_cache()
+    runtime.invalidate_pair_cache()
+    yield
+    enterprise_root.invalidate_cache()
+    runtime.invalidate_pair_cache()
+
+
+@pytest.fixture
+def fake_root() -> bytes:
+    return bytes.fromhex("ab" * 32)
+
+
+def _stub_root_in_ssm(monkeypatch: pytest.MonkeyPatch, root: bytes) -> mock.Mock:
+    client = mock.Mock()
+    client.get_parameter.return_value = {"Parameter": {"Value": root.hex()}}
+    monkeypatch.setattr(enterprise_root, "_get_ssm_client", lambda: client)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Acceptance #1 — both sides of a pair derive matching bearer tokens.
+# ---------------------------------------------------------------------------
+
+
+class TestSymmetricDerivation:
+    def test_engineering_and_sga_derive_matching_bearer(
+        self, monkeypatch: pytest.MonkeyPatch, fake_root: bytes
+    ) -> None:
+        """8th-layer-corp/engineering and /sga compute the same token."""
+        _stub_root_in_ssm(monkeypatch, fake_root)
+
+        # Side A: engineering deriving for sga.
+        monkeypatch.setenv("CQ_GROUP", "engineering")
+        runtime.invalidate_pair_cache()
+        token_from_eng = runtime.derive_bearer_token("8th-layer-corp/sga")
+
+        # Side B: sga deriving for engineering.
+        monkeypatch.setenv("CQ_GROUP", "sga")
+        runtime.invalidate_pair_cache()
+        token_from_sga = runtime.derive_bearer_token("8th-layer-corp/engineering")
+
+        assert token_from_eng == token_from_sga
+        # And the token is non-empty + b64url-shape (no padding chars).
+        assert token_from_eng
+        assert "=" not in token_from_eng
+
+    def test_different_pairs_produce_different_tokens(self, monkeypatch: pytest.MonkeyPatch, fake_root: bytes) -> None:
+        _stub_root_in_ssm(monkeypatch, fake_root)
+        token_eng_sga = runtime.derive_bearer_token("8th-layer-corp/sga")
+        token_eng_finance = runtime.derive_bearer_token("8th-layer-corp/finance")
+        assert token_eng_sga != token_eng_finance
+
+    def test_self_pair_rejected(self, monkeypatch: pytest.MonkeyPatch, fake_root: bytes) -> None:
+        _stub_root_in_ssm(monkeypatch, fake_root)
+        with pytest.raises(ValueError):
+            runtime.derive_bearer_token("8th-layer-corp/engineering")
+
+
+# ---------------------------------------------------------------------------
+# verify_bearer_against_peer — receiver-side check.
+# ---------------------------------------------------------------------------
+
+
+class TestVerify:
+    def test_round_trip_accepts(self, monkeypatch: pytest.MonkeyPatch, fake_root: bytes) -> None:
+        _stub_root_in_ssm(monkeypatch, fake_root)
+        # Sender (sga) derives, receiver (engineering) verifies.
+        monkeypatch.setenv("CQ_GROUP", "sga")
+        runtime.invalidate_pair_cache()
+        bearer = runtime.derive_bearer_token("8th-layer-corp/engineering")
+
+        monkeypatch.setenv("CQ_GROUP", "engineering")
+        runtime.invalidate_pair_cache()
+        assert runtime.verify_bearer_against_peer("8th-layer-corp/sga", bearer) is True
+
+    def test_tampered_bearer_rejected(self, monkeypatch: pytest.MonkeyPatch, fake_root: bytes) -> None:
+        _stub_root_in_ssm(monkeypatch, fake_root)
+        monkeypatch.setenv("CQ_GROUP", "engineering")
+        good = runtime.derive_bearer_token("8th-layer-corp/sga")
+        bad = good[:-2] + ("AA" if good[-2:] != "AA" else "BB")
+        assert runtime.verify_bearer_against_peer("8th-layer-corp/sga", bad) is False
+
+    def test_empty_inputs_rejected(self) -> None:
+        assert runtime.verify_bearer_against_peer("", "anything") is False
+        assert runtime.verify_bearer_against_peer("8th-layer-corp/sga", "") is False
+
+    def test_ssm_failure_returns_false_not_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = mock.Mock()
+        client.get_parameter.side_effect = RuntimeError("boom")
+        monkeypatch.setattr(enterprise_root, "_get_ssm_client", lambda: client)
+        runtime.invalidate_pair_cache()
+        assert runtime.verify_bearer_against_peer("8th-layer-corp/sga", "anything") is False
+
+
+# ---------------------------------------------------------------------------
+# require_peer_key — dual-mode FastAPI dependency.
+# ---------------------------------------------------------------------------
+
+
+def _request_with(headers: dict[str, str]) -> FastApiRequest:
+    """Construct a minimal FastAPI Request with the given headers."""
+    raw = []
+    for k, v in headers.items():
+        raw.append((k.lower().encode("latin-1"), v.encode("latin-1")))
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/",
+        "headers": raw,
+    }
+    return FastApiRequest(scope=scope)
+
+
+class TestRequirePeerKey:
+    def test_pair_secret_bearer_accepted(self, monkeypatch: pytest.MonkeyPatch, fake_root: bytes) -> None:
+        _stub_root_in_ssm(monkeypatch, fake_root)
+        # Receiver = engineering. Sender = sga.
+        monkeypatch.setenv("CQ_GROUP", "engineering")
+        runtime.invalidate_pair_cache()
+
+        # Sender (sga) computes the bearer.
+        monkeypatch.setenv("CQ_GROUP", "sga")
+        runtime.invalidate_pair_cache()
+        bearer = runtime.derive_bearer_token("8th-layer-corp/engineering")
+
+        # Switch to receiver context.
+        monkeypatch.setenv("CQ_GROUP", "engineering")
+        runtime.invalidate_pair_cache()
+
+        req = _request_with(
+            {
+                "authorization": f"Bearer {bearer}",
+                aigrp.FORWARDER_HEADER: "8th-layer-corp/sga",
+            }
+        )
+        # Should not raise.
+        _legacy.require_peer_key(req)
+
+    def test_legacy_bearer_accepted_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CQ_AIGRP_PEER_KEY", "legacy-shared-secret")
+        req = _request_with({"authorization": "Bearer legacy-shared-secret"})
+        _legacy.require_peer_key(req)  # no raise
+
+    def test_invalid_bearer_rejected_with_legacy_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CQ_AIGRP_PEER_KEY", "legacy-shared-secret")
+        req = _request_with({"authorization": "Bearer wrong"})
+        with pytest.raises(HTTPException) as exc:
+            _legacy.require_peer_key(req)
+        assert exc.value.status_code == 401
+
+    def test_missing_authorization_rejected(self) -> None:
+        req = _request_with({})
+        with pytest.raises(HTTPException) as exc:
+            _legacy.require_peer_key(req)
+        assert exc.value.status_code == 401
+
+    def test_neither_mode_configured_yields_503(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # No CQ_AIGRP_PEER_KEY, no SSM root.
+        client = mock.Mock()
+        client.get_parameter.side_effect = RuntimeError("no param")
+        monkeypatch.setattr(enterprise_root, "_get_ssm_client", lambda: client)
+        req = _request_with({"authorization": "Bearer anything"})
+        with pytest.raises(HTTPException) as exc:
+            _legacy.require_peer_key(req)
+        assert exc.value.status_code == 503
+
+    def test_pair_secret_failure_falls_through_to_legacy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Pair-secret derive fails (no SSM), but legacy bearer matches.
+        client = mock.Mock()
+        client.get_parameter.side_effect = RuntimeError("ssm down")
+        monkeypatch.setattr(enterprise_root, "_get_ssm_client", lambda: client)
+        monkeypatch.setenv("CQ_AIGRP_PEER_KEY", "legacy-secret")
+        req = _request_with(
+            {
+                "authorization": "Bearer legacy-secret",
+                aigrp.FORWARDER_HEADER: "8th-layer-corp/sga",
+            }
+        )
+        _legacy.require_peer_key(req)  # no raise — legacy fallback kicked in
+
+    def test_cross_enterprise_falls_through_to_legacy(self, monkeypatch: pytest.MonkeyPatch, fake_root: bytes) -> None:
+        """Aggregator from a foreign Enterprise doesn't trigger pair-secret mode."""
+        _stub_root_in_ssm(monkeypatch, fake_root)
+        monkeypatch.setenv("CQ_AIGRP_PEER_KEY", "legacy-secret")
+        # Receiver is 8th-layer-corp, forwarder is from 'aggregator-corp'.
+        req = _request_with(
+            {
+                "authorization": "Bearer legacy-secret",
+                aigrp.FORWARDER_HEADER: "aggregator-corp/marketing",
+            }
+        )
+        _legacy.require_peer_key(req)  # legacy bearer passes, pair-secret skipped
+
+
+# ---------------------------------------------------------------------------
+# bootstrap_root_if_needed — first-boot mint.
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrap:
+    def test_skips_when_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # CQ_ENTERPRISE_ROOT_BOOTSTRAP unset by fixture.
+        client = mock.Mock()
+        monkeypatch.setattr(enterprise_root, "_get_ssm_client", lambda: client)
+        assert runtime.bootstrap_root_if_needed() is False
+        client.put_parameter.assert_not_called()
+
+    def test_skips_when_root_already_present(self, monkeypatch: pytest.MonkeyPatch, fake_root: bytes) -> None:
+        monkeypatch.setenv("CQ_ENTERPRISE_ROOT_BOOTSTRAP", "true")
+        monkeypatch.setenv("CQ_ENTERPRISE_ROOT_KMS_KEY_ID", "alias/x")
+        client = _stub_root_in_ssm(monkeypatch, fake_root)
+        assert runtime.bootstrap_root_if_needed() is False
+        client.put_parameter.assert_not_called()
+
+    def test_mints_when_enabled_and_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CQ_ENTERPRISE_ROOT_BOOTSTRAP", "true")
+        monkeypatch.setenv("CQ_ENTERPRISE_ROOT_KMS_KEY_ID", "alias/x")
+        client = mock.Mock()
+        # First read: missing.
+        client.get_parameter.side_effect = RuntimeError("ParameterNotFound")
+        monkeypatch.setattr(enterprise_root, "_get_ssm_client", lambda: client)
+        assert runtime.bootstrap_root_if_needed() is True
+        client.put_parameter.assert_called_once()
+        kwargs = client.put_parameter.call_args.kwargs
+        assert kwargs["Type"] == "SecureString"
+        assert kwargs["KeyId"] == "alias/x"
+        assert kwargs["Overwrite"] is False
+
+    def test_refuses_to_mint_without_kms_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CQ_ENTERPRISE_ROOT_BOOTSTRAP", "true")
+        # No kms key id.
+        client = mock.Mock()
+        client.get_parameter.side_effect = RuntimeError("ParameterNotFound")
+        monkeypatch.setattr(enterprise_root, "_get_ssm_client", lambda: client)
+        assert runtime.bootstrap_root_if_needed() is False
+        client.put_parameter.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# is_first_deploy_runtime — replaces the static env hardcode.
+# ---------------------------------------------------------------------------
+
+
+class TestIsFirstDeployRuntime:
+    def test_no_seed_url_means_first_deploy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("CQ_AIGRP_SEED_PEER_URL", raising=False)
+        assert runtime.is_first_deploy_runtime() is True
+
+    def test_seed_url_means_not_first_deploy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CQ_AIGRP_SEED_PEER_URL", "http://seed.example/")
+        assert runtime.is_first_deploy_runtime() is False
+
+    def test_legacy_env_overrides_runtime(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Even with a seed, the legacy override wins.
+        monkeypatch.setenv("CQ_AIGRP_SEED_PEER_URL", "http://seed.example/")
+        monkeypatch.setenv("CQ_AIGRP_IS_FIRST_DEPLOY", "true")
+        assert runtime.is_first_deploy_runtime() is True
+
+
+# ---------------------------------------------------------------------------
+# aigrp_enabled — Phase 1.0d makes Enterprise root sufficient.
+# ---------------------------------------------------------------------------
+
+
+class TestAigrpEnabled:
+    def test_enabled_with_legacy_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CQ_AIGRP_PEER_KEY", "anything")
+        assert _legacy.aigrp_enabled() is True
+
+    def test_enabled_with_only_root_present(self, monkeypatch: pytest.MonkeyPatch, fake_root: bytes) -> None:
+        # No legacy env, but SSM has the root.
+        _stub_root_in_ssm(monkeypatch, fake_root)
+        assert _legacy.aigrp_enabled() is True
+
+    def test_disabled_when_neither_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = mock.Mock()
+        client.get_parameter.side_effect = RuntimeError("ParameterNotFound")
+        monkeypatch.setattr(enterprise_root, "_get_ssm_client", lambda: client)
+        assert _legacy.aigrp_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# End-to-end pair derivation matches what envelope.py expects.
+# ---------------------------------------------------------------------------
+
+
+class TestEnvelopeIntegration:
+    def test_envelope_signed_one_side_verified_other_side(
+        self, monkeypatch: pytest.MonkeyPatch, fake_root: bytes
+    ) -> None:
+        """A signed/verified envelope cycle using runtime-derived secrets.
+
+        Decision 28 §1.6 — envelope HMAC uses the pair-secret. This test
+        proves runtime + envelope agree on the derivation, which is the
+        bigger-picture acceptance: an actual cross-L2 message round-trips.
+        """
+        from cq_server.aigrp import envelope
+
+        _stub_root_in_ssm(monkeypatch, fake_root)
+        envelope.reset_replay_cache_for_tests()
+
+        # Sender = engineering. Compute pair_secret directly via runtime.
+        monkeypatch.setenv("CQ_GROUP", "engineering")
+        runtime.invalidate_pair_cache()
+        sender_secret = runtime._pair_secret_for_peer("8th-layer-corp/sga")
+
+        env = envelope.sign_envelope(
+            pair_secret=sender_secret,
+            src_l2_id="8th-layer-corp/engineering",
+            dst_l2_id="8th-layer-corp/sga",
+            payload={"hello": "world"},
+        )
+
+        # Receiver = sga. Derive its view of the pair-secret independently.
+        monkeypatch.setenv("CQ_GROUP", "sga")
+        runtime.invalidate_pair_cache()
+        receiver_secret = runtime._pair_secret_for_peer("8th-layer-corp/engineering")
+
+        # The two sides MUST agree on the secret.
+        assert sender_secret == receiver_secret
+
+        payload = envelope.verify_envelope(
+            envelope=env,
+            pair_secret=receiver_secret,
+            expected_dst_l2_id="8th-layer-corp/sga",
+        )
+        assert payload == {"hello": "world"}


### PR DESCRIPTION
## Summary

Phase 1.0d closes the gap surfaced after Phase 1.0b (#177): enterprise_root + pair_secret libraries shipped, but no production caller. Two L2s under the same Enterprise still had different per-stack `CQ_AIGRP_PEER_KEY` values from per-L2 Secrets Manager — cross-L2 wire auth failed even with valid xgroup_consent grants.

This PR wires the runtime end-to-end:

- **New `cq_server.aigrp.runtime` module:**
  - `derive_bearer_token(peer_l2_id)` / `verify_bearer_against_peer(peer_l2_id, presented)` — HKDF-derived per-pair Authorization bearer (HMAC-SHA256 over a versioned constant under the pair-secret). Both sides compute the same value because `pair_secret` derivation is lex-canonical.
  - `bootstrap_root_if_needed()` — first-boot helper. `CQ_ENTERPRISE_ROOT_BOOTSTRAP=true` on the genesis L2 mints a 32-byte random root + PUTs to SSM; idempotent on subsequent boots. Default `false`.
  - `is_first_deploy_runtime()` — replaces the static `CQ_AIGRP_IS_FIRST_DEPLOY` env with a runtime determination (no seed peer URL = genesis).
  - 5-min in-process pair-secret cache, matched to `enterprise_root` cache TTL.

- **`aigrp._legacy.require_peer_key` is now dual-mode:** tries pair-secret bearer first (gated on `X-8L-Forwarder-L2-Id` header declaring the same Enterprise), falls back to legacy `CQ_AIGRP_PEER_KEY` for cross-Enterprise callers (aggregator) + the cutover window.

- **`consults.py` + `app.py` outbound calls** derive the per-target bearer when the target is an intra-Enterprise sibling; legacy bearer otherwise. `app.py` lifespan calls `bootstrap_root_if_needed` at startup.

- **`enterprise_root.py`** honours an optional `CQ_ENTERPRISE_ROOT_SSM_PATH` override for unusual SSM hierarchies.

## Companion PR

- **OneZero1ai/8th-layer**: `chore(deploy): customer-l2 Phase 1.0d AIGRP runtime parameters (#178)` — drops `CQ_AIGRP_PEER_KEY` Secret + `CQ_AIGRP_IS_FIRST_DEPLOY` hardcode, adds `EnterpriseRootSsmPath` / `EnterpriseRootKmsKeyId` / `EnterpriseRootBootstrap` / `AutoApprovePolicy` / `DirectorySkipAnnounce` parameters, scoped IAM. **Merge order: this PR first (image), template second.**

## Acceptance

1. `8th-layer-corp/engineering` and `/sga` (live as of 2026-05-09) — when both run the new image — derive the same pair-secret regardless of which side computes. Covered by `TestSymmetricDerivation` + `TestEnvelopeIntegration`.
2. xgroup_consent grant signed by both admins → engineering reads sga's granted KU domain via AIGRP forward-query, with HMAC envelope auth using the derived pair-secret. Envelope integration test in `TestEnvelopeIntegration`.
3. Existing per-stack `CQ_AIGRP_PEER_KEY` Secrets Manager values become orphan after both PRs roll out — flagged for cleanup follow-up; this PR does NOT delete them so the operator can audit first.
4. customer-l2.yaml lints clean (cfn-lint), see companion PR.

## Tests

- `tests/test_aigrp_runtime.py`: 25 new tests
  - `TestSymmetricDerivation` — both sides agree on bearer, different pairs differ, self-pair refused.
  - `TestVerify` — round-trip, tampered bearer rejected, empty inputs, SSM failure → False (fail-closed).
  - `TestRequirePeerKey` — pair-secret accepted, legacy accepted, invalid rejected, missing auth, neither configured (503), pair-secret failure falls through to legacy, cross-Enterprise falls through.
  - `TestBootstrap` — disabled / already-present / mints / refuses-without-kms-key.
  - `TestIsFirstDeployRuntime` — no-seed/seed/legacy-override.
  - `TestAigrpEnabled` — legacy env / root-only / neither.
  - `TestEnvelopeIntegration` — runtime-derived secret round-trips through `aigrp.envelope`.
- `tests/test_aigrp_enterprise_root.py`: 3 new for SSM path override.
- **Full pytest run: 762 passed, 5 skipped, 0 failures** (excluding 1 pre-existing `test_migration_0015_aigrp_peers_pair_secret_ref` head-revision assertion that's stale on `origin/main` — verified by stashing changes and re-running).

## Self-review (8l-reviewer checklist)

8l-reviewer subagent isn't invocable from inside the session; performed self-review against the checklist:

- HMAC integrity — `hmac.compare_digest` for constant-time compare; `pair_secret` HKDF unmodified.
- Self-pair refused — `_pair_secret_for_peer` raises ValueError when `peer_l2_id == self_id`.
- Cross-Enterprise leak — `require_peer_key` only attempts pair-secret when `declared_enterprise == enterprise()`.
- Forwarder header spoof — bearer derivation uses sender's claimed L2 id; attacker w/o pair_secret can't compute correct bearer for any claimed identity.
- Cache poisoning — pair_secret cache keyed by `(self_enterprise, peer_l2_id)`; no external write path.
- Fail-closed — `verify_bearer_against_peer` returns False on any SSM/KMS error; sender side falls through to legacy (graceful degrade).
- Error info leak — exception strings logged but not returned to client.
- Bootstrap mint race — `overwrite=False` on PUT; second simultaneous bootstrap raises ParameterAlreadyExists, helper logs + continues.

## Decision 28 ambiguities resolved

1. **Bearer derivation shape**: Decision 28 spells out HMAC for the *envelope* but doesn't pin a transport-bearer shape. Chose `HMAC(pair_secret, "aigrp-bearer-v1")` — direction-symmetric, minimal complexity, sufficient under TLS + envelope auth on payload-bearing endpoints. **Operator awareness**: alternative is `(method, path, ts, src_l2_id)` MAC for stronger replay properties; current shape relies on TLS for replay protection on the bearer itself. Envelope replay-cache covers payload-bearing endpoints separately.
2. **`is_first_deploy` semantics**: brief said "let runtime determine via SSM lookup". But SSM presence is true on every L2 after the genesis bootstrap — second L2 finds the root present too. Genuine semantic is "no seed peer URL configured". Documented in module docstring + tests cover.
3. **Bootstrap KMS key id provisioning**: required `CQ_ENTERPRISE_ROOT_KMS_KEY_ID` env at bootstrap time; companion template plumbs it through. Decision 28 says CMK is operator-provisioned — runtime never creates KMS keys.

## Risk per change

- `aigrp/runtime.py` (NEW) — new auth path, comprehensive test coverage, fail-closed semantics. **Low risk** behind dual-mode fallback.
- `aigrp/_legacy.py:require_peer_key` (rewrite) — accepts legacy bearer unchanged; pair-secret path only triggers on intra-Enterprise forwarder header. **Low risk** during cutover; legacy still works.
- `consults.py:_bearer_for_target` (NEW) — derives per-target bearer; falls back to legacy on failure. **Low risk**.
- `app.py:_aigrp_outbound_bearer` (NEW) — same fall-through. **Low risk**.
- `enterprise_root.py:_param_path` (override) — additive; default unchanged. **Negligible risk**.

## Test plan

- [ ] CI green on this PR
- [ ] Companion PR (template) lints clean (cfn-lint runs locally clean)
- [ ] After merge: deploy new image to one of the two `8th-layer-corp` L2 stacks (engineering OR sga); confirm AIGRP poll loop accepts the new bearer (sibling on old image still authenticates via legacy fallback)
- [ ] After both stacks redeployed: confirm forward-query between engineering and sga succeeds end-to-end
- [ ] Operator audits + deletes orphan `CQ_AIGRP_PEER_KEY` Secrets Manager values (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)