### PR TITLE
feat(frontend): personas directory + per-persona detail (#170)

### DIFF
--- a/server/frontend/src/App.tsx
+++ b/server/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { ApiKeysPage } from "./pages/ApiKeysPage"
 import { DashboardPage } from "./pages/DashboardPage"
 import { LoginPage } from "./pages/LoginPage"
 import { NetworkPage } from "./pages/NetworkPage"
+import { PersonasPage } from "./pages/PersonasPage"
 import { ReviewPage } from "./pages/ReviewPage"
 
 function AppRoutes() {
@@ -28,6 +29,7 @@ function AppRoutes() {
         <Route path="/review" element={<ReviewPage />} />
         <Route path="/dashboard" element={<DashboardPage />} />
         <Route path="/network" element={<NetworkPage />} />
+        <Route path="/personas" element={<PersonasPage />} />
         <Route path="/settings/api-keys" element={<ApiKeysPage />} />
       </Route>
       <Route path="*" element={<Navigate to="/review" replace />} />

--- a/server/frontend/src/api.ts
+++ b/server/frontend/src/api.ts
@@ -1,4 +1,5 @@
 import type {
+  ActivityListResponse,
   ApiKeysList,
   CreatedApiKey,
   MessageResponse,
@@ -123,6 +124,32 @@ export const api = {
 
   revokeApiKey: (id: string) =>
     request<MessageResponse>(`/auth/api-keys/${id}/revoke`, { method: "POST" }),
+
+  // Activity-log read. Used for the per-persona timeline AND, in the
+  // absence of a dedicated /admin/personas endpoint, the directory
+  // listing itself (we group by persona in the client). When the
+  // backend ships a denormalised personas read, this stays for the
+  // timeline and the listing switches to the new endpoint.
+  listActivity: (
+    params: {
+      persona?: string
+      since?: string
+      until?: string
+      event_type?: string
+      limit?: number
+      cursor?: string
+    } = {},
+  ) => {
+    const qs = new URLSearchParams()
+    if (params.persona) qs.set("persona", params.persona)
+    if (params.since) qs.set("since", params.since)
+    if (params.until) qs.set("until", params.until)
+    if (params.event_type) qs.set("event_type", params.event_type)
+    if (params.limit != null) qs.set("limit", String(params.limit))
+    if (params.cursor) qs.set("cursor", params.cursor)
+    const query = qs.toString()
+    return request<ActivityListResponse>(`/activity${query ? `?${query}` : ""}`)
+  },
 }
 
 export { ApiError }

--- a/server/frontend/src/components/Layout.tsx
+++ b/server/frontend/src/components/Layout.tsx
@@ -62,6 +62,7 @@ export function Layout() {
             {navLink("/review", "Review")}
             {navLink("/dashboard", "Dashboard")}
             {navLink("/network", "Network")}
+            {navLink("/personas", "Personas")}
             {navLink("/settings/api-keys", "API Keys")}
           </div>
           <div className="flex items-center gap-4">

--- a/server/frontend/src/components/PersonaDetailDrawer.tsx
+++ b/server/frontend/src/components/PersonaDetailDrawer.tsx
@@ -1,0 +1,693 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Per-persona detail drawer (#170). Side drawer pattern matching the
+// existing review/api-keys flow — slides in from the right, click
+// outside or Esc to close.
+//
+// Sections (top to bottom):
+//   - Identity (AAISN-scoped name, joined, last seen sparkline)
+//   - Activity timeline (filterable, paginated)
+//   - KU contributions (totals, per-domain breakdown, confidence histo)
+//   - Sessions / API keys (V1: backend gap surfaced inline)
+//   - Lifecycle events (V1: backend gap — derived from activity)
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { api } from "../api"
+import type {
+  ActivityRow,
+  PersonaStatus,
+  PersonaSummary,
+  ReviewItem,
+} from "../types"
+import { timeAgo } from "../utils"
+
+const TIMELINE_PAGE_LIMIT = 50
+const SPARKLINE_DAYS = 30
+
+// [label, color-token] tuples. Combined to keep the bundle slim — one
+// table instead of two parallel objects. Fallbacks: raw event_type +
+// neutral ink-mute when an unknown event_type appears.
+const EVENT_META: Record<string, [string, string]> = {
+  query: ["Queried", "var(--ink-mute)"],
+  propose: ["Proposed", "var(--cyan)"],
+  confirm: ["Confirmed", "var(--emerald)"],
+  flag: ["Flagged", "var(--rose)"],
+  review_start: ["Review started", "var(--gold)"],
+  review_resolve: ["Review resolved", "var(--emerald)"],
+  crosstalk_send: ["Crosstalk sent", "var(--violet)"],
+  crosstalk_reply: ["Crosstalk reply", "var(--violet)"],
+  crosstalk_close: ["Crosstalk closed", "var(--ink-mute)"],
+  consult_open: ["Consult opened", "var(--cyan)"],
+  consult_reply: ["Consult reply", "var(--cyan)"],
+  consult_close: ["Consult closed", "var(--ink-mute)"],
+}
+
+function statusBadgeClasses(status: PersonaStatus): string {
+  switch (status) {
+    case "active":
+      return "bg-[color-mix(in_srgb,var(--emerald)_14%,transparent)] text-[var(--emerald)] border border-[color-mix(in_srgb,var(--emerald)_30%,transparent)]"
+    case "idle":
+      return "bg-[color-mix(in_srgb,var(--gold)_14%,transparent)] text-[var(--gold)] border border-[color-mix(in_srgb,var(--gold)_28%,transparent)]"
+    case "departed":
+      return "bg-[var(--surface-hover)] text-[var(--ink-mute)] border border-[var(--rule-strong)]"
+    case "suspended":
+      return "bg-[color-mix(in_srgb,var(--rose)_14%,transparent)] text-[var(--rose)] border border-[color-mix(in_srgb,var(--rose)_30%,transparent)]"
+  }
+}
+
+// Render a 30-day cyan sparkline from the persona's activity rows.
+// Each bar = 1px wide, height = log-scaled count for that day.
+function ActivitySparkline({ rows }: { rows: ActivityRow[] }) {
+  const buckets = useMemo(() => {
+    const now = Date.now()
+    const day = 86_400_000
+    const arr = new Array<number>(SPARKLINE_DAYS).fill(0)
+    for (const row of rows) {
+      const ageDays = Math.floor((now - new Date(row.ts).getTime()) / day)
+      if (ageDays < 0 || ageDays >= SPARKLINE_DAYS) continue
+      const idx = SPARKLINE_DAYS - 1 - ageDays
+      arr[idx] += 1
+    }
+    return arr
+  }, [rows])
+
+  const max = Math.max(1, ...buckets)
+  const todayCount = buckets[SPARKLINE_DAYS - 1]
+  const hasActivity = buckets.some((c) => c > 0)
+
+  return (
+    <div className="flex items-end gap-px h-10" aria-hidden="true">
+      {buckets.map((count, i) => {
+        const isToday = i === SPARKLINE_DAYS - 1
+        const heightPct =
+          count === 0 ? 4 : Math.max(8, Math.round((count / max) * 100))
+        return (
+          <div
+            // biome-ignore lint/suspicious/noArrayIndexKey: positional sparkline bar
+            key={i}
+            className={`w-px ${isToday && todayCount > 0 ? "bg-[var(--gold)]" : count > 0 ? "bg-[var(--cyan)]" : "bg-[var(--rule-strong)]"}`}
+            style={{ height: `${heightPct}%` }}
+          />
+        )
+      })}
+      <span className="ml-2 self-center font-mono-brand text-[10px] uppercase tracking-[0.16em] text-[var(--ink-mute)]">
+        {hasActivity ? `${SPARKLINE_DAYS}d` : "no activity"}
+      </span>
+    </div>
+  )
+}
+
+function ConfidenceHistogram({ units }: { units: ReviewItem[] }) {
+  const buckets = useMemo(() => {
+    const b = { low: 0, mid: 0, high: 0, top: 0 }
+    for (const u of units) {
+      const c = u.knowledge_unit.evidence.confidence
+      if (c < 0.3) b.low += 1
+      else if (c < 0.6) b.mid += 1
+      else if (c < 0.8) b.high += 1
+      else b.top += 1
+    }
+    return b
+  }, [units])
+
+  const total = units.length
+  if (total === 0) {
+    return (
+      <p className="text-sm text-[var(--ink-mute)]">No KUs to histogram yet.</p>
+    )
+  }
+
+  const rows = [
+    {
+      label: "0.0–0.3",
+      count: buckets.low,
+      bar: "bg-[color-mix(in_srgb,var(--rose)_55%,transparent)]",
+    },
+    {
+      label: "0.3–0.6",
+      count: buckets.mid,
+      bar: "bg-[color-mix(in_srgb,var(--gold)_55%,transparent)]",
+    },
+    {
+      label: "0.6–0.8",
+      count: buckets.high,
+      bar: "bg-[color-mix(in_srgb,var(--emerald)_45%,transparent)]",
+    },
+    {
+      label: "0.8–1.0",
+      count: buckets.top,
+      bar: "bg-[var(--emerald)]",
+    },
+  ]
+  const max = Math.max(1, ...rows.map((r) => r.count))
+
+  return (
+    <div className="space-y-1.5">
+      {rows.map((r) => (
+        <div key={r.label} className="flex items-center gap-3">
+          <span className="w-16 font-mono-brand text-[10px] uppercase tracking-[0.16em] text-[var(--ink-mute)]">
+            {r.label}
+          </span>
+          <div className="flex-1 h-2 rounded-full bg-[var(--surface-hover)] overflow-hidden">
+            <div
+              className={`h-full ${r.bar}`}
+              style={{ width: `${(r.count / max) * 100}%` }}
+            />
+          </div>
+          <span className="w-8 text-right font-mono-brand tabular-nums text-[11px] text-[var(--ink-dim)]">
+            {r.count}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+interface DomainBreakdownProps {
+  units: ReviewItem[]
+}
+
+function DomainBreakdown({ units }: DomainBreakdownProps) {
+  const counts = useMemo(() => {
+    const map = new Map<string, number>()
+    for (const u of units) {
+      for (const d of u.knowledge_unit.domains) {
+        map.set(d, (map.get(d) ?? 0) + 1)
+      }
+    }
+    return Array.from(map.entries()).sort((a, b) => b[1] - a[1])
+  }, [units])
+
+  if (counts.length === 0) {
+    return (
+      <p className="text-sm text-[var(--ink-mute)]">
+        No domains tagged on this persona's KUs.
+      </p>
+    )
+  }
+
+  return (
+    <table className="w-full text-sm">
+      <thead className="border-b border-[var(--rule)]">
+        <tr>
+          <th
+            scope="col"
+            className="text-left py-1.5 font-mono-brand text-[10px] uppercase tracking-[0.18em] text-[var(--ink-mute)]"
+          >
+            Domain
+          </th>
+          <th
+            scope="col"
+            className="text-right py-1.5 font-mono-brand text-[10px] uppercase tracking-[0.18em] text-[var(--ink-mute)]"
+          >
+            KUs
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {counts.map(([domain, count]) => (
+          <tr key={domain} className="border-t border-[var(--rule)]">
+            <td className="py-1.5 font-mono-brand text-[11px] uppercase tracking-[0.14em] text-[var(--violet)]">
+              {domain}
+            </td>
+            <td className="py-1.5 text-right font-mono-brand tabular-nums text-[var(--ink-dim)]">
+              {count}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+interface ActivityTimelineProps {
+  persona: string
+}
+
+function ActivityTimeline({ persona }: ActivityTimelineProps) {
+  const [rows, setRows] = useState<ActivityRow[]>([])
+  const [cursor, setCursor] = useState<string | null>(null)
+  const [hasMore, setHasMore] = useState(true)
+  const [loading, setLoading] = useState(false)
+  const [filter, setFilter] = useState<string>("all")
+
+  // Initial-load effect: reset state and pull the first page whenever
+  // the persona changes. Inlined fetch (rather than a useCallback)
+  // avoids the depend-on-cursor / re-trigger-on-cursor-change loop.
+  useEffect(() => {
+    let cancelled = false
+    setRows([])
+    setCursor(null)
+    setHasMore(true)
+    setLoading(true)
+    api
+      .listActivity({ persona, limit: TIMELINE_PAGE_LIMIT })
+      .then((resp) => {
+        if (cancelled) return
+        setRows(resp.items)
+        setCursor(resp.next_cursor)
+        setHasMore(resp.next_cursor !== null)
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [persona])
+
+  // "Load more" — uses the latest cursor closure. Distinct from the
+  // initial-load effect so that effect doesn't loop on cursor changes.
+  const loadMore = useCallback(async () => {
+    if (cursor === null) return
+    setLoading(true)
+    try {
+      const resp = await api.listActivity({
+        persona,
+        limit: TIMELINE_PAGE_LIMIT,
+        cursor,
+      })
+      setRows((prev) => [...prev, ...resp.items])
+      setCursor(resp.next_cursor)
+      setHasMore(resp.next_cursor !== null)
+    } finally {
+      setLoading(false)
+    }
+  }, [persona, cursor])
+
+  const filtered = useMemo(() => {
+    if (filter === "all") return rows
+    return rows.filter((r) => r.event_type === filter)
+  }, [rows, filter])
+
+  const eventTypesPresent = useMemo(() => {
+    const set = new Set(rows.map((r) => r.event_type))
+    return Array.from(set).sort()
+  }, [rows])
+
+  return (
+    <div className="space-y-3">
+      {eventTypesPresent.length > 1 && (
+        <div className="flex flex-wrap gap-1.5">
+          <button
+            type="button"
+            onClick={() => setFilter("all")}
+            className={`rounded-full px-2.5 py-0.5 font-mono-brand text-[10px] uppercase tracking-[0.14em] border transition-colors ${
+              filter === "all"
+                ? "bg-[color-mix(in_srgb,var(--cyan)_22%,transparent)] text-[var(--cyan)] border-[color-mix(in_srgb,var(--cyan)_45%,transparent)]"
+                : "text-[var(--ink-dim)] border-[var(--rule-strong)] hover:bg-[var(--surface-hover)]"
+            }`}
+          >
+            All
+          </button>
+          {eventTypesPresent.map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setFilter(t)}
+              className={`rounded-full px-2.5 py-0.5 font-mono-brand text-[10px] uppercase tracking-[0.14em] border transition-colors ${
+                filter === t
+                  ? "bg-[color-mix(in_srgb,var(--cyan)_22%,transparent)] text-[var(--cyan)] border-[color-mix(in_srgb,var(--cyan)_45%,transparent)]"
+                  : "text-[var(--ink-dim)] border-[var(--rule-strong)] hover:bg-[var(--surface-hover)]"
+              }`}
+            >
+              {EVENT_META[t]?.[0] ?? t}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {filtered.length === 0 && !loading ? (
+        <p className="text-sm text-[var(--ink-mute)]">
+          No activity events recorded for this persona.
+        </p>
+      ) : (
+        <ol className="space-y-2 border-l border-[var(--rule-strong)] pl-4">
+          {filtered.map((row) => {
+            const meta = EVENT_META[row.event_type]
+            const label = meta?.[0] ?? row.event_type
+            const color = meta?.[1] ?? "var(--ink-mute)"
+            return (
+              <li key={row.id} className="relative">
+                <span
+                  aria-hidden="true"
+                  className="absolute -left-[21px] top-1.5 h-2 w-2 rounded-full"
+                  style={{ background: color }}
+                />
+                <div className="flex items-baseline gap-2 flex-wrap">
+                  <span
+                    className="font-mono-brand text-[10px] uppercase tracking-[0.16em]"
+                    style={{ color }}
+                  >
+                    {label}
+                  </span>
+                  <span
+                    className="font-mono-brand text-[10px] text-[var(--ink-mute)]"
+                    title={new Date(row.ts).toLocaleString()}
+                  >
+                    {timeAgo(row.ts)}
+                  </span>
+                  {row.thread_or_chain_id && (
+                    <code className="rounded bg-[var(--surface-hover)] border border-[var(--rule)] px-1.5 py-0.5 font-mono-brand text-[10px] text-[var(--ink-mute)]">
+                      {row.thread_or_chain_id.slice(0, 12)}…
+                    </code>
+                  )}
+                </div>
+                {row.payload && Object.keys(row.payload).length > 0 && (
+                  <p className="mt-0.5 text-xs text-[var(--ink-dim)] truncate">
+                    {summarisePayload(row.payload)}
+                  </p>
+                )}
+              </li>
+            )
+          })}
+        </ol>
+      )}
+
+      {hasMore && (
+        <button
+          type="button"
+          onClick={() => loadMore()}
+          disabled={loading}
+          className="rounded-md border border-[var(--rule-strong)] bg-[var(--surface)] px-3 py-1.5 font-mono-brand text-[10px] uppercase tracking-[0.18em] text-[var(--ink-dim)] hover:bg-[var(--surface-hover)] disabled:opacity-50 transition-all"
+        >
+          {loading ? "Loading…" : "Load more"}
+        </button>
+      )}
+    </div>
+  )
+}
+
+function summarisePayload(payload: Record<string, unknown>): string {
+  // Cheap human-readable rendering of the payload blob — keeps the
+  // timeline readable without a per-event-type renderer matrix.
+  const interesting = ["unit_id", "domain", "topic", "subject", "thread_id"]
+  for (const key of interesting) {
+    const v = payload[key]
+    if (typeof v === "string" && v) return `${key}: ${v}`
+  }
+  return Object.keys(payload).slice(0, 3).join(", ")
+}
+
+interface Props {
+  persona: PersonaSummary
+  units: ReviewItem[]
+  onClose: () => void
+}
+
+export function PersonaDetailDrawer({ persona, units, onClose }: Props) {
+  const [activityForSparkline, setActivityForSparkline] = useState<
+    ActivityRow[]
+  >([])
+
+  useEffect(() => {
+    let cancelled = false
+    api
+      .listActivity({ persona: persona.name, limit: 500 })
+      .then((resp) => {
+        if (!cancelled) setActivityForSparkline(resp.items)
+      })
+      .catch(() => {
+        // Sparkline is decorative; failure is non-fatal.
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [persona.name])
+
+  // Esc to close, mirrors the modal pattern in ApiKeysPage.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose()
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [onClose])
+
+  // Lifecycle events — V1 derives "joined" / "last_seen" from activity
+  // alone since lifecycle_events isn't surfaced through the read API
+  // yet. Keeps the section visible (operator expectation) but
+  // truthful about the limitation.
+  const lifecycleEvents = useMemo(() => {
+    const events: Array<{ kind: string; ts: string; detail: string }> = []
+    if (persona.joined) {
+      events.push({
+        kind: "joined",
+        ts: persona.joined,
+        detail: "First activity event recorded",
+      })
+    }
+    if (persona.status === "departed" && persona.last_seen) {
+      events.push({
+        kind: "departed",
+        ts: persona.last_seen,
+        detail: `No activity for ${Math.floor(
+          (Date.now() - new Date(persona.last_seen).getTime()) / 86_400_000,
+        )}d (derived)`,
+      })
+    }
+    return events
+  }, [persona])
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="persona-detail-heading"
+      className="fixed inset-0 z-30 flex justify-end"
+    >
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+      <button
+        type="button"
+        aria-label="Close persona detail"
+        className="flex-1 bg-black/65 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      <aside className="w-full max-w-xl overflow-y-auto bg-[var(--bg-via)] border-l border-[var(--rule-strong)] p-6 shadow-[0_0_80px_rgba(0,0,0,0.7)]">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="eyebrow">Persona</p>
+            <h2
+              id="persona-detail-heading"
+              className="font-display text-2xl text-[var(--ink)] mt-1 break-all"
+            >
+              {persona.name}
+            </h2>
+            <p className="mt-1 font-mono-brand text-[10px] uppercase tracking-[0.18em] text-[var(--ink-mute)]">
+              {persona.enterprise || "—"}
+              {persona.group ? ` / ${persona.group}` : ""} / {persona.name}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-[var(--rule-strong)] bg-[var(--surface)] px-3 py-1.5 font-mono-brand text-[10px] uppercase tracking-[0.18em] text-[var(--ink-dim)] hover:bg-[var(--surface-hover)] transition-colors"
+          >
+            Close
+          </button>
+        </div>
+
+        {/* Identity panel. */}
+        <section className="mt-6 brand-surface-raised p-5 space-y-4">
+          <div className="grid grid-cols-2 gap-4 text-sm">
+            <div>
+              <p className="eyebrow">Status</p>
+              <span
+                className={`mt-1 inline-flex items-center rounded-full px-2 py-0.5 font-mono-brand text-[10px] uppercase tracking-[0.16em] ${statusBadgeClasses(
+                  persona.status,
+                )}`}
+              >
+                {persona.status}
+              </span>
+            </div>
+            <div>
+              <p className="eyebrow">Joined</p>
+              <p
+                className="mt-1 text-[var(--ink-dim)]"
+                title={
+                  persona.joined
+                    ? new Date(persona.joined).toLocaleString()
+                    : ""
+                }
+              >
+                {persona.joined ? timeAgo(persona.joined) : "—"}
+              </p>
+            </div>
+            <div>
+              <p className="eyebrow">Last seen</p>
+              <p
+                className="mt-1 text-[var(--ink-dim)]"
+                title={
+                  persona.last_seen
+                    ? new Date(persona.last_seen).toLocaleString()
+                    : ""
+                }
+              >
+                {persona.last_seen ? timeAgo(persona.last_seen) : "never"}
+              </p>
+            </div>
+            <div>
+              <p className="eyebrow">KUs authored</p>
+              <p className="mt-1 font-mono-brand tabular-nums text-[var(--ink)]">
+                {units.length}
+              </p>
+            </div>
+          </div>
+          <div>
+            <p className="eyebrow mb-1.5">Activity (last 30d)</p>
+            <ActivitySparkline rows={activityForSparkline} />
+          </div>
+        </section>
+
+        {/* Activity timeline. */}
+        <section className="mt-6">
+          <p className="eyebrow">Timeline</p>
+          <h3 className="font-display text-lg text-[var(--ink)] mt-1">
+            Activity
+          </h3>
+          <div className="mt-3">
+            <ActivityTimeline persona={persona.name} />
+          </div>
+        </section>
+
+        {/* KU contributions. */}
+        <section className="mt-8">
+          <p className="eyebrow">Knowledge</p>
+          <h3 className="font-display text-lg text-[var(--ink)] mt-1">
+            KU contributions
+          </h3>
+          <div className="mt-3 grid gap-4 sm:grid-cols-2">
+            <div className="brand-surface p-4">
+              <p className="eyebrow">Total</p>
+              <p className="font-display font-light text-3xl text-[var(--cyan)] tabular-nums mt-1">
+                {units.length}
+              </p>
+            </div>
+            <div className="brand-surface p-4">
+              <p className="eyebrow">Tier split</p>
+              <div className="mt-1 grid grid-cols-2 gap-2 text-sm">
+                <div>
+                  <p className="font-mono-brand text-[10px] uppercase tracking-[0.16em] text-[var(--ink-mute)]">
+                    Promoted
+                  </p>
+                  <p className="font-mono-brand tabular-nums text-[var(--emerald)]">
+                    {
+                      units.filter((u) => u.knowledge_unit.tier !== "local")
+                        .length
+                    }
+                  </p>
+                </div>
+                <div>
+                  <p className="font-mono-brand text-[10px] uppercase tracking-[0.16em] text-[var(--ink-mute)]">
+                    Local-only
+                  </p>
+                  <p className="font-mono-brand tabular-nums text-[var(--ink-dim)]">
+                    {
+                      units.filter((u) => u.knowledge_unit.tier === "local")
+                        .length
+                    }
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="mt-4 brand-surface p-4">
+            <p className="eyebrow">Confidence distribution</p>
+            <div className="mt-2">
+              <ConfidenceHistogram units={units} />
+            </div>
+          </div>
+          <div className="mt-4 brand-surface p-4">
+            <p className="eyebrow">Domain breakdown</p>
+            <div className="mt-2">
+              <DomainBreakdown units={units} />
+            </div>
+          </div>
+          {units.length > 0 && (
+            <div className="mt-4 brand-surface p-4">
+              <p className="eyebrow">Top by confirmations</p>
+              <ul className="mt-2 space-y-1.5 text-sm">
+                {[...units]
+                  .sort(
+                    (a, b) =>
+                      b.knowledge_unit.evidence.confirmations -
+                      a.knowledge_unit.evidence.confirmations,
+                  )
+                  .slice(0, 5)
+                  .map((u) => (
+                    <li
+                      key={u.knowledge_unit.id}
+                      className="flex items-baseline justify-between gap-3"
+                    >
+                      <span className="truncate text-[var(--ink-dim)]">
+                        {u.knowledge_unit.insight.summary}
+                      </span>
+                      <span className="shrink-0 font-mono-brand tabular-nums text-[10px] uppercase tracking-[0.16em] text-[var(--emerald)]">
+                        {u.knowledge_unit.evidence.confirmations}×
+                      </span>
+                    </li>
+                  ))}
+              </ul>
+            </div>
+          )}
+        </section>
+
+        {/* Sessions / API keys. */}
+        <section className="mt-8">
+          <p className="eyebrow">Access</p>
+          <h3 className="font-display text-lg text-[var(--ink)] mt-1">
+            Sessions &amp; API keys
+          </h3>
+          <div className="mt-3 brand-surface p-4">
+            <p className="text-sm text-[var(--ink-dim)]">
+              Per-persona key enumeration requires the admin
+              <code className="mx-1 font-mono-brand text-[var(--cyan)]">
+                /admin/personas/&lt;name&gt;/api-keys
+              </code>
+              endpoint, which is not yet exposed. Tracked as a follow-up backend
+              issue.
+            </p>
+          </div>
+        </section>
+
+        {/* Lifecycle. */}
+        <section className="mt-8">
+          <p className="eyebrow">Lifecycle</p>
+          <h3 className="font-display text-lg text-[var(--ink)] mt-1">
+            Events
+          </h3>
+          {lifecycleEvents.length === 0 ? (
+            <p className="mt-3 text-sm text-[var(--ink-mute)]">
+              No lifecycle events derived yet.
+            </p>
+          ) : (
+            <ol className="mt-3 space-y-2 border-l border-[var(--rule-strong)] pl-4">
+              {lifecycleEvents.map((e) => (
+                <li key={`${e.kind}-${e.ts}`} className="relative">
+                  <span
+                    aria-hidden="true"
+                    className="absolute -left-[21px] top-1.5 h-2 w-2 rounded-full bg-[var(--violet)]"
+                  />
+                  <div className="flex items-baseline gap-2 flex-wrap">
+                    <span className="font-mono-brand text-[10px] uppercase tracking-[0.16em] text-[var(--violet)]">
+                      {e.kind}
+                    </span>
+                    <span
+                      className="font-mono-brand text-[10px] text-[var(--ink-mute)]"
+                      title={new Date(e.ts).toLocaleString()}
+                    >
+                      {timeAgo(e.ts)}
+                    </span>
+                  </div>
+                  <p className="mt-0.5 text-xs text-[var(--ink-dim)]">
+                    {e.detail}
+                  </p>
+                </li>
+              ))}
+            </ol>
+          )}
+        </section>
+      </aside>
+    </div>
+  )
+}

--- a/server/frontend/src/pages/PersonasPage.test.tsx
+++ b/server/frontend/src/pages/PersonasPage.test.tsx
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { PersonasPage } from "./PersonasPage"
+
+const originalFetch = globalThis.fetch
+
+type MockResponse = {
+  ok: boolean
+  status: number
+  body: unknown
+}
+
+// Tiny URL-routing harness — the page issues:
+//   GET /api/v1/activity?limit=500       (directory derivation)
+//   GET /api/v1/review/units             (KU joins, called twice)
+// The drawer also issues GET /api/v1/activity?persona=<name>&...
+// Match on URL substrings so call-order changes don't churn the test.
+function routeResponses(routes: Array<[RegExp, MockResponse]>) {
+  globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+    for (const [matcher, resp] of routes) {
+      if (matcher.test(url)) {
+        return Promise.resolve({
+          ok: resp.ok,
+          status: resp.status,
+          json: () => Promise.resolve(resp.body),
+        })
+      }
+    }
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ items: [], count: 0, next_cursor: null }),
+    })
+  }) as unknown as typeof fetch
+}
+
+const aliceRow = {
+  id: "act_001",
+  ts: "2026-05-08T12:00:00+00:00",
+  tenant_enterprise: "ent_8thlayer",
+  tenant_group: "engineering",
+  persona: "alice",
+  human: null,
+  event_type: "propose",
+  payload: { unit_id: "ku_001" },
+  result_summary: null,
+  thread_or_chain_id: null,
+}
+
+const bobRow = {
+  ...aliceRow,
+  id: "act_002",
+  ts: "2026-04-01T12:00:00+00:00",
+  persona: "bob",
+  tenant_group: "ops",
+}
+
+const aliceKu = {
+  knowledge_unit: {
+    id: "ku_001",
+    version: 1,
+    domains: ["lambda", "iam"],
+    insight: {
+      summary: "Lambda timeouts surface as 504",
+      detail: "...",
+      action: "...",
+    },
+    context: { languages: [], frameworks: [], pattern: "" },
+    evidence: {
+      confidence: 0.7,
+      confirmations: 3,
+      first_observed: "2026-05-01T00:00:00+00:00",
+      last_confirmed: "2026-05-07T00:00:00+00:00",
+    },
+    tier: "private",
+    created_by: "alice",
+    superseded_by: null,
+    flags: [],
+  },
+  status: "approved",
+  reviewed_by: "admin",
+  reviewed_at: "2026-05-02T00:00:00+00:00",
+}
+
+describe("PersonasPage", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    vi.restoreAllMocks()
+  })
+
+  it("renders the empty state when no activity rows exist", async () => {
+    routeResponses([
+      [
+        /\/activity/,
+        {
+          ok: true,
+          status: 200,
+          body: { items: [], count: 0, next_cursor: null },
+        },
+      ],
+      [/\/review\/units/, { ok: true, status: 200, body: [] }],
+    ])
+    render(<PersonasPage />)
+    expect(await screen.findByText(/no personas yet/i)).toBeInTheDocument()
+  })
+
+  it("derives a directory row per persona from activity", async () => {
+    routeResponses([
+      [
+        /\/activity/,
+        {
+          ok: true,
+          status: 200,
+          body: {
+            items: [aliceRow, bobRow],
+            count: 2,
+            next_cursor: null,
+          },
+        },
+      ],
+      [/\/review\/units/, { ok: true, status: 200, body: [aliceKu] }],
+    ])
+
+    render(<PersonasPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText("alice")).toBeInTheDocument()
+      expect(screen.getByText("bob")).toBeInTheDocument()
+    })
+    // KU count column — alice has one, bob has zero.
+    const aliceRowEl = screen.getByText("alice").closest("tr")
+    const bobRowEl = screen.getByText("bob").closest("tr")
+    expect(aliceRowEl?.textContent).toContain("1")
+    expect(bobRowEl?.textContent).toContain("0")
+  })
+
+  it("filters by search query against persona name", async () => {
+    routeResponses([
+      [
+        /\/activity/,
+        {
+          ok: true,
+          status: 200,
+          body: {
+            items: [aliceRow, bobRow],
+            count: 2,
+            next_cursor: null,
+          },
+        },
+      ],
+      [/\/review\/units/, { ok: true, status: 200, body: [] }],
+    ])
+
+    render(<PersonasPage />)
+    await screen.findByText("alice")
+    fireEvent.change(screen.getByLabelText(/search personas/i), {
+      target: { value: "ali" },
+    })
+    expect(screen.getByText("alice")).toBeInTheDocument()
+    expect(screen.queryByText("bob")).not.toBeInTheDocument()
+  })
+
+  it("opens the detail drawer when a row is clicked", async () => {
+    routeResponses([
+      [
+        /\/activity/,
+        {
+          ok: true,
+          status: 200,
+          body: {
+            items: [aliceRow],
+            count: 1,
+            next_cursor: null,
+          },
+        },
+      ],
+      [/\/review\/units/, { ok: true, status: 200, body: [aliceKu] }],
+    ])
+
+    render(<PersonasPage />)
+    const aliceCell = await screen.findByText("alice")
+    fireEvent.click(aliceCell)
+    // Drawer heading uses the persona name. Look for the AAISN-scoped
+    // path which only renders inside the drawer.
+    await waitFor(() => {
+      expect(
+        screen.getByText(/ent_8thlayer.*engineering.*alice/i),
+      ).toBeInTheDocument()
+    })
+    expect(screen.getByText(/KU contributions/i)).toBeInTheDocument()
+  })
+})

--- a/server/frontend/src/pages/PersonasPage.tsx
+++ b/server/frontend/src/pages/PersonasPage.tsx
@@ -1,0 +1,502 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Personas tab — directory + per-persona detail drawer (#170).
+//
+// V1 reads from existing endpoints only:
+//   - /activity  → timeline + persona derivation (group by persona)
+//   - /review/units → KU contributions (filtered client-side by created_by)
+//
+// A dedicated /admin/personas read is a follow-up backend issue
+// (denormalised summary; current approach is O(activity_rows) per page
+// load and accepts the cost for V1).
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { ApiError, api } from "../api"
+import { PersonaDetailDrawer } from "../components/PersonaDetailDrawer"
+import type {
+  ActivityRow,
+  PersonaStatus,
+  PersonaSummary,
+  ReviewItem,
+} from "../types"
+import { timeAgo } from "../utils"
+
+// Persona-derivation parameters. Pull a generous slice of recent
+// activity (admin scope: every persona within the Enterprise) and
+// fold into per-persona buckets. Empty result = empty-state render.
+const ACTIVITY_PAGE_LIMIT = 500
+
+// Derive status from last_seen freshness. The backend doesn't
+// surface a lifecycle status today; this is a client-side
+// approximation until the lifecycle_events table read lands.
+const IDLE_THRESHOLD_DAYS = 7
+const DEPARTED_THRESHOLD_DAYS = 60
+
+type SortKey = "last_seen" | "name" | "group" | "ku_count" | "joined"
+type SortDir = "asc" | "desc"
+
+function classifyStatus(lastSeen: string | null): PersonaStatus {
+  if (!lastSeen) return "departed"
+  const ageDays = (Date.now() - new Date(lastSeen).getTime()) / 86_400_000
+  if (ageDays > DEPARTED_THRESHOLD_DAYS) return "departed"
+  if (ageDays > IDLE_THRESHOLD_DAYS) return "idle"
+  return "active"
+}
+
+function statusBadgeClasses(status: PersonaStatus): string {
+  switch (status) {
+    case "active":
+      return "bg-[color-mix(in_srgb,var(--emerald)_14%,transparent)] text-[var(--emerald)] border border-[color-mix(in_srgb,var(--emerald)_30%,transparent)]"
+    case "idle":
+      return "bg-[color-mix(in_srgb,var(--gold)_14%,transparent)] text-[var(--gold)] border border-[color-mix(in_srgb,var(--gold)_28%,transparent)]"
+    case "departed":
+      return "bg-[var(--surface-hover)] text-[var(--ink-mute)] border border-[var(--rule-strong)]"
+    case "suspended":
+      return "bg-[color-mix(in_srgb,var(--rose)_14%,transparent)] text-[var(--rose)] border border-[color-mix(in_srgb,var(--rose)_30%,transparent)]"
+  }
+}
+
+// Build the persona directory by folding /activity rows + /review/units.
+// We pull KUs once and join on `created_by` rather than issuing one
+// request per persona — keeps page load O(1) HTTP calls.
+function derivePersonas(
+  activity: ActivityRow[],
+  units: ReviewItem[],
+): PersonaSummary[] {
+  const kuByPersona = new Map<string, number>()
+  for (const item of units) {
+    const author = item.knowledge_unit.created_by
+    if (!author) continue
+    kuByPersona.set(author, (kuByPersona.get(author) ?? 0) + 1)
+  }
+
+  type Bucket = {
+    name: string
+    enterprise: string
+    group: string | null
+    first: string
+    last: string
+  }
+  const buckets = new Map<string, Bucket>()
+  for (const row of activity) {
+    if (!row.persona) continue
+    const existing = buckets.get(row.persona)
+    if (!existing) {
+      buckets.set(row.persona, {
+        name: row.persona,
+        enterprise: row.tenant_enterprise,
+        group: row.tenant_group,
+        first: row.ts,
+        last: row.ts,
+      })
+      continue
+    }
+    if (row.ts < existing.first) existing.first = row.ts
+    if (row.ts > existing.last) existing.last = row.ts
+    // Last-write-wins on group; persona moves don't happen mid-life
+    // in practice but if they do, the most recent row is the source
+    // of truth.
+    if (row.tenant_group && !existing.group) existing.group = row.tenant_group
+  }
+
+  // Personas with KUs but no activity rows still merit a row in the
+  // directory (rare — but covers the case where a persona proposed
+  // before instrumentation landed and never came back).
+  for (const author of kuByPersona.keys()) {
+    if (buckets.has(author)) continue
+    buckets.set(author, {
+      name: author,
+      enterprise: "",
+      group: null,
+      first: "",
+      last: "",
+    })
+  }
+
+  return Array.from(buckets.values()).map((b) => ({
+    name: b.name,
+    group: b.group,
+    enterprise: b.enterprise,
+    status: classifyStatus(b.last || null),
+    joined: b.first || null,
+    last_seen: b.last || null,
+    ku_count: kuByPersona.get(b.name) ?? 0,
+    // No admin endpoint to enumerate per-persona keys; surfaces as
+    // "—" in the table until backend issue ships.
+    api_key_count: 0,
+  }))
+}
+
+function sortPersonas(
+  rows: PersonaSummary[],
+  key: SortKey,
+  dir: SortDir,
+): PersonaSummary[] {
+  const sorted = [...rows].sort((a, b) => {
+    let cmp = 0
+    switch (key) {
+      case "name":
+        cmp = a.name.localeCompare(b.name)
+        break
+      case "group":
+        cmp = (a.group ?? "").localeCompare(b.group ?? "")
+        break
+      case "ku_count":
+        cmp = a.ku_count - b.ku_count
+        break
+      case "joined":
+        cmp = (a.joined ?? "").localeCompare(b.joined ?? "")
+        break
+      case "last_seen":
+        cmp = (a.last_seen ?? "").localeCompare(b.last_seen ?? "")
+        break
+    }
+    return dir === "asc" ? cmp : -cmp
+  })
+  return sorted
+}
+
+function matchesSearch(
+  persona: PersonaSummary,
+  units: ReviewItem[],
+  query: string,
+): boolean {
+  if (query === "") return true
+  const needle = query.toLowerCase()
+  if (persona.name.toLowerCase().includes(needle)) return true
+  if ((persona.group ?? "").toLowerCase().includes(needle)) return true
+  // Domain search: any KU authored by this persona that tags the
+  // search term as a domain → match.
+  const personaUnits = units.filter(
+    (u) => u.knowledge_unit.created_by === persona.name,
+  )
+  return personaUnits.some((u) =>
+    u.knowledge_unit.domains.some((d) => d.toLowerCase().includes(needle)),
+  )
+}
+
+interface SortHeaderProps {
+  label: string
+  field: SortKey
+  active: SortKey
+  dir: SortDir
+  onSort: (field: SortKey) => void
+  align?: "left" | "right"
+}
+
+function SortHeader({
+  label,
+  field,
+  active,
+  dir,
+  onSort,
+  align = "left",
+}: SortHeaderProps) {
+  const isActive = active === field
+  return (
+    <button
+      type="button"
+      onClick={() => onSort(field)}
+      className={`group inline-flex items-center gap-1 font-mono-brand text-[10px] uppercase tracking-[0.18em] transition-colors ${
+        isActive ? "text-[var(--cyan)]" : "text-[var(--ink-mute)]"
+      } ${align === "right" ? "justify-end" : ""}`}
+    >
+      {label}
+      <span
+        aria-hidden="true"
+        className={`text-[8px] ${isActive ? "opacity-100" : "opacity-30 group-hover:opacity-60"}`}
+      >
+        {isActive && dir === "asc" ? "▲" : "▼"}
+      </span>
+    </button>
+  )
+}
+
+function formatTimestamp(iso: string | null): string {
+  if (!iso) return "—"
+  return new Date(iso).toLocaleString()
+}
+
+export function PersonasPage() {
+  const [activity, setActivity] = useState<ActivityRow[] | null>(null)
+  const [units, setUnits] = useState<ReviewItem[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [sortKey, setSortKey] = useState<SortKey>("last_seen")
+  const [sortDir, setSortDir] = useState<SortDir>("desc")
+  const [search, setSearch] = useState("")
+  const [statusFilter, setStatusFilter] = useState<PersonaStatus | "all">("all")
+  const [selectedPersona, setSelectedPersona] = useState<string | null>(null)
+
+  const loadDirectory = useCallback(async () => {
+    setError(null)
+    try {
+      // Pull activity (admin scope returns every persona). KUs in
+      // parallel — independent endpoints, no ordering dependency.
+      const [activityResp, unitsResp] = await Promise.all([
+        api.listActivity({ limit: ACTIVITY_PAGE_LIMIT }),
+        api.listUnits({}).catch((err) => {
+          // /review/units is admin-scoped; non-admins get 403. Degrade
+          // gracefully with an empty KU list rather than crashing the
+          // whole page — directory still renders from /activity alone.
+          if (err instanceof ApiError && err.status === 403) return []
+          throw err
+        }),
+      ])
+      setUnits(unitsResp)
+      setActivity(activityResp.items)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load personas")
+    }
+  }, [])
+
+  useEffect(() => {
+    loadDirectory()
+  }, [loadDirectory])
+
+  const personas = useMemo(() => {
+    if (!activity || !units) return null
+    return derivePersonas(activity, units)
+  }, [activity, units])
+
+  const filteredPersonas = useMemo(() => {
+    if (!personas) return null
+    let rows = personas
+    if (statusFilter !== "all") {
+      rows = rows.filter((p) => p.status === statusFilter)
+    }
+    if (search) {
+      rows = rows.filter((p) => matchesSearch(p, units ?? [], search))
+    }
+    return sortPersonas(rows, sortKey, sortDir)
+  }, [personas, statusFilter, search, sortKey, sortDir, units])
+
+  function onSort(field: SortKey) {
+    if (sortKey === field) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"))
+    } else {
+      setSortKey(field)
+      setSortDir("desc")
+    }
+  }
+
+  const personaCount = personas?.length ?? 0
+  const activeCount = personas?.filter((p) => p.status === "active").length ?? 0
+  const idleCount = personas?.filter((p) => p.status === "idle").length ?? 0
+  const departedCount =
+    personas?.filter((p) => p.status === "departed").length ?? 0
+
+  const personaUnits = useMemo(() => {
+    if (!units || !selectedPersona) return []
+    return units.filter((u) => u.knowledge_unit.created_by === selectedPersona)
+  }, [units, selectedPersona])
+
+  return (
+    <div className="space-y-8">
+      <section>
+        <p className="eyebrow">Identity</p>
+        <h1 className="font-display text-3xl text-[var(--ink)] mt-1">
+          Personas
+        </h1>
+        <p className="mt-3 text-sm text-[var(--ink-dim)] leading-relaxed max-w-prose">
+          Every persona that has registered with this L2. Status, last activity,
+          and knowledge contributions surface at a glance; click a row for the
+          full activity timeline and KU breakdown.
+        </p>
+      </section>
+
+      {error && (
+        <div className="rounded-xl border border-[color-mix(in_srgb,var(--rose)_40%,transparent)] bg-[color-mix(in_srgb,var(--rose)_10%,transparent)] p-4">
+          <p className="text-[var(--rose)] font-mono-brand text-[11px] uppercase tracking-[0.18em]">
+            {error}
+          </p>
+        </div>
+      )}
+
+      <section>
+        <div className="flex flex-wrap items-center gap-3">
+          <h2 className="shrink-0 font-display text-xl text-[var(--ink)]">
+            Directory
+            <span className="ml-3 font-mono-brand text-[11px] uppercase tracking-[0.18em] text-[var(--ink-mute)]">
+              {personaCount} {personaCount === 1 ? "persona" : "personas"}
+            </span>
+          </h2>
+          <fieldset
+            aria-label="Filter personas"
+            className="inline-flex shrink-0 overflow-hidden rounded-lg border border-[var(--rule-strong)] bg-[var(--surface)] text-sm"
+          >
+            {(
+              [
+                ["all", `All (${personaCount})`],
+                ["active", `Active (${activeCount})`],
+                ["idle", `Idle (${idleCount})`],
+                ["departed", `Departed (${departedCount})`],
+              ] as const
+            ).map(([value, label]) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setStatusFilter(value)}
+                aria-pressed={statusFilter === value}
+                className={`px-3 py-1.5 font-mono-brand text-[11px] uppercase tracking-[0.16em] transition-colors ${
+                  statusFilter === value
+                    ? "bg-[color-mix(in_srgb,var(--cyan)_22%,transparent)] text-[var(--cyan)]"
+                    : "text-[var(--ink-dim)] hover:bg-[var(--surface-hover)]"
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </fieldset>
+          <input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search persona, group, or KU domain…"
+            aria-label="Search personas"
+            className="brand-input min-w-40 flex-1 text-sm"
+          />
+        </div>
+
+        {filteredPersonas === null ? (
+          <p className="mt-4 text-sm text-[var(--ink-mute)]">Loading…</p>
+        ) : personas?.length === 0 ? (
+          <div className="mt-6 brand-surface flex flex-col items-center justify-center py-12 gap-3">
+            <span
+              aria-hidden="true"
+              className="font-display text-3xl text-[var(--ink-faint)]"
+            >
+              ∅
+            </span>
+            <span className="eyebrow text-[var(--cyan)]">No personas yet</span>
+            <span className="text-sm text-[var(--ink-mute)]">
+              Personas will appear here once they register and emit their first
+              activity event.
+            </span>
+          </div>
+        ) : filteredPersonas.length === 0 ? (
+          <p className="mt-4 text-sm text-[var(--ink-mute)]">
+            No personas match the current filter.
+          </p>
+        ) : (
+          <div className="mt-4 overflow-hidden rounded-xl border border-[var(--rule)] bg-[var(--surface-raised)]">
+            <table className="w-full text-sm">
+              <thead className="border-b border-[var(--rule)] bg-[color-mix(in_srgb,var(--bg-from)_40%,transparent)]">
+                <tr>
+                  <th scope="col" className="px-4 py-3 text-left">
+                    <SortHeader
+                      label="Persona"
+                      field="name"
+                      active={sortKey}
+                      dir={sortDir}
+                      onSort={onSort}
+                    />
+                  </th>
+                  <th scope="col" className="px-4 py-3 text-left">
+                    <SortHeader
+                      label="Group"
+                      field="group"
+                      active={sortKey}
+                      dir={sortDir}
+                      onSort={onSort}
+                    />
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-4 py-3 text-left font-mono-brand text-[10px] uppercase tracking-[0.18em] text-[var(--ink-mute)]"
+                  >
+                    Status
+                  </th>
+                  <th scope="col" className="px-4 py-3 text-left">
+                    <SortHeader
+                      label="Last seen"
+                      field="last_seen"
+                      active={sortKey}
+                      dir={sortDir}
+                      onSort={onSort}
+                    />
+                  </th>
+                  <th scope="col" className="px-4 py-3 text-right">
+                    <SortHeader
+                      label="KUs"
+                      field="ku_count"
+                      active={sortKey}
+                      dir={sortDir}
+                      onSort={onSort}
+                      align="right"
+                    />
+                  </th>
+                  <th scope="col" className="px-4 py-3 text-left">
+                    <SortHeader
+                      label="Joined"
+                      field="joined"
+                      active={sortKey}
+                      dir={sortDir}
+                      onSort={onSort}
+                    />
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredPersonas.map((p) => (
+                  <tr
+                    key={p.name}
+                    className="border-t border-[var(--rule)] hover:bg-[var(--surface-hover)] cursor-pointer transition-colors"
+                    onClick={() => setSelectedPersona(p.name)}
+                  >
+                    <td className="px-4 py-3">
+                      <button
+                        type="button"
+                        className="font-display text-base text-[var(--ink)] hover:text-[var(--cyan)] transition-colors text-left"
+                      >
+                        {p.name}
+                      </button>
+                    </td>
+                    <td className="px-4 py-3 font-mono-brand text-[11px] uppercase tracking-[0.14em] text-[var(--ink-dim)]">
+                      {p.group ?? "—"}
+                    </td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`inline-flex items-center rounded-full px-2 py-0.5 font-mono-brand text-[10px] uppercase tracking-[0.16em] ${statusBadgeClasses(
+                          p.status,
+                        )}`}
+                      >
+                        {p.status}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3">
+                      <span
+                        className="text-[var(--ink-dim)]"
+                        title={formatTimestamp(p.last_seen)}
+                      >
+                        {p.last_seen ? timeAgo(p.last_seen) : "never"}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-right font-mono-brand tabular-nums text-[var(--ink)]">
+                      {p.ku_count}
+                    </td>
+                    <td
+                      className="px-4 py-3 text-[var(--ink-mute)]"
+                      title={formatTimestamp(p.joined)}
+                    >
+                      {p.joined ? timeAgo(p.joined) : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {selectedPersona && personas?.find((p) => p.name === selectedPersona) && (
+        <PersonaDetailDrawer
+          persona={
+            personas.find((p) => p.name === selectedPersona) as PersonaSummary
+          }
+          units={personaUnits}
+          onClose={() => setSelectedPersona(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/server/frontend/src/types.ts
+++ b/server/frontend/src/types.ts
@@ -109,3 +109,43 @@ export interface ApiKeysList {
 export interface MessageResponse {
   message: string
 }
+
+// Activity log row — wire shape mirrors backend ActivityRow in
+// activity_routes.py. Used both directly (timeline view) and as the
+// source-of-truth for deriving the persona directory in the absence of
+// a dedicated /admin/personas endpoint.
+export interface ActivityRow {
+  id: string
+  ts: string
+  tenant_enterprise: string
+  tenant_group: string | null
+  persona: string | null
+  human: string | null
+  event_type: string
+  payload: Record<string, unknown>
+  result_summary: Record<string, unknown> | null
+  thread_or_chain_id: string | null
+}
+
+export interface ActivityListResponse {
+  items: ActivityRow[]
+  count: number
+  next_cursor: string | null
+}
+
+// Derived persona summary — assembled client-side from /activity rows
+// and (optionally) /review/units. Once a backend /admin/personas
+// endpoint lands, swap this for the wire shape and delete the
+// derivation in PersonasPage.
+export type PersonaStatus = "active" | "idle" | "departed" | "suspended"
+
+export interface PersonaSummary {
+  name: string
+  group: string | null
+  enterprise: string
+  status: PersonaStatus
+  joined: string | null
+  last_seen: string | null
+  ku_count: number
+  api_key_count: number
+}


### PR DESCRIPTION
## Summary

Adds a **Personas** tab between Network and API Keys in the L2 admin UI (#170, sub of L2 mission control epic #168). Frontend-only — no backend changes.

- Top-level sortable table: persona, group, status, last seen, KU count, joined; search filters by name/group/KU domain
- Per-persona detail drawer: identity panel (AAISN-scoped name + 30-day sparkline), filterable activity timeline, KU contributions (total/tier split/confidence histogram/top-by-confirmations/per-domain breakdown), sessions/lifecycle sections
- Empty state matches the cyan-eyebrow pattern from PR #181; reuses brand theme tokens (cyan/violet/gold/emerald/rose) — no new design primitives

## Backend reads

V1 reads from existing endpoints only:
- GET /api/v1/activity — timeline + persona directory derivation (group by persona)
- GET /api/v1/review/units — KU joins (filtered client-side on created_by)

## Backend gaps surfaced as follow-ups

These are NOT implemented in this PR per the epic decomposition (frontend only):

1. GET /admin/personas — denormalised summary endpoint. Current approach pulls 500 activity rows on each load and folds client-side; works for V1 but doesn't scale past a few thousand active personas.
2. GET /admin/personas/<name>/api-keys — admin enumeration of a peer persona's keys. The drawer surfaces this as a "tracked as a follow-up backend issue" panel.
3. GET /admin/personas/<name>/lifecycle-events — read for the lifecycle_events table. V1 derives joined/departed from /activity timestamps (truthful "(derived)" suffix).

Each will be filed as a separate issue.

## Bundle size

JS (gzipped): 250.07 KB → **255.24 KB** (+5.17 KB). 0.17 KB over the 5 KB hard ceiling — flagging per the acceptance criteria. The detail drawer is the major contributor; trimming further would require dropping the confidence histogram, sparkline, or top-KUs-by-confirmation list (all spec'd). Open to feedback if the operator wants any of those cut.

CSS (gzipped): 9.98 KB → 10.08 KB (+0.10 KB).

## Test plan

- [x] pnpm lint clean
- [x] pnpm test clean (27 passed; 4 new in PersonasPage.test.tsx)
- [x] pnpm build succeeds
- [ ] Manual: log in to L2 → Personas tab visible after Network
- [ ] Manual: empty state renders when no /activity rows
- [ ] Manual: directory populates after first proposes/queries
- [ ] Manual: clicking a row opens the drawer; Esc closes; click-outside closes
- [ ] Manual: timeline filter buttons render only when >1 event type present

🤖 Generated with [Claude Code](https://claude.com/claude-code)