### PR TITLE
feat(auth): FO-1a — passkey enrollment substrate (closes 1a of #191)

### DIFF
--- a/scripts/cleanup-test-fixtures.py
+++ b/scripts/cleanup-test-fixtures.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-Teardown of 8th-Layer.ai test fixtures.
+"""Teardown of 8th-Layer.ai test fixtures.
 
 Default mode: --dry-run (read-only AWS calls, lists candidate resources).
 Use --execute to actually delete (in safe ordering).
@@ -27,13 +26,12 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
 import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 try:
@@ -97,10 +95,10 @@ class AuditLog:
     def __post_init__(self):
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self.fh = open(self.path, "a", encoding="utf-8")
-        self.write(f"=== cleanup run started {datetime.now(timezone.utc).isoformat()} ===")
+        self.write(f"=== cleanup run started {datetime.now(UTC).isoformat()} ===")
 
     def write(self, line: str):
-        ts = datetime.now(timezone.utc).isoformat()
+        ts = datetime.now(UTC).isoformat()
         self.fh.write(f"{ts}\t{line}\n")
         self.fh.flush()
 
@@ -108,7 +106,7 @@ class AuditLog:
         self.write(f"{kind}\t{resource}\t{action}\t{result}")
 
     def close(self):
-        self.write(f"=== cleanup run finished {datetime.now(timezone.utc).isoformat()} ===")
+        self.write(f"=== cleanup run finished {datetime.now(UTC).isoformat()} ===")
         self.fh.close()
 
 
@@ -476,7 +474,7 @@ def main():
     if args.execute:
         args.dry_run = False
 
-    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
     log_path = Path(args.log_dir) / f"cleanup-{ts}.log"
     audit = AuditLog(path=log_path)
     audit.write(f"mode={'execute' if args.execute else 'dry-run'} filter={args.filter}")
@@ -530,7 +528,7 @@ def main():
     active_count = sum(1 for inv in inventories if inv.services)
     print(f"# Estimated savings: ~${active_count * COST_PER_CLUSTER_MO_USD:.2f}/month "
           f"({active_count} clusters x ~${COST_PER_CLUSTER_MO_USD}/mo each).")
-    print(f"#   - Fargate task: ~$15/mo  ALB: ~$22/mo  ENI: ~$3/mo  Logs: ~$0.50/mo")
+    print("#   - Fargate task: ~$15/mo  ALB: ~$22/mo  ENI: ~$3/mo  Logs: ~$0.50/mo")
     print()
 
     # Directory probe

--- a/server/backend/alembic/versions/0017_add_user_email.py
+++ b/server/backend/alembic/versions/0017_add_user_email.py
@@ -1,0 +1,87 @@
+"""FO-1a: add ``email`` column to ``users`` + conditional unique index.
+
+Revision ID: 0017_add_user_email
+Revises: 0016_xgroup_consent
+Create Date: 2026-05-10
+
+Founder Onboarding (#191, phase 1a). Adds an additive ``email`` column
+to ``users`` for passkey enrollment. The column is nullable — existing
+non-passkey users carry NULL — and uniqueness is enforced by a
+*conditional* unique index (``WHERE email IS NOT NULL``) so multiple
+NULLs do not collide.
+
+Why a partial index rather than a full UNIQUE constraint: the legacy
+users-table seed path (CLI / SDK auth flows that pre-date the email
+column) never wrote an email; making the column UNIQUE would either
+require a non-NULL DEFAULT (which we don't want — placeholder emails
+are worse than NULL) or accept that all existing rows collide on
+empty-string. Partial-unique sidesteps both.
+
+Idempotency mirrors 0015 — guard with ``_column_names`` for the column
+add and an inspector check for the index. Re-run is a no-op.
+
+# Downgrade
+
+Drops the index and column. Note: the conditional-unique index
+predicate (``WHERE email IS NOT NULL``) is part of the index DDL on
+both SQLite and Postgres; ``op.drop_index`` removes it cleanly.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0017_add_user_email"
+down_revision: str | Sequence[str] | None = "0016_xgroup_consent"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _column_names(bind: sa.engine.Connection, table_name: str) -> set[str]:
+    inspector = sa.inspect(bind)
+    if table_name not in inspector.get_table_names():
+        return set()
+    return {col["name"] for col in inspector.get_columns(table_name)}
+
+
+def _index_names(bind: sa.engine.Connection, table_name: str) -> set[str]:
+    inspector = sa.inspect(bind)
+    if table_name not in inspector.get_table_names():
+        return set()
+    return {idx["name"] for idx in inspector.get_indexes(table_name)}
+
+
+def upgrade() -> None:
+    """Add ``users.email`` + conditional unique index."""
+    bind = op.get_bind()
+
+    if "email" not in _column_names(bind, "users"):
+        op.add_column("users", sa.Column("email", sa.Text(), nullable=True))
+
+    if "idx_users_email_unique" not in _index_names(bind, "users"):
+        # Partial unique index: only enforces uniqueness for rows where
+        # ``email IS NOT NULL``. Both SQLite and PostgreSQL support
+        # ``CREATE UNIQUE INDEX ... WHERE`` with this exact syntax.
+        op.create_index(
+            "idx_users_email_unique",
+            "users",
+            ["email"],
+            unique=True,
+            sqlite_where=sa.text("email IS NOT NULL"),
+            postgresql_where=sa.text("email IS NOT NULL"),
+        )
+
+
+def downgrade() -> None:
+    """Drop ``users.email`` + its conditional unique index."""
+    bind = op.get_bind()
+
+    if "idx_users_email_unique" in _index_names(bind, "users"):
+        op.drop_index("idx_users_email_unique", table_name="users")
+
+    if "email" in _column_names(bind, "users"):
+        with op.batch_alter_table("users") as batch_op:
+            batch_op.drop_column("email")

--- a/server/backend/alembic/versions/0018_webauthn_credentials.py
+++ b/server/backend/alembic/versions/0018_webauthn_credentials.py
@@ -1,0 +1,105 @@
+"""FO-1a: ``webauthn_credentials`` table for passkey enrollment.
+
+Revision ID: 0018_webauthn_credentials
+Revises: 0017_add_user_email
+Create Date: 2026-05-10
+
+Founder Onboarding (#191, phase 1a). Stores one row per registered
+WebAuthn credential — credential id, COSE-encoded public key, and the
+authenticator's monotonic ``sign_count``. ``credential_id`` and
+``public_key`` are bytes (BLOB on SQLite, BYTEA on PostgreSQL), the
+shape py_webauthn returns from ``verify_registration_response``.
+
+# Schema
+
+* ``id`` — surrogate INT PK, sqlite_autoincrement matches baseline.
+* ``user_id`` — FK to ``users.id`` with CASCADE (delete a user, their
+  credentials go with them).
+* ``credential_id`` — UNIQUE, the value the authenticator returns and
+  the key into our lookup on assertion.
+* ``public_key`` — COSE-encoded public key bytes.
+* ``sign_count`` — monotonic counter; assertion verification requires
+  a strictly-greater value (clone detection).
+* ``transports`` — comma-separated transport hints (``usb``,
+  ``ble``, ``nfc``, ``internal``); informational.
+* ``aaguid`` — authenticator model identifier (16 bytes); informational
+  but useful for revoking a known-compromised model.
+* ``name`` — optional human-readable label (e.g. "DW's YubiKey 5C").
+* ``created_at`` / ``last_used_at`` — ISO-8601 strings, matching the
+  ``users`` / ``api_keys`` convention.
+
+Index on ``user_id`` mirrors ``idx_api_keys_user`` for the same
+"list-by-owner" query path the admin UI uses for API keys.
+
+# Idempotency
+
+Standard table-existence + index-existence guards (see 0015 / 0016)
+so the migration is safe to re-run. Downgrade drops index then table.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0018_webauthn_credentials"
+down_revision: str | Sequence[str] | None = "0017_add_user_email"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _table_exists(bind: sa.engine.Connection, table_name: str) -> bool:
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def upgrade() -> None:
+    """Create ``webauthn_credentials`` + supporting index."""
+    bind = op.get_bind()
+
+    if not _table_exists(bind, "webauthn_credentials"):
+        op.create_table(
+            "webauthn_credentials",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("user_id", sa.Integer(), nullable=False),
+            sa.Column("credential_id", sa.LargeBinary(), nullable=False),
+            sa.Column("public_key", sa.LargeBinary(), nullable=False),
+            sa.Column(
+                "sign_count",
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text("0"),
+            ),
+            sa.Column("transports", sa.Text(), nullable=True),
+            sa.Column("aaguid", sa.LargeBinary(), nullable=True),
+            sa.Column("name", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.Text(), nullable=False),
+            sa.Column("last_used_at", sa.Text(), nullable=True),
+            sa.UniqueConstraint("credential_id", name="uq_webauthn_credentials_credential_id"),
+            sa.ForeignKeyConstraint(
+                ["user_id"],
+                ["users.id"],
+                ondelete="CASCADE",
+                name="fk_webauthn_credentials_user_id",
+            ),
+            # Match the baseline convention for INTEGER PK tables.
+            sqlite_autoincrement=True,
+        )
+        op.create_index(
+            "idx_webauthn_user",
+            "webauthn_credentials",
+            ["user_id"],
+        )
+
+
+def downgrade() -> None:
+    """Drop ``webauthn_credentials`` + index."""
+    bind = op.get_bind()
+    if _table_exists(bind, "webauthn_credentials"):
+        inspector = sa.inspect(bind)
+        idx_names = {idx["name"] for idx in inspector.get_indexes("webauthn_credentials")}
+        if "idx_webauthn_user" in idx_names:
+            op.drop_index("idx_webauthn_user", table_name="webauthn_credentials")
+        op.drop_table("webauthn_credentials")

--- a/server/backend/pyproject.toml
+++ b/server/backend/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
     "cryptography>=42",
     "rfc8785>=0.1.4",
     "httpx",
+    # FO-1a (#191) — passkey/WebAuthn enrollment substrate. py_webauthn
+    # 2.x handles attestation parsing + assertion signature verification.
+    "webauthn>=2.0",
 ]
 
 [project.scripts]

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -36,6 +36,7 @@ from .embed import compose_text, embed_text
 from .embed import model_id as embed_model_id
 from .migrations import run_migrations
 from .network import router as network_router
+from .passkey_routes import router as passkey_router
 from .quality import check_propose_quality
 from .reflect import router as reflect_router
 from .reputation_routes import router as reputation_router
@@ -398,6 +399,9 @@ async def lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
 
 api_router = APIRouter()
 api_router.include_router(auth_router)
+# FO-1a (#191) — passkey enrollment + login. Mounted alongside the
+# password-based auth router; both live under /auth on the same prefix.
+api_router.include_router(passkey_router)
 api_router.include_router(review_router)
 api_router.include_router(network_router)
 api_router.include_router(consults_router)

--- a/server/backend/src/cq_server/migrations.py
+++ b/server/backend/src/cq_server/migrations.py
@@ -36,7 +36,7 @@ BASELINE_REVISION = "0001"
 # Phase 2 (task #100) — chain head after porting fork-delta tables to
 # Alembic. Update this string when adding a new migration so test
 # assertions and ops scripts stay in sync with the actual chain head.
-HEAD_REVISION = "0016_xgroup_consent"
+HEAD_REVISION = "0018_webauthn_credentials"
 
 
 def _find_alembic_ini() -> Path:

--- a/server/backend/src/cq_server/passkey.py
+++ b/server/backend/src/cq_server/passkey.py
@@ -123,10 +123,7 @@ def _set_challenge_cache_override_for_tests(cache: dict[str, _ChallengeEntry] | 
     on ``CQ_TESTING=1`` so an accidental import path can't trip it.
     """
     if os.environ.get("CQ_TESTING") != "1":
-        raise RuntimeError(
-            "_set_challenge_cache_override_for_tests is test-only; "
-            "set CQ_TESTING=1 in test environment"
-        )
+        raise RuntimeError("_set_challenge_cache_override_for_tests is test-only; set CQ_TESTING=1 in test environment")
     global _challenge_cache  # noqa: PLW0603
     _challenge_cache = {} if cache is None else cache
 
@@ -181,9 +178,7 @@ def begin_registration(
     one already on file.
     """
     challenge = secrets.token_bytes(32)
-    exclude = [
-        PublicKeyCredentialDescriptor(id=cid) for cid in (existing_credential_ids or [])
-    ]
+    exclude = [PublicKeyCredentialDescriptor(id=cid) for cid in (existing_credential_ids or [])]
     options = generate_registration_options(
         rp_id=rp_id(),
         rp_name=rp_name(),
@@ -245,9 +240,7 @@ def finish_registration(
         # so don't fail verification on UP-only authenticators yet.
         require_user_verification=False,
     )
-    aaguid_bytes = (
-        bytes.fromhex(verified.aaguid.replace("-", "")) if verified.aaguid else None
-    )
+    aaguid_bytes = bytes.fromhex(verified.aaguid.replace("-", "")) if verified.aaguid else None
     return VerifiedRegistration(
         credential_id=verified.credential_id,
         public_key=verified.credential_public_key,
@@ -275,9 +268,7 @@ def begin_authentication(
     options = generate_authentication_options(
         rp_id=rp_id(),
         challenge=challenge,
-        allow_credentials=[
-            PublicKeyCredentialDescriptor(id=cid) for cid in allow_credential_ids
-        ],
+        allow_credentials=[PublicKeyCredentialDescriptor(id=cid) for cid in allow_credential_ids],
         user_verification=UserVerificationRequirement.PREFERRED,
     )
     _store_challenge(username, challenge)

--- a/server/backend/src/cq_server/passkey.py
+++ b/server/backend/src/cq_server/passkey.py
@@ -58,14 +58,40 @@ DEFAULT_RP_NAME = "8th-Layer.ai (dev)"
 CHALLENGE_TTL_SECONDS = 60
 
 
+def _is_dev_env() -> bool:
+    return os.environ.get("CQ_ENV", "dev").lower() == "dev"
+
+
 def rp_id() -> str:
-    """Return the RP ID used in registration / authentication options."""
-    return os.environ.get("CQ_WEBAUTHN_RP_ID", DEFAULT_RP_ID)
+    """Return the RP ID used in registration / authentication options.
+
+    Refuses to silently default in non-dev: a misconfigured production
+    deploy that ships without ``CQ_WEBAUTHN_RP_ID`` would silently bind
+    every credential to ``localhost``, which is a config-failure-mode
+    we'd rather catch loud at startup than silently break in prod.
+    """
+    val = os.environ.get("CQ_WEBAUTHN_RP_ID", "").strip()
+    if not val:
+        if not _is_dev_env():
+            raise RuntimeError("CQ_WEBAUTHN_RP_ID is required in non-dev environments")
+        return DEFAULT_RP_ID
+    return val
 
 
 def rp_origin() -> str:
-    """Return the RP origin (URL) used to verify clientDataJSON."""
-    return os.environ.get("CQ_WEBAUTHN_RP_ORIGIN", DEFAULT_RP_ORIGIN)
+    """Return the RP origin (URL) used to verify clientDataJSON.
+
+    Same fail-loud semantics as ``rp_id()`` plus an https-only check
+    in non-dev so a typo'd ``http://`` URL doesn't sneak through.
+    """
+    val = os.environ.get("CQ_WEBAUTHN_RP_ORIGIN", "").strip()
+    if not val:
+        if not _is_dev_env():
+            raise RuntimeError("CQ_WEBAUTHN_RP_ORIGIN is required in non-dev environments")
+        return DEFAULT_RP_ORIGIN
+    if not _is_dev_env() and not val.startswith("https://"):
+        raise RuntimeError("CQ_WEBAUTHN_RP_ORIGIN must use https:// in non-dev environments")
+    return val
 
 
 def rp_name() -> str:
@@ -88,14 +114,28 @@ class _ChallengeEntry:
 _challenge_cache: dict[str, _ChallengeEntry] = {}
 
 
-def set_challenge_cache_override(cache: dict[str, _ChallengeEntry] | None) -> None:
+def _set_challenge_cache_override_for_tests(cache: dict[str, _ChallengeEntry] | None) -> None:
     """Inject a challenge cache dict for tests; pass ``None`` to reset.
 
     Tests use this to assert on cache state and to ensure isolation
-    between cases. Production code never calls this.
+    between cases. Production code never calls this — the underscore
+    prefix is the lint-catchable signal. The function is also gated
+    on ``CQ_TESTING=1`` so an accidental import path can't trip it.
     """
+    if os.environ.get("CQ_TESTING") != "1":
+        raise RuntimeError(
+            "_set_challenge_cache_override_for_tests is test-only; "
+            "set CQ_TESTING=1 in test environment"
+        )
     global _challenge_cache  # noqa: PLW0603
     _challenge_cache = {} if cache is None else cache
+
+
+# NOTE on horizontal scaling (FO-1c follow-up): this dict is per-process.
+# /enroll/begin landing on replica A and /enroll/finish on replica B
+# will fail with "challenge missing or expired". Acceptable for FO-1a's
+# single-task ECS deployment. Must move to Redis or DynamoDB-with-TTL
+# before any load-balanced multi-replica deployment.
 
 
 def _store_challenge(username: str, challenge: bytes, *, user_id_bytes: bytes | None = None) -> None:

--- a/server/backend/src/cq_server/passkey.py
+++ b/server/backend/src/cq_server/passkey.py
@@ -1,0 +1,301 @@
+"""WebAuthn / passkey ceremony helpers (FO-1a, #191).
+
+Thin wrapper around ``py_webauthn`` 2.x. Owns:
+
+* RP configuration (id / origin / name) read from env with sane local
+  defaults so tests and dev servers don't need to set anything.
+* The temporary challenge cache keyed by username — a 60s TTL dict
+  living in this process. Tests inject their own dict via
+  ``set_challenge_cache_override`` so assertions on cache state stay
+  deterministic.
+* Pure functions for the four ceremony steps (registration begin/finish,
+  authentication begin/finish). The route layer in
+  ``passkey_routes.py`` wires these into FastAPI handlers.
+
+Out of scope here (FO-1b/c work):
+* Email / magic-link invites — that's FO-1b.
+* Cookie-bound JWT or per-session model — FO-1c.
+
+Note on attestation: we use the default ``AttestationConveyancePreference.NONE``
+in the registration options. py_webauthn still parses + verifies the
+authenticator data + COSE public key on ``verify_registration_response``
+even when attestation is "none"; we just don't require an attestation
+trust path. That matches every consumer-passkey flow (Apple, 1Password,
+YubiKey self-attestation) and is the right default for FO-1a where the
+goal is "any authenticator works", not enterprise-attested keys.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from webauthn import (
+    generate_authentication_options,
+    generate_registration_options,
+    options_to_json,
+    verify_authentication_response,
+    verify_registration_response,
+)
+from webauthn.helpers.structs import (
+    AuthenticatorSelectionCriteria,
+    PublicKeyCredentialDescriptor,
+    ResidentKeyRequirement,
+    UserVerificationRequirement,
+)
+
+# --- RP config ------------------------------------------------------------
+
+DEFAULT_RP_ID = "localhost"
+DEFAULT_RP_ORIGIN = "http://localhost:3000"
+DEFAULT_RP_NAME = "8th-Layer.ai (dev)"
+
+# Challenge cache TTL — short enough that an abandoned ceremony cleans up
+# quickly, long enough to absorb a user pause between begin and finish.
+CHALLENGE_TTL_SECONDS = 60
+
+
+def rp_id() -> str:
+    """Return the RP ID used in registration / authentication options."""
+    return os.environ.get("CQ_WEBAUTHN_RP_ID", DEFAULT_RP_ID)
+
+
+def rp_origin() -> str:
+    """Return the RP origin (URL) used to verify clientDataJSON."""
+    return os.environ.get("CQ_WEBAUTHN_RP_ORIGIN", DEFAULT_RP_ORIGIN)
+
+
+def rp_name() -> str:
+    """Return the RP display name shown to the user during enrollment."""
+    return os.environ.get("CQ_WEBAUTHN_RP_NAME", DEFAULT_RP_NAME)
+
+
+# --- Challenge cache ------------------------------------------------------
+
+
+@dataclass
+class _ChallengeEntry:
+    challenge: bytes
+    expires_at: float
+    # Stored so finish() can pin the user_id used at begin() — defends
+    # against finish-with-different-user attacks for registration.
+    user_id_bytes: bytes | None = None
+
+
+_challenge_cache: dict[str, _ChallengeEntry] = {}
+
+
+def set_challenge_cache_override(cache: dict[str, _ChallengeEntry] | None) -> None:
+    """Inject a challenge cache dict for tests; pass ``None`` to reset.
+
+    Tests use this to assert on cache state and to ensure isolation
+    between cases. Production code never calls this.
+    """
+    global _challenge_cache  # noqa: PLW0603
+    _challenge_cache = {} if cache is None else cache
+
+
+def _store_challenge(username: str, challenge: bytes, *, user_id_bytes: bytes | None = None) -> None:
+    _challenge_cache[username] = _ChallengeEntry(
+        challenge=challenge,
+        expires_at=time.monotonic() + CHALLENGE_TTL_SECONDS,
+        user_id_bytes=user_id_bytes,
+    )
+
+
+def _consume_challenge(username: str) -> _ChallengeEntry | None:
+    """Pop and return the challenge for ``username`` if it exists and is fresh.
+
+    Returns None on cache miss or expiry. Single-use semantics: once
+    consumed the entry is gone, so a replayed finish() with the same
+    challenge bytes cannot succeed twice.
+    """
+    entry = _challenge_cache.pop(username, None)
+    if entry is None:
+        return None
+    if entry.expires_at < time.monotonic():
+        return None
+    return entry
+
+
+# --- Registration ceremony ------------------------------------------------
+
+
+def begin_registration(
+    *,
+    username: str,
+    user_id_bytes: bytes,
+    display_name: str | None = None,
+    existing_credential_ids: list[bytes] | None = None,
+) -> dict[str, Any]:
+    """Generate WebAuthn registration options + cache the challenge.
+
+    Returns the options as a JSON-serialisable dict (the wire shape
+    browsers consume via ``navigator.credentials.create``).
+
+    ``existing_credential_ids`` populates ``excludeCredentials`` so a
+    user enrolling a second authenticator can't accidentally re-enroll
+    one already on file.
+    """
+    challenge = secrets.token_bytes(32)
+    exclude = [
+        PublicKeyCredentialDescriptor(id=cid) for cid in (existing_credential_ids or [])
+    ]
+    options = generate_registration_options(
+        rp_id=rp_id(),
+        rp_name=rp_name(),
+        user_name=username,
+        user_id=user_id_bytes,
+        user_display_name=display_name or username,
+        challenge=challenge,
+        # Prefer platform / passkey-style enrollments (resident keys),
+        # but accept either. UV preferred matches the consumer-passkey
+        # default; FO-1c can tighten this to "required" once the session
+        # model lands.
+        authenticator_selection=AuthenticatorSelectionCriteria(
+            resident_key=ResidentKeyRequirement.PREFERRED,
+            user_verification=UserVerificationRequirement.PREFERRED,
+        ),
+        exclude_credentials=exclude,
+    )
+    _store_challenge(username, challenge, user_id_bytes=user_id_bytes)
+    # ``options_to_json`` emits the exact base64url-encoded shape the
+    # browser API expects; we re-parse to a dict so FastAPI can return
+    # it as a JSON object rather than a JSON-encoded string.
+    import json
+
+    return json.loads(options_to_json(options))
+
+
+@dataclass
+class VerifiedRegistration:
+    """Subset of py_webauthn's VerifiedRegistration that the route persists."""
+
+    credential_id: bytes
+    public_key: bytes
+    sign_count: int
+    aaguid: bytes | None
+    transports: list[str] | None
+
+
+def finish_registration(
+    *,
+    username: str,
+    credential: dict[str, Any],
+    transports: list[str] | None = None,
+) -> VerifiedRegistration:
+    """Verify the browser's registration response and return persistable fields.
+
+    Raises ``ValueError`` on missing/expired challenge or on signature
+    verification failure (the route layer maps that to 400).
+    """
+    entry = _consume_challenge(username)
+    if entry is None:
+        raise ValueError("registration challenge missing or expired")
+
+    verified = verify_registration_response(
+        credential=credential,
+        expected_challenge=entry.challenge,
+        expected_rp_id=rp_id(),
+        expected_origin=rp_origin(),
+        # FO-1a accepts any authenticator; UV is preferred not required,
+        # so don't fail verification on UP-only authenticators yet.
+        require_user_verification=False,
+    )
+    aaguid_bytes = (
+        bytes.fromhex(verified.aaguid.replace("-", "")) if verified.aaguid else None
+    )
+    return VerifiedRegistration(
+        credential_id=verified.credential_id,
+        public_key=verified.credential_public_key,
+        sign_count=int(verified.sign_count),
+        aaguid=aaguid_bytes,
+        transports=transports,
+    )
+
+
+# --- Authentication ceremony ----------------------------------------------
+
+
+def begin_authentication(
+    *,
+    username: str,
+    allow_credential_ids: list[bytes],
+) -> dict[str, Any]:
+    """Generate authentication options for a known user.
+
+    ``allow_credential_ids`` is the list of credential ids enrolled by
+    this user — sent so the browser only attempts authenticators that
+    can actually satisfy the challenge.
+    """
+    challenge = secrets.token_bytes(32)
+    options = generate_authentication_options(
+        rp_id=rp_id(),
+        challenge=challenge,
+        allow_credentials=[
+            PublicKeyCredentialDescriptor(id=cid) for cid in allow_credential_ids
+        ],
+        user_verification=UserVerificationRequirement.PREFERRED,
+    )
+    _store_challenge(username, challenge)
+    import json
+
+    return json.loads(options_to_json(options))
+
+
+@dataclass
+class VerifiedAuthentication:
+    """Subset of py_webauthn's VerifiedAuthentication for the route layer."""
+
+    credential_id: bytes
+    new_sign_count: int
+
+
+def finish_authentication(
+    *,
+    username: str,
+    credential: dict[str, Any],
+    public_key: bytes,
+    current_sign_count: int,
+) -> VerifiedAuthentication:
+    """Verify an assertion and return the new sign_count.
+
+    Caller passes the stored ``public_key`` and ``current_sign_count``
+    for the credential id the browser presented. py_webauthn enforces
+    that the new sign_count is strictly greater (clone detection); we
+    surface that as ValueError on replay.
+    """
+    entry = _consume_challenge(username)
+    if entry is None:
+        raise ValueError("authentication challenge missing or expired")
+
+    verified = verify_authentication_response(
+        credential=credential,
+        expected_challenge=entry.challenge,
+        expected_rp_id=rp_id(),
+        expected_origin=rp_origin(),
+        credential_public_key=public_key,
+        credential_current_sign_count=current_sign_count,
+        require_user_verification=False,
+    )
+    raw_id = credential.get("rawId") or credential.get("raw_id")
+    # rawId comes through as base64url; py_webauthn re-encodes it on
+    # the verified object's id (str). Resolve back to bytes for the
+    # caller — that's the lookup key we used to find the row.
+    from webauthn.helpers import base64url_to_bytes
+
+    if isinstance(raw_id, bytes):
+        cid_bytes = raw_id
+    elif isinstance(raw_id, str):
+        cid_bytes = base64url_to_bytes(raw_id)
+    else:
+        # Should never happen — py_webauthn would have rejected the
+        # credential dict before reaching here.
+        raise ValueError("credential rawId missing")
+    return VerifiedAuthentication(
+        credential_id=cid_bytes,
+        new_sign_count=int(verified.new_sign_count),
+    )

--- a/server/backend/src/cq_server/passkey_routes.py
+++ b/server/backend/src/cq_server/passkey_routes.py
@@ -1,0 +1,248 @@
+"""FastAPI router for passkey enrollment + login (FO-1a, #191).
+
+Four endpoints, paired begin/finish per ceremony:
+
+* ``POST /auth/passkey/enroll/begin``  — authenticated. Returns the
+  WebAuthn registration options the browser passes to
+  ``navigator.credentials.create``.
+* ``POST /auth/passkey/enroll/finish`` — authenticated. Verifies the
+  attestation response, persists the credential row.
+* ``POST /auth/passkey/login/begin``   — anonymous. Caller supplies a
+  username (or, post-FO-1b, an email); returns assertion options.
+* ``POST /auth/passkey/login/finish``  — anonymous. Verifies the
+  assertion, increments ``sign_count``, mints a JWT via
+  ``auth.create_token`` (FO-1c will swap that for a cookie-bound
+  session token).
+
+Out of scope here (deferred to FO-1b/c):
+* Self-service signup / first-credential enrollment for users with no
+  password row — FO-2 owns the ``/signup`` shape.
+* Email-based account discovery for ``login/begin`` — FO-1b lands the
+  invite + magic-link path; this PR keeps things username-keyed.
+* Replacing JWT with a cookie-bound session — FO-1c.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from . import passkey
+from .auth import _get_jwt_secret, create_token, get_current_user
+from .deps import get_store
+from .store._sqlite import SqliteStore
+
+router = APIRouter(prefix="/auth/passkey", tags=["auth", "passkey"])
+
+
+# --- Request / response shapes -------------------------------------------
+
+
+class EnrollBeginRequest(BaseModel):
+    """Optional human-readable label for the new credential."""
+
+    name: str | None = Field(default=None, max_length=64)
+
+
+class EnrollFinishRequest(BaseModel):
+    """Browser-side WebAuthn ``AttestationResponse`` plus optional metadata."""
+
+    credential: dict[str, Any]
+    name: str | None = Field(default=None, max_length=64)
+    transports: list[str] | None = Field(default=None, max_length=8)
+
+
+class EnrollFinishResponse(BaseModel):
+    """Response from a successful enrollment finish."""
+
+    credential_db_id: int
+    credential_id_b64u: str
+    sign_count: int
+
+
+class LoginBeginRequest(BaseModel):
+    """Username for which to generate assertion options."""
+
+    username: str = Field(min_length=1, max_length=128)
+
+
+class LoginFinishRequest(BaseModel):
+    """Browser-side WebAuthn ``AssertionResponse`` plus the asserted username."""
+
+    username: str = Field(min_length=1, max_length=128)
+    credential: dict[str, Any]
+
+
+class LoginFinishResponse(BaseModel):
+    """JWT bearer token + the new sign_count after a successful assertion."""
+
+    token: str
+    username: str
+    sign_count: int
+
+
+# --- Helpers --------------------------------------------------------------
+
+
+def _user_id_bytes(user_id: int) -> bytes:
+    """Encode the integer user.id as bytes for WebAuthn's ``user.id`` field.
+
+    WebAuthn requires opaque bytes, max 64. We use a fixed-width 8-byte
+    big-endian encoding so the same row produces the same WebAuthn id
+    every time (important for ``excludeCredentials`` parity).
+    """
+    return int(user_id).to_bytes(8, "big", signed=False)
+
+
+# --- Routes: enrollment ---------------------------------------------------
+
+
+@router.post("/enroll/begin")
+async def enroll_begin(
+    request: EnrollBeginRequest,  # noqa: ARG001 — name is opaque at begin
+    username: str = Depends(get_current_user),
+    store: SqliteStore = Depends(get_store),
+) -> dict[str, Any]:
+    """Generate registration options for the authenticated caller.
+
+    The caller is identified by the existing JWT/API-key auth; we look
+    up the user row, build options including any already-enrolled
+    credential ids in ``excludeCredentials``, and cache the challenge.
+    """
+    user = await store.get_user(username)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    user_id = int(user["id"])
+    existing = await store.list_webauthn_credentials_for_user(user_id)
+    return passkey.begin_registration(
+        username=username,
+        user_id_bytes=_user_id_bytes(user_id),
+        display_name=username,
+        existing_credential_ids=[row["credential_id"] for row in existing],
+    )
+
+
+@router.post("/enroll/finish")
+async def enroll_finish(
+    request: EnrollFinishRequest,
+    username: str = Depends(get_current_user),
+    store: SqliteStore = Depends(get_store),
+) -> EnrollFinishResponse:
+    """Verify the attestation response and persist the credential."""
+    user = await store.get_user(username)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    try:
+        verified = passkey.finish_registration(
+            username=username,
+            credential=request.credential,
+            transports=request.transports,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001 — py_webauthn raises subclasses of Exception
+        raise HTTPException(status_code=400, detail=f"registration verification failed: {exc}") from exc
+
+    transports_csv = ",".join(verified.transports) if verified.transports else None
+    row = await store.insert_webauthn_credential(
+        user_id=int(user["id"]),
+        credential_id=verified.credential_id,
+        public_key=verified.public_key,
+        sign_count=verified.sign_count,
+        transports=transports_csv,
+        aaguid=verified.aaguid,
+        name=request.name,
+    )
+    from webauthn.helpers import bytes_to_base64url
+
+    return EnrollFinishResponse(
+        credential_db_id=int(row["id"]),
+        credential_id_b64u=bytes_to_base64url(verified.credential_id),
+        sign_count=verified.sign_count,
+    )
+
+
+# --- Routes: authentication ----------------------------------------------
+
+
+@router.post("/login/begin")
+async def login_begin(
+    request: LoginBeginRequest,
+    store: SqliteStore = Depends(get_store),
+) -> dict[str, Any]:
+    """Generate assertion options for a user with at least one credential.
+
+    Anonymous endpoint: the caller is asserting an identity, not yet
+    proving it. We still want to refuse fast on unknown usernames /
+    no-credentials so the frontend can render an error rather than
+    spinning up the browser ceremony.
+    """
+    user = await store.get_user(request.username)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    creds = await store.list_webauthn_credentials_for_user(int(user["id"]))
+    if not creds:
+        raise HTTPException(status_code=404, detail="No passkeys enrolled for user")
+    return passkey.begin_authentication(
+        username=request.username,
+        allow_credential_ids=[row["credential_id"] for row in creds],
+    )
+
+
+@router.post("/login/finish")
+async def login_finish(
+    request: LoginFinishRequest,
+    store: SqliteStore = Depends(get_store),
+) -> LoginFinishResponse:
+    """Verify the assertion, advance ``sign_count``, mint a JWT.
+
+    ``sign_count`` is enforced by py_webauthn (strictly greater than the
+    stored value); we re-raise any error as 400 so the client surfaces
+    "this passkey was just used elsewhere — re-authenticate" rather than
+    a generic 500.
+    """
+    user = await store.get_user(request.username)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    # Look up the credential the browser claims to have used. The
+    # rawId in the credential dict is the same bytes we stored at
+    # enroll time, so this is a single equality lookup.
+    raw_id = request.credential.get("rawId") or request.credential.get("raw_id")
+    if isinstance(raw_id, str):
+        from webauthn.helpers import base64url_to_bytes
+
+        cid_bytes = base64url_to_bytes(raw_id)
+    elif isinstance(raw_id, bytes):
+        cid_bytes = raw_id
+    else:
+        raise HTTPException(status_code=400, detail="credential rawId missing")
+    cred_row = await store.get_webauthn_credential_by_id(cid_bytes)
+    if cred_row is None or cred_row["user_id"] != int(user["id"]):
+        raise HTTPException(status_code=404, detail="Credential not found for user")
+
+    try:
+        verified = passkey.finish_authentication(
+            username=request.username,
+            credential=request.credential,
+            public_key=cred_row["public_key"],
+            current_sign_count=int(cred_row["sign_count"]),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001 — py_webauthn replay raises InvalidAuthenticationResponse
+        raise HTTPException(status_code=400, detail=f"authentication failed: {exc}") from exc
+
+    await store.update_webauthn_sign_count(
+        credential_id=verified.credential_id,
+        new_sign_count=verified.new_sign_count,
+        last_used_at=datetime.now(UTC).isoformat(),
+    )
+    token = create_token(request.username, secret=_get_jwt_secret())
+    return LoginFinishResponse(
+        token=token,
+        username=request.username,
+        sign_count=verified.new_sign_count,
+    )

--- a/server/backend/src/cq_server/passkey_routes.py
+++ b/server/backend/src/cq_server/passkey_routes.py
@@ -24,27 +24,29 @@ Out of scope here (deferred to FO-1b/c):
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
+from webauthn.helpers.exceptions import (
+    InvalidAuthenticationResponse,
+    InvalidJSONStructure,
+    InvalidRegistrationResponse,
+)
 
 from . import passkey
 from .auth import _get_jwt_secret, create_token, get_current_user
 from .deps import get_store
 from .store._sqlite import SqliteStore
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/auth/passkey", tags=["auth", "passkey"])
 
 
 # --- Request / response shapes -------------------------------------------
-
-
-class EnrollBeginRequest(BaseModel):
-    """Optional human-readable label for the new credential."""
-
-    name: str | None = Field(default=None, max_length=64)
 
 
 class EnrollFinishRequest(BaseModel):
@@ -102,7 +104,6 @@ def _user_id_bytes(user_id: int) -> bytes:
 
 @router.post("/enroll/begin")
 async def enroll_begin(
-    request: EnrollBeginRequest,  # noqa: ARG001 — name is opaque at begin
     username: str = Depends(get_current_user),
     store: SqliteStore = Depends(get_store),
 ) -> dict[str, Any]:
@@ -111,6 +112,8 @@ async def enroll_begin(
     The caller is identified by the existing JWT/API-key auth; we look
     up the user row, build options including any already-enrolled
     credential ids in ``excludeCredentials``, and cache the challenge.
+    The credential ``name`` is supplied at finish time (in
+    ``EnrollFinishRequest``), not begin — begin takes no body.
     """
     user = await store.get_user(username)
     if user is None:
@@ -142,9 +145,20 @@ async def enroll_finish(
             transports=request.transports,
         )
     except ValueError as exc:
+        # ValueError comes from our own `passkey.finish_registration` for
+        # cache-miss / TTL conditions — message is operator-controlled,
+        # safe to surface.
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    except Exception as exc:  # noqa: BLE001 — py_webauthn raises subclasses of Exception
-        raise HTTPException(status_code=400, detail=f"registration verification failed: {exc}") from exc
+    except (
+        InvalidRegistrationResponse,
+        InvalidAuthenticationResponse,
+        InvalidJSONStructure,
+    ) as exc:
+        # py_webauthn-internal failure messages can leak parsed-CBOR
+        # fragments and authenticator-data fields; log server-side, return
+        # a generic 400 to the client.
+        logger.info("passkey enrollment verification failed for %s: %s", username, exc)
+        raise HTTPException(status_code=400, detail="passkey verification failed") from None
 
     transports_csv = ",".join(verified.transports) if verified.transports else None
     row = await store.insert_webauthn_credential(
@@ -232,8 +246,15 @@ async def login_finish(
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    except Exception as exc:  # noqa: BLE001 — py_webauthn replay raises InvalidAuthenticationResponse
-        raise HTTPException(status_code=400, detail=f"authentication failed: {exc}") from exc
+    except (
+        InvalidRegistrationResponse,
+        InvalidAuthenticationResponse,
+        InvalidJSONStructure,
+    ) as exc:
+        # py_webauthn raises InvalidAuthenticationResponse for the
+        # replay-attack / clone-detection path. Don't leak its message.
+        logger.info("passkey login verification failed for %s: %s", request.username, exc)
+        raise HTTPException(status_code=400, detail="passkey verification failed") from None
 
     await store.update_webauthn_sign_count(
         credential_id=verified.credential_id,

--- a/server/backend/src/cq_server/store/_sqlite.py
+++ b/server/backend/src/cq_server/store/_sqlite.py
@@ -224,9 +224,7 @@ class SqliteStore:
     async def get_webauthn_credential_by_id(self, credential_id: bytes) -> dict[str, Any] | None:
         return await self._run_sync(self._get_webauthn_credential_by_id_sync, credential_id)
 
-    async def update_webauthn_sign_count(
-        self, *, credential_id: bytes, new_sign_count: int, last_used_at: str
-    ) -> None:
+    async def update_webauthn_sign_count(self, *, credential_id: bytes, new_sign_count: int, last_used_at: str) -> None:
         await self._run_sync(
             self._update_webauthn_sign_count_sync,
             credential_id=credential_id,
@@ -4236,15 +4234,10 @@ class SqliteStore:
             "last_used_at": row[9],
         }
 
-    def _update_webauthn_sign_count_sync(
-        self, *, credential_id: bytes, new_sign_count: int, last_used_at: str
-    ) -> None:
+    def _update_webauthn_sign_count_sync(self, *, credential_id: bytes, new_sign_count: int, last_used_at: str) -> None:
         with self._engine.begin() as conn:
             conn.execute(
-                text(
-                    "UPDATE webauthn_credentials SET sign_count = :sc, last_used_at = :lu "
-                    "WHERE credential_id = :cid"
-                ),
+                text("UPDATE webauthn_credentials SET sign_count = :sc, last_used_at = :lu WHERE credential_id = :cid"),
                 {"sc": new_sign_count, "lu": last_used_at, "cid": credential_id},
             )
 

--- a/server/backend/src/cq_server/store/_sqlite.py
+++ b/server/backend/src/cq_server/store/_sqlite.py
@@ -194,6 +194,49 @@ class SqliteStore:
     async def create_user(self, username: str, password_hash: str) -> None:
         await self._run_sync(self._create_user_sync, username, password_hash)
 
+    # --- WebAuthn / passkey credentials (FO-1a, #191) ---------------------
+
+    async def insert_webauthn_credential(
+        self,
+        *,
+        user_id: int,
+        credential_id: bytes,
+        public_key: bytes,
+        sign_count: int,
+        transports: str | None = None,
+        aaguid: bytes | None = None,
+        name: str | None = None,
+    ) -> dict[str, Any]:
+        return await self._run_sync(
+            self._insert_webauthn_credential_sync,
+            user_id=user_id,
+            credential_id=credential_id,
+            public_key=public_key,
+            sign_count=sign_count,
+            transports=transports,
+            aaguid=aaguid,
+            name=name,
+        )
+
+    async def list_webauthn_credentials_for_user(self, user_id: int) -> list[dict[str, Any]]:
+        return await self._run_sync(self._list_webauthn_credentials_for_user_sync, user_id)
+
+    async def get_webauthn_credential_by_id(self, credential_id: bytes) -> dict[str, Any] | None:
+        return await self._run_sync(self._get_webauthn_credential_by_id_sync, credential_id)
+
+    async def update_webauthn_sign_count(
+        self, *, credential_id: bytes, new_sign_count: int, last_used_at: str
+    ) -> None:
+        await self._run_sync(
+            self._update_webauthn_sign_count_sync,
+            credential_id=credential_id,
+            new_sign_count=new_sign_count,
+            last_used_at=last_used_at,
+        )
+
+    async def get_user_by_email(self, email: str) -> dict[str, Any] | None:
+        return await self._run_sync(self._get_user_by_email_sync, email)
+
     async def daily_counts(
         self,
         *,
@@ -4095,6 +4138,137 @@ class SqliteStore:
                 {"since": lookback_iso},
             ).fetchall()
         return [self._reflect_row_to_dict(r) for r in rows]
+
+    # --- WebAuthn / passkey sync impls (FO-1a, #191) ----------------------
+
+    def _insert_webauthn_credential_sync(
+        self,
+        *,
+        user_id: int,
+        credential_id: bytes,
+        public_key: bytes,
+        sign_count: int,
+        transports: str | None,
+        aaguid: bytes | None,
+        name: str | None,
+    ) -> dict[str, Any]:
+        created_at = datetime.now(UTC).isoformat()
+        with self._engine.begin() as conn:
+            result = conn.execute(
+                text(
+                    "INSERT INTO webauthn_credentials "
+                    "(user_id, credential_id, public_key, sign_count, transports, aaguid, name, created_at) "
+                    "VALUES (:uid, :cid, :pk, :sc, :tr, :ag, :nm, :ca)"
+                ),
+                {
+                    "uid": user_id,
+                    "cid": credential_id,
+                    "pk": public_key,
+                    "sc": sign_count,
+                    "tr": transports,
+                    "ag": aaguid,
+                    "nm": name,
+                    "ca": created_at,
+                },
+            )
+            row_id = result.lastrowid
+        return {
+            "id": row_id,
+            "user_id": user_id,
+            "credential_id": credential_id,
+            "public_key": public_key,
+            "sign_count": sign_count,
+            "transports": transports,
+            "aaguid": aaguid,
+            "name": name,
+            "created_at": created_at,
+            "last_used_at": None,
+        }
+
+    def _list_webauthn_credentials_for_user_sync(self, user_id: int) -> list[dict[str, Any]]:
+        with self._engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT id, user_id, credential_id, public_key, sign_count, transports, "
+                    "aaguid, name, created_at, last_used_at "
+                    "FROM webauthn_credentials WHERE user_id = :uid ORDER BY id ASC"
+                ),
+                {"uid": user_id},
+            ).fetchall()
+        return [
+            {
+                "id": r[0],
+                "user_id": r[1],
+                "credential_id": bytes(r[2]),
+                "public_key": bytes(r[3]),
+                "sign_count": r[4],
+                "transports": r[5],
+                "aaguid": bytes(r[6]) if r[6] is not None else None,
+                "name": r[7],
+                "created_at": r[8],
+                "last_used_at": r[9],
+            }
+            for r in rows
+        ]
+
+    def _get_webauthn_credential_by_id_sync(self, credential_id: bytes) -> dict[str, Any] | None:
+        with self._engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT id, user_id, credential_id, public_key, sign_count, transports, "
+                    "aaguid, name, created_at, last_used_at "
+                    "FROM webauthn_credentials WHERE credential_id = :cid"
+                ),
+                {"cid": credential_id},
+            ).fetchone()
+        if row is None:
+            return None
+        return {
+            "id": row[0],
+            "user_id": row[1],
+            "credential_id": bytes(row[2]),
+            "public_key": bytes(row[3]),
+            "sign_count": row[4],
+            "transports": row[5],
+            "aaguid": bytes(row[6]) if row[6] is not None else None,
+            "name": row[7],
+            "created_at": row[8],
+            "last_used_at": row[9],
+        }
+
+    def _update_webauthn_sign_count_sync(
+        self, *, credential_id: bytes, new_sign_count: int, last_used_at: str
+    ) -> None:
+        with self._engine.begin() as conn:
+            conn.execute(
+                text(
+                    "UPDATE webauthn_credentials SET sign_count = :sc, last_used_at = :lu "
+                    "WHERE credential_id = :cid"
+                ),
+                {"sc": new_sign_count, "lu": last_used_at, "cid": credential_id},
+            )
+
+    def _get_user_by_email_sync(self, email: str) -> dict[str, Any] | None:
+        with self._engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT id, username, password_hash, created_at, role, "
+                    "enterprise_id, group_id, email FROM users WHERE email = :e"
+                ),
+                {"e": email},
+            ).fetchone()
+        if row is None:
+            return None
+        return {
+            "id": row[0],
+            "username": row[1],
+            "password_hash": row[2],
+            "created_at": row[3],
+            "role": row[4],
+            "enterprise_id": row[5],
+            "group_id": row[6],
+            "email": row[7],
+        }
 
 
 class _SyncStoreProxy:

--- a/server/backend/tests/test_default_enterprise_backfill.py
+++ b/server/backend/tests/test_default_enterprise_backfill.py
@@ -407,6 +407,7 @@ class TestIdempotencyAndChain:
         ``run_migrations`` silently misses the new revision on stamped
         DBs. Pin the constant so the chain head is the source of truth.
         """
-        # Bumped to 0016_xgroup_consent (Phase 1.0b — Decision 28).
-        # Chains after 0015_phase_1_0c_aigrp_peers_pair_secret_ref.
-        assert HEAD_REVISION == "0016_xgroup_consent"
+        # Bumped to 0018_webauthn_credentials (FO-1a — passkey enrollment
+        # substrate, #191). Chains after 0017_add_user_email (additive
+        # ``email`` column on ``users``).
+        assert HEAD_REVISION == "0018_webauthn_credentials"

--- a/server/backend/tests/test_migration_0011_activity_log.py
+++ b/server/backend/tests/test_migration_0011_activity_log.py
@@ -473,13 +473,13 @@ class TestHeadRevisionAndHistory:
         is the source of truth for ops scripts and stamp logic."""
         from cq_server.migrations import HEAD_REVISION
 
-        # Bumped by 0016_xgroup_consent (Phase 1.0b — Decision 28
-        # intra-Enterprise xgroup_consent + AIGRP key protocols).
-        # Earlier bumps: 0015 (Phase 1.0c — Decision 27/28 audit gap),
-        # 0014 (#124 crosstalk tables), 0013 (#121 finding 3), 0012
-        # (#103), 0011 (#108 Stage 1). Each new migration MUST move
-        # this constant.
-        assert HEAD_REVISION == "0016_xgroup_consent"
+        # Bumped by 0018_webauthn_credentials (FO-1a passkey enrollment
+        # substrate, #191) — chains after 0017_add_user_email. Earlier
+        # bumps: 0016 (Phase 1.0b xgroup_consent + AIGRP key protocols),
+        # 0015 (Phase 1.0c — Decision 27/28 audit gap), 0014 (#124
+        # crosstalk tables), 0013 (#121 finding 3), 0012 (#103), 0011
+        # (#108 Stage 1). Each new migration MUST move this constant.
+        assert HEAD_REVISION == "0018_webauthn_credentials"
 
     @pytest.mark.parametrize("invalid_dir", [None])
     def test_alembic_history_includes_0011(self, invalid_dir: object) -> None:

--- a/server/backend/tests/test_migration_0015_aigrp_peers_pair_secret_ref.py
+++ b/server/backend/tests/test_migration_0015_aigrp_peers_pair_secret_ref.py
@@ -271,7 +271,11 @@ class TestHeadRevisionAndHistory:
     def test_head_revision_constant_was_bumped(self) -> None:
         from cq_server.migrations import HEAD_REVISION
 
-        assert HEAD_REVISION == "0015_phase_1_0c_aigrp_peers_pair_secret_ref"
+        # NOTE: this pin originally asserted 0015 (the rev introduced by
+        # this test file), then jumped past 0016 unupdated. FO-1a (#191)
+        # bumps to 0018_webauthn_credentials; the lineage 0015 → 0016
+        # → 0017 → 0018 is exercised by ``test_migrations`` regardless.
+        assert HEAD_REVISION == "0018_webauthn_credentials"
 
     def test_alembic_history_includes_0015(self) -> None:
         repo_root = Path(__file__).resolve().parents[1]

--- a/server/backend/tests/test_passkey.py
+++ b/server/backend/tests/test_passkey.py
@@ -59,19 +59,20 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
     monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "test.db"))
     monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
     monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    monkeypatch.setenv("CQ_TESTING", "1")
     monkeypatch.setenv("CQ_WEBAUTHN_RP_ID", RP_ID)
     monkeypatch.setenv("CQ_WEBAUTHN_RP_ORIGIN", RP_ORIGIN)
     monkeypatch.setenv("CQ_WEBAUTHN_RP_NAME", RP_NAME)
     # Reset the in-process challenge cache between tests so per-test
     # state never leaks across cases.
-    passkey.set_challenge_cache_override(None)
+    passkey._set_challenge_cache_override_for_tests(None)
     app.dependency_overrides[require_api_key] = lambda: "alice"
     app.dependency_overrides[get_current_user] = lambda: "alice"
     with TestClient(app) as c:
         yield c
     app.dependency_overrides.pop(require_api_key, None)
     app.dependency_overrides.pop(get_current_user, None)
-    passkey.set_challenge_cache_override(None)
+    passkey._set_challenge_cache_override_for_tests(None)
 
 
 def _seed_user(username: str = "alice", password: str = "secret123") -> None:
@@ -376,3 +377,45 @@ class TestLoginFinish:
             json={"username": "alice", "credential": replay},
         )
         assert bad.status_code == 400
+        # Generic detail — py_webauthn's internal exception message is
+        # logged server-side, not surfaced to the client (review fix #2).
+        assert bad.json()["detail"] == "passkey verification failed"
+
+
+class TestRpConfigHardening:
+    """Verify the env-gated dev-default pattern (review fix #1)."""
+
+    def test_rp_id_raises_in_non_dev_when_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CQ_ENV", "production")
+        monkeypatch.delenv("CQ_WEBAUTHN_RP_ID", raising=False)
+        with pytest.raises(RuntimeError, match="CQ_WEBAUTHN_RP_ID is required"):
+            passkey.rp_id()
+
+    def test_rp_origin_rejects_http_in_non_dev(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CQ_ENV", "production")
+        monkeypatch.setenv("CQ_WEBAUTHN_RP_ORIGIN", "http://insecure.example.com")
+        with pytest.raises(RuntimeError, match="must use https://"):
+            passkey.rp_origin()
+
+    def test_rp_id_returns_default_in_dev(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CQ_ENV", "dev")
+        monkeypatch.delenv("CQ_WEBAUTHN_RP_ID", raising=False)
+        assert passkey.rp_id() == passkey.DEFAULT_RP_ID
+
+
+class TestChallengeCacheGate:
+    """Verify the test-only injection point refuses to fire in production
+    (review fix #3)."""
+
+    def test_override_refuses_without_cq_testing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("CQ_TESTING", raising=False)
+        with pytest.raises(RuntimeError, match="test-only"):
+            passkey._set_challenge_cache_override_for_tests({})

--- a/server/backend/tests/test_passkey.py
+++ b/server/backend/tests/test_passkey.py
@@ -115,24 +115,14 @@ class _FakeAuthenticator:
     def _rp_id_hash(self, rp_id: str) -> bytes:
         return hashlib.sha256(rp_id.encode()).digest()
 
-    def make_registration_credential(
-        self, *, challenge: bytes, rp_id: str, origin: str
-    ) -> dict[str, Any]:
+    def make_registration_credential(self, *, challenge: bytes, rp_id: str, origin: str) -> dict[str, Any]:
         """Build a registration response with fmt=none."""
         flags = 0x41  # UP | AT
         sign_count = 0
         attested_cred_data = (
-            self.aaguid
-            + struct.pack(">H", len(self.credential_id))
-            + self.credential_id
-            + self.cose_public_key()
+            self.aaguid + struct.pack(">H", len(self.credential_id)) + self.credential_id + self.cose_public_key()
         )
-        auth_data = (
-            self._rp_id_hash(rp_id)
-            + bytes([flags])
-            + struct.pack(">I", sign_count)
-            + attested_cred_data
-        )
+        auth_data = self._rp_id_hash(rp_id) + bytes([flags]) + struct.pack(">I", sign_count) + attested_cred_data
         client_data = json.dumps(
             {
                 "type": "webauthn.create",
@@ -142,9 +132,7 @@ class _FakeAuthenticator:
             },
             separators=(",", ":"),
         ).encode()
-        attestation_object = cbor2.dumps(
-            {"fmt": "none", "attStmt": {}, "authData": auth_data}
-        )
+        attestation_object = cbor2.dumps({"fmt": "none", "attStmt": {}, "authData": auth_data})
         cred_id_b64u = bytes_to_base64url(self.credential_id)
         return {
             "id": cred_id_b64u,
@@ -166,9 +154,7 @@ class _FakeAuthenticator:
         user_handle: bytes = b"\x00" * 8,
     ) -> dict[str, Any]:
         """Build an assertion response signed with the stored EC key."""
-        auth_data = (
-            self._rp_id_hash(rp_id) + bytes([0x01]) + struct.pack(">I", sign_count)
-        )
+        auth_data = self._rp_id_hash(rp_id) + bytes([0x01]) + struct.pack(">I", sign_count)
         client_data = json.dumps(
             {
                 "type": "webauthn.get",
@@ -236,9 +222,7 @@ class TestEnrollFinish:
         challenge = _challenge_from_options(begin)
 
         authenticator = _FakeAuthenticator()
-        cred = authenticator.make_registration_credential(
-            challenge=challenge, rp_id=RP_ID, origin=RP_ORIGIN
-        )
+        cred = authenticator.make_registration_credential(challenge=challenge, rp_id=RP_ID, origin=RP_ORIGIN)
         resp = client.post(
             "/auth/passkey/enroll/finish",
             json={"credential": cred, "name": "DW's YubiKey"},
@@ -260,9 +244,7 @@ class TestEnrollFinish:
 
 
 class TestLoginBegin:
-    def test_login_begin_returns_options_for_known_user(
-        self, client: TestClient
-    ) -> None:
+    def test_login_begin_returns_options_for_known_user(self, client: TestClient) -> None:
         _seed_user()
         # First enroll one credential so login/begin has something to allow.
         begin = client.post("/auth/passkey/enroll/begin", json={}).json()
@@ -274,22 +256,16 @@ class TestLoginBegin:
         )
         client.post("/auth/passkey/enroll/finish", json={"credential": cred})
 
-        resp = client.post(
-            "/auth/passkey/login/begin", json={"username": "alice"}
-        )
+        resp = client.post("/auth/passkey/login/begin", json={"username": "alice"})
         assert resp.status_code == 200, resp.text
         body = resp.json()
         assert body["rpId"] == RP_ID
         # ``allowCredentials`` is the camelCased wire shape py_webauthn emits.
         assert len(body["allowCredentials"]) == 1
-        assert body["allowCredentials"][0]["id"] == bytes_to_base64url(
-            authenticator.credential_id
-        )
+        assert body["allowCredentials"][0]["id"] == bytes_to_base64url(authenticator.credential_id)
 
     def test_login_begin_unknown_user_404(self, client: TestClient) -> None:
-        resp = client.post(
-            "/auth/passkey/login/begin", json={"username": "ghost"}
-        )
+        resp = client.post("/auth/passkey/login/begin", json={"username": "ghost"})
         assert resp.status_code == 404
 
 
@@ -306,13 +282,9 @@ class TestLoginFinish:
         client.post("/auth/passkey/enroll/finish", json={"credential": cred})
         return authenticator
 
-    def test_login_finish_mints_jwt_and_advances_sign_count(
-        self, client: TestClient
-    ) -> None:
+    def test_login_finish_mints_jwt_and_advances_sign_count(self, client: TestClient) -> None:
         authenticator = self._enroll(client)
-        login_begin = client.post(
-            "/auth/passkey/login/begin", json={"username": "alice"}
-        ).json()
+        login_begin = client.post("/auth/passkey/login/begin", json={"username": "alice"}).json()
         assertion = authenticator.make_authentication_credential(
             challenge=_challenge_from_options(login_begin),
             rp_id=RP_ID,
@@ -328,9 +300,7 @@ class TestLoginFinish:
         assert body["username"] == "alice"
         assert body["sign_count"] == 1
         # The JWT verifies under the same secret the server uses.
-        payload = verify_token(
-            body["token"], secret="test-secret-thirty-two-chars-min!"
-        )
+        payload = verify_token(body["token"], secret="test-secret-thirty-two-chars-min!")
         assert payload["sub"] == "alice"
 
         # The DB row's sign_count advanced too.
@@ -345,9 +315,7 @@ class TestLoginFinish:
         """Same signCount on a subsequent assertion is a clone signal."""
         authenticator = self._enroll(client)
         # First successful login — advances sign_count to 1.
-        login_begin = client.post(
-            "/auth/passkey/login/begin", json={"username": "alice"}
-        ).json()
+        login_begin = client.post("/auth/passkey/login/begin", json={"username": "alice"}).json()
         assertion = authenticator.make_authentication_credential(
             challenge=_challenge_from_options(login_begin),
             rp_id=RP_ID,
@@ -363,9 +331,7 @@ class TestLoginFinish:
         # Replay with the SAME signCount — py_webauthn requires strictly
         # greater. New begin first to seed a fresh challenge so the only
         # thing failing is the signCount.
-        login_begin_2 = client.post(
-            "/auth/passkey/login/begin", json={"username": "alice"}
-        ).json()
+        login_begin_2 = client.post("/auth/passkey/login/begin", json={"username": "alice"}).json()
         replay = authenticator.make_authentication_credential(
             challenge=_challenge_from_options(login_begin_2),
             rp_id=RP_ID,
@@ -385,25 +351,19 @@ class TestLoginFinish:
 class TestRpConfigHardening:
     """Verify the env-gated dev-default pattern (review fix #1)."""
 
-    def test_rp_id_raises_in_non_dev_when_unset(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_rp_id_raises_in_non_dev_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CQ_ENV", "production")
         monkeypatch.delenv("CQ_WEBAUTHN_RP_ID", raising=False)
         with pytest.raises(RuntimeError, match="CQ_WEBAUTHN_RP_ID is required"):
             passkey.rp_id()
 
-    def test_rp_origin_rejects_http_in_non_dev(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_rp_origin_rejects_http_in_non_dev(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CQ_ENV", "production")
         monkeypatch.setenv("CQ_WEBAUTHN_RP_ORIGIN", "http://insecure.example.com")
         with pytest.raises(RuntimeError, match="must use https://"):
             passkey.rp_origin()
 
-    def test_rp_id_returns_default_in_dev(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_rp_id_returns_default_in_dev(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CQ_ENV", "dev")
         monkeypatch.delenv("CQ_WEBAUTHN_RP_ID", raising=False)
         assert passkey.rp_id() == passkey.DEFAULT_RP_ID
@@ -413,9 +373,7 @@ class TestChallengeCacheGate:
     """Verify the test-only injection point refuses to fire in production
     (review fix #3)."""
 
-    def test_override_refuses_without_cq_testing(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_override_refuses_without_cq_testing(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("CQ_TESTING", raising=False)
         with pytest.raises(RuntimeError, match="test-only"):
             passkey._set_challenge_cache_override_for_tests({})

--- a/server/backend/tests/test_passkey.py
+++ b/server/backend/tests/test_passkey.py
@@ -1,0 +1,378 @@
+"""End-to-end tests for the FO-1a passkey enrollment substrate (#191).
+
+Covers the four ceremony endpoints plus a replay-attack negative case:
+
+* ``test_enroll_begin_returns_options_shape`` — the registration options
+  emitted to the browser have the WebAuthn-mandated keys and the
+  challenge round-trips through the in-process cache.
+* ``test_enroll_finish_persists_credential`` — a synthesised "none"
+  attestation completes registration and a row lands in
+  ``webauthn_credentials``.
+* ``test_login_begin_returns_options_for_known_user`` — assertion
+  options come back with the user's credential id pre-populated.
+* ``test_login_finish_mints_jwt_and_advances_sign_count`` — a successful
+  assertion increments ``sign_count`` and yields a JWT verifiable by
+  the existing ``auth.verify_token``.
+* ``test_login_finish_rejects_replay`` — re-using the same authenticator
+  output (same ``signCount``) on the next login fails with 400. This is
+  the one safety property the WebAuthn spec demands of relying parties.
+
+The "fake authenticator" is a Python EC P-256 key + manual CBOR
+(authenticator data + COSE public-key) construction. py_webauthn's
+``verify_registration_response`` happily accepts ``fmt="none"`` so we
+don't need to construct an attestation statement.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import secrets
+import struct
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import cbor2
+import pytest
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from fastapi.testclient import TestClient
+from webauthn.helpers import bytes_to_base64url
+
+from cq_server import passkey
+from cq_server.app import app
+from cq_server.auth import get_current_user, hash_password, verify_token
+from cq_server.deps import require_api_key
+
+RP_ID = "localhost"
+RP_ORIGIN = "http://localhost:3000"
+RP_NAME = "8th-Layer test"
+
+
+# --- Fixtures -------------------------------------------------------------
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    """Spin up a TestClient with a fresh DB and the auth dep overridden."""
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "test.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    monkeypatch.setenv("CQ_WEBAUTHN_RP_ID", RP_ID)
+    monkeypatch.setenv("CQ_WEBAUTHN_RP_ORIGIN", RP_ORIGIN)
+    monkeypatch.setenv("CQ_WEBAUTHN_RP_NAME", RP_NAME)
+    # Reset the in-process challenge cache between tests so per-test
+    # state never leaks across cases.
+    passkey.set_challenge_cache_override(None)
+    app.dependency_overrides[require_api_key] = lambda: "alice"
+    app.dependency_overrides[get_current_user] = lambda: "alice"
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.pop(require_api_key, None)
+    app.dependency_overrides.pop(get_current_user, None)
+    passkey.set_challenge_cache_override(None)
+
+
+def _seed_user(username: str = "alice", password: str = "secret123") -> None:
+    """Insert a user row directly via the store sync proxy."""
+    from cq_server.app import _get_store
+
+    store = _get_store()
+    store.sync.create_user(username, hash_password(password))
+
+
+# --- Fake-authenticator helpers ------------------------------------------
+
+
+class _FakeAuthenticator:
+    """Holds an EC P-256 keypair and produces WebAuthn ceremony payloads.
+
+    Real authenticators ship signed authenticator data + a COSE public
+    key; we synthesise both. Default attestation format is "none" since
+    py_webauthn accepts that for any algorithm and skips trust-path
+    verification.
+    """
+
+    def __init__(self) -> None:
+        self.priv = ec.generate_private_key(ec.SECP256R1())
+        self.credential_id = secrets.token_bytes(16)
+        self.aaguid = b"\x00" * 16
+
+    def cose_public_key(self) -> bytes:
+        nums = self.priv.public_key().public_numbers()
+        return cbor2.dumps(
+            {
+                1: 2,  # kty=EC2
+                3: -7,  # alg=ES256
+                -1: 1,  # crv=P-256
+                -2: nums.x.to_bytes(32, "big"),
+                -3: nums.y.to_bytes(32, "big"),
+            }
+        )
+
+    def _rp_id_hash(self, rp_id: str) -> bytes:
+        return hashlib.sha256(rp_id.encode()).digest()
+
+    def make_registration_credential(
+        self, *, challenge: bytes, rp_id: str, origin: str
+    ) -> dict[str, Any]:
+        """Build a registration response with fmt=none."""
+        flags = 0x41  # UP | AT
+        sign_count = 0
+        attested_cred_data = (
+            self.aaguid
+            + struct.pack(">H", len(self.credential_id))
+            + self.credential_id
+            + self.cose_public_key()
+        )
+        auth_data = (
+            self._rp_id_hash(rp_id)
+            + bytes([flags])
+            + struct.pack(">I", sign_count)
+            + attested_cred_data
+        )
+        client_data = json.dumps(
+            {
+                "type": "webauthn.create",
+                "challenge": bytes_to_base64url(challenge),
+                "origin": origin,
+                "crossOrigin": False,
+            },
+            separators=(",", ":"),
+        ).encode()
+        attestation_object = cbor2.dumps(
+            {"fmt": "none", "attStmt": {}, "authData": auth_data}
+        )
+        cred_id_b64u = bytes_to_base64url(self.credential_id)
+        return {
+            "id": cred_id_b64u,
+            "rawId": cred_id_b64u,
+            "type": "public-key",
+            "response": {
+                "clientDataJSON": bytes_to_base64url(client_data),
+                "attestationObject": bytes_to_base64url(attestation_object),
+            },
+        }
+
+    def make_authentication_credential(
+        self,
+        *,
+        challenge: bytes,
+        rp_id: str,
+        origin: str,
+        sign_count: int,
+        user_handle: bytes = b"\x00" * 8,
+    ) -> dict[str, Any]:
+        """Build an assertion response signed with the stored EC key."""
+        auth_data = (
+            self._rp_id_hash(rp_id) + bytes([0x01]) + struct.pack(">I", sign_count)
+        )
+        client_data = json.dumps(
+            {
+                "type": "webauthn.get",
+                "challenge": bytes_to_base64url(challenge),
+                "origin": origin,
+                "crossOrigin": False,
+            },
+            separators=(",", ":"),
+        ).encode()
+        signature = self.priv.sign(
+            auth_data + hashlib.sha256(client_data).digest(),
+            ec.ECDSA(hashes.SHA256()),
+        )
+        cred_id_b64u = bytes_to_base64url(self.credential_id)
+        return {
+            "id": cred_id_b64u,
+            "rawId": cred_id_b64u,
+            "type": "public-key",
+            "response": {
+                "clientDataJSON": bytes_to_base64url(client_data),
+                "authenticatorData": bytes_to_base64url(auth_data),
+                "signature": bytes_to_base64url(signature),
+                "userHandle": bytes_to_base64url(user_handle),
+            },
+        }
+
+
+def _challenge_from_options(options: dict[str, Any]) -> bytes:
+    """Pull the challenge bytes out of the options dict.
+
+    py_webauthn emits challenges as base64url strings on the JSON
+    options shape; both registration and authentication share that
+    field name.
+    """
+    from webauthn.helpers import base64url_to_bytes
+
+    return base64url_to_bytes(options["challenge"])
+
+
+# --- Tests ----------------------------------------------------------------
+
+
+class TestEnrollBegin:
+    def test_enroll_begin_returns_options_shape(self, client: TestClient) -> None:
+        _seed_user()
+        resp = client.post("/auth/passkey/enroll/begin", json={})
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        # WebAuthn mandates these keys on the registration options.
+        assert body["rp"]["id"] == RP_ID
+        assert body["rp"]["name"] == RP_NAME
+        assert body["user"]["name"] == "alice"
+        assert isinstance(body["challenge"], str) and len(body["challenge"]) > 0
+        assert body["pubKeyCredParams"]
+        # The challenge round-trips through the in-process cache.
+        from cq_server import passkey as pk
+
+        assert "alice" in pk._challenge_cache  # noqa: SLF001 — test introspection
+
+
+class TestEnrollFinish:
+    def test_enroll_finish_persists_credential(self, client: TestClient) -> None:
+        _seed_user()
+        begin = client.post("/auth/passkey/enroll/begin", json={}).json()
+        challenge = _challenge_from_options(begin)
+
+        authenticator = _FakeAuthenticator()
+        cred = authenticator.make_registration_credential(
+            challenge=challenge, rp_id=RP_ID, origin=RP_ORIGIN
+        )
+        resp = client.post(
+            "/auth/passkey/enroll/finish",
+            json={"credential": cred, "name": "DW's YubiKey"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["credential_db_id"] >= 1
+        assert body["sign_count"] == 0
+
+        # Row landed; credential_id matches the synthetic authenticator.
+        from cq_server.app import _get_store
+
+        store = _get_store()
+        rows = store.sync.list_webauthn_credentials_for_user(1)
+        assert len(rows) == 1
+        assert rows[0]["credential_id"] == authenticator.credential_id
+        assert rows[0]["sign_count"] == 0
+        assert rows[0]["name"] == "DW's YubiKey"
+
+
+class TestLoginBegin:
+    def test_login_begin_returns_options_for_known_user(
+        self, client: TestClient
+    ) -> None:
+        _seed_user()
+        # First enroll one credential so login/begin has something to allow.
+        begin = client.post("/auth/passkey/enroll/begin", json={}).json()
+        authenticator = _FakeAuthenticator()
+        cred = authenticator.make_registration_credential(
+            challenge=_challenge_from_options(begin),
+            rp_id=RP_ID,
+            origin=RP_ORIGIN,
+        )
+        client.post("/auth/passkey/enroll/finish", json={"credential": cred})
+
+        resp = client.post(
+            "/auth/passkey/login/begin", json={"username": "alice"}
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["rpId"] == RP_ID
+        # ``allowCredentials`` is the camelCased wire shape py_webauthn emits.
+        assert len(body["allowCredentials"]) == 1
+        assert body["allowCredentials"][0]["id"] == bytes_to_base64url(
+            authenticator.credential_id
+        )
+
+    def test_login_begin_unknown_user_404(self, client: TestClient) -> None:
+        resp = client.post(
+            "/auth/passkey/login/begin", json={"username": "ghost"}
+        )
+        assert resp.status_code == 404
+
+
+class TestLoginFinish:
+    def _enroll(self, client: TestClient) -> _FakeAuthenticator:
+        _seed_user()
+        begin = client.post("/auth/passkey/enroll/begin", json={}).json()
+        authenticator = _FakeAuthenticator()
+        cred = authenticator.make_registration_credential(
+            challenge=_challenge_from_options(begin),
+            rp_id=RP_ID,
+            origin=RP_ORIGIN,
+        )
+        client.post("/auth/passkey/enroll/finish", json={"credential": cred})
+        return authenticator
+
+    def test_login_finish_mints_jwt_and_advances_sign_count(
+        self, client: TestClient
+    ) -> None:
+        authenticator = self._enroll(client)
+        login_begin = client.post(
+            "/auth/passkey/login/begin", json={"username": "alice"}
+        ).json()
+        assertion = authenticator.make_authentication_credential(
+            challenge=_challenge_from_options(login_begin),
+            rp_id=RP_ID,
+            origin=RP_ORIGIN,
+            sign_count=1,
+        )
+        resp = client.post(
+            "/auth/passkey/login/finish",
+            json={"username": "alice", "credential": assertion},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["username"] == "alice"
+        assert body["sign_count"] == 1
+        # The JWT verifies under the same secret the server uses.
+        payload = verify_token(
+            body["token"], secret="test-secret-thirty-two-chars-min!"
+        )
+        assert payload["sub"] == "alice"
+
+        # The DB row's sign_count advanced too.
+        from cq_server.app import _get_store
+
+        store = _get_store()
+        rows = store.sync.list_webauthn_credentials_for_user(1)
+        assert rows[0]["sign_count"] == 1
+        assert rows[0]["last_used_at"] is not None
+
+    def test_login_finish_rejects_replay(self, client: TestClient) -> None:
+        """Same signCount on a subsequent assertion is a clone signal."""
+        authenticator = self._enroll(client)
+        # First successful login — advances sign_count to 1.
+        login_begin = client.post(
+            "/auth/passkey/login/begin", json={"username": "alice"}
+        ).json()
+        assertion = authenticator.make_authentication_credential(
+            challenge=_challenge_from_options(login_begin),
+            rp_id=RP_ID,
+            origin=RP_ORIGIN,
+            sign_count=1,
+        )
+        ok = client.post(
+            "/auth/passkey/login/finish",
+            json={"username": "alice", "credential": assertion},
+        )
+        assert ok.status_code == 200
+
+        # Replay with the SAME signCount — py_webauthn requires strictly
+        # greater. New begin first to seed a fresh challenge so the only
+        # thing failing is the signCount.
+        login_begin_2 = client.post(
+            "/auth/passkey/login/begin", json={"username": "alice"}
+        ).json()
+        replay = authenticator.make_authentication_credential(
+            challenge=_challenge_from_options(login_begin_2),
+            rp_id=RP_ID,
+            origin=RP_ORIGIN,
+            sign_count=1,  # same as the previous successful login
+        )
+        bad = client.post(
+            "/auth/passkey/login/finish",
+            json={"username": "alice", "credential": replay},
+        )
+        assert bad.status_code == 400

--- a/server/backend/uv.lock
+++ b/server/backend/uv.lock
@@ -146,6 +146,49 @@ wheels = [
 ]
 
 [[package]]
+name = "cbor2"
+version = "6.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/fe/5d7f37d51ec21cccf9ae14a42a674907b8385779e639482f83c6eff1bcee/cbor2-6.0.1.tar.gz", hash = "sha256:46a745c296ec336fe83fa7905b77b4faa243eb32bb84fab1cfdb0e4636d1985b", size = 84191, upload-time = "2026-04-28T21:23:37.629Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/7d/b2f9cd0c27bce0415a7dec71d0073e29b8e3f5bf45ea25f6874392c24add/cbor2-6.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4d8dba16aa67ca13aa85849c5cbe4a88a353d6ed28ca8c11afc2ad9bc96b7ea7", size = 401782, upload-time = "2026-04-28T21:22:42.383Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/24/0d42399c25cdf9310f7a980c52a178dcc4cc4cc2786d435601396875ed3a/cbor2-6.0.1-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:3dfe0bf4dbd0e522d0446c5e544b5e43fcb23115996f556b7d02092fc07bb0a1", size = 447870, upload-time = "2026-04-28T21:22:43.886Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/66/fbbdf6924848f2c31632e6801c0b109216bacbc278ebb11c21ad4b312336/cbor2-6.0.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:873ac665a1e8b3b9baa7d9384221917c828e8c72f670b2df887ed4a627367842", size = 458778, upload-time = "2026-04-28T21:22:45.582Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/79/183adadb623f88dd017caab8252a0750be97a0073d7ca3020101a315e636/cbor2-6.0.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:36519c11fda756c466b70082ff912708e9c6a6f8d0858983935f287654c1e75a", size = 514018, upload-time = "2026-04-28T21:22:47.334Z" },
+    { url = "https://files.pythonhosted.org/packages/37/47/9a3f2413100a68ec10416739bad2075e72f58e31c0ee51f59318cb86941b/cbor2-6.0.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d4659353f9ae454b1d2a3130f2690232c7bdb68f3d144558c4d8e0b5eb53691f", size = 525481, upload-time = "2026-04-28T21:22:48.95Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/e5/004946ebd82db48fc72cb18a0eea2f720de97dd3f5c7e87a5f2f716f1ed4/cbor2-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:ce23169d812f37636dbf92af67460a4eee5c340c4b838b883e307ac1cde9f67e", size = 288765, upload-time = "2026-04-28T21:22:50.679Z" },
+    { url = "https://files.pythonhosted.org/packages/58/48/f4a9250e17341341d6014cb45e9f5f01990fec00ebf32fd743c48dd99680/cbor2-6.0.1-cp311-cp311-win_arm64.whl", hash = "sha256:b7958d97f6d8646a336f035cfa7da74eccef4ce4295ae948e2f0f50210c2e8ee", size = 280895, upload-time = "2026-04-28T21:22:52.514Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/06/9bdbdf550f5bddb103efd0fa57023e73ec2339c8e1269a77191a5c5897d0/cbor2-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:778746168f80403dcb5e0e85a16076967652aef74bf2d13f53ce3d150e9b8be7", size = 401250, upload-time = "2026-04-28T21:22:53.838Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/0b/8c2b44c7513c58f96a2ef9fed97e504f965ed5cc922f08c1edfe9a0aa808/cbor2-6.0.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:82802f05ae595cfe451ab6a15948b20445a411fb83ef8568591577f6b91313aa", size = 445322, upload-time = "2026-04-28T21:22:55.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/6c/2c1d9a26bac69b9c97530e342a49c2d8a2fc0aa9e253c5645f074afa17d6/cbor2-6.0.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:65f0dc88cbd2cc252c31212b0bac3d10ae8e94db5e476a662022593cdd3cc56a", size = 456460, upload-time = "2026-04-28T21:22:57.021Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c1/feacc2e1278ef708787d61c5e670288353e68dc3a023246d57764e03f373/cbor2-6.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:10f0376763ce8913c1a5b9f21c51ca55848ed16795bd2b80860d56ed944374ab", size = 511095, upload-time = "2026-04-28T21:22:59.58Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2e/8c4b5d9d53ca3750ce19878e40be3a7628d7e6e4fb303456ed7c3fc03155/cbor2-6.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83d2b27908f8697041cee46af54ab684e9dd6e9710d70d31dc50e89cc908433d", size = 524005, upload-time = "2026-04-28T21:23:01.284Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/36/786ec690daad8d8574a2bf94e6532e39936bbad1d576f2225102298084d1/cbor2-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:4d324878156075778da61f9d4a09e6c4306493964f24f8fd92b43d97e99eac10", size = 288302, upload-time = "2026-04-28T21:23:03.081Z" },
+    { url = "https://files.pythonhosted.org/packages/97/64/757b3cede871c52af6e26d713546048953d66db60c8840e5a2434a412e70/cbor2-6.0.1-cp312-cp312-win_arm64.whl", hash = "sha256:3e8eaee64cd09d67a413e1fc758750e9e9c15cdb677a725163da834b981552ec", size = 277907, upload-time = "2026-04-28T21:23:04.518Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ee/d11300317773bc8e85e23f59fc71c732ba1176d059341588318cab81f501/cbor2-6.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:067d23ac75bfa35bed0e795169139259dc9d9bae503c8ede29740f99b37415f3", size = 400366, upload-time = "2026-04-28T21:23:06.234Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/be/0bc836d8259333277fc532d13197238b7c097e83c8ee3df13e8c5e418ec1/cbor2-6.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:5df6d0cd72c62dfb300facd6ccb982214fe3376b69f393d0d271e4436fd7b624", size = 444682, upload-time = "2026-04-28T21:23:07.494Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d0/3ffca18a38f0d8b6b1a6649d1245b876f5cf4cf9be3f5b2d19717b227af8/cbor2-6.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:50ebae27b72061c8baf3cd8458c3eb2de7c112d0be77af24e8c4206a2b0e7b61", size = 454983, upload-time = "2026-04-28T21:23:09.115Z" },
+    { url = "https://files.pythonhosted.org/packages/73/95/bc054345ef594a6ac92398a453f5e4ec7f45faaf6f18aff61d06fc9bc0c6/cbor2-6.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c1cfab10d65989cd79c203a00b5460feb6f34c519714779a77ccfb772704ff4b", size = 510410, upload-time = "2026-04-28T21:23:10.96Z" },
+    { url = "https://files.pythonhosted.org/packages/13/27/47bfc56a269d83713f69166dcadfba6890ff87cdae787c11bcd924d369f8/cbor2-6.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:df1e47d7dfb335ee82cd6593db111e6ca12d2c370a08a94d3622b4c08fda3b69", size = 522764, upload-time = "2026-04-28T21:23:12.376Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/c86f51bc78c211bcf685485a8c888713d714ebd64192435a45b68bef2b0b/cbor2-6.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:897f6fe58d1522608b6b71a7aa964f31c40deed5fff2d00511233bacb396dded", size = 287646, upload-time = "2026-04-28T21:23:13.799Z" },
+    { url = "https://files.pythonhosted.org/packages/97/e9/4670d40a86ae74b0afcb976e346d5429d745b6780a0407143346b4dab408/cbor2-6.0.1-cp313-cp313-win_arm64.whl", hash = "sha256:80765e22c387fb489102ed751f5706fc184c9cdb34257df3dab4d393564b00e6", size = 276903, upload-time = "2026-04-28T21:23:15.398Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b6/bf11bd69c8cb4b909caa1e098f8d29aab62694a1126ecace29e57e63fc1d/cbor2-6.0.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:67aa9514b08163de9c180d2a2bcf3f3a050d2a2ef9ca9bb8cc8b3a7bd4e6599d", size = 399070, upload-time = "2026-04-28T21:23:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/66/16/84b689706815f45a702c90043260f3588b6c75c188e0a6d47ff8b0d98b4e/cbor2-6.0.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:f173a5d6a686006c9edaeee5aab1356be2cba86c3af15b592e5cf8749831dcaf", size = 444127, upload-time = "2026-04-28T21:23:18.002Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/93/a7ff418ae1dc40ea06093550c5a6a7c20df602d4a75bd17f11b83c8344c3/cbor2-6.0.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:1eedb7bda2a528149ff95345e383c2f97104800debc9ef6f0cd693b46b0df4ff", size = 454497, upload-time = "2026-04-28T21:23:20.04Z" },
+    { url = "https://files.pythonhosted.org/packages/74/43/ea1c74b37b3ebb27567521e74f8c4d4dfdf30d65c0e26934a1717e5de4e0/cbor2-6.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ead214c6d4b4a6b20213c3a4a0e93a565acedbaa367f793cf5bf19936365fa46", size = 509875, upload-time = "2026-04-28T21:23:21.785Z" },
+    { url = "https://files.pythonhosted.org/packages/09/f0/4e2b87da1819d420e8a5b90e1e5cba000e241468b1967e7c695647835236/cbor2-6.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d177965364ae29b7d8854a0d38f41e2aa3ef2a440a8fd28550413ea649715eb5", size = 521864, upload-time = "2026-04-28T21:23:23.047Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a2/210c0adbf443cc09e05bb46ba74124a5cf61fac461d43dc83e23a2093e16/cbor2-6.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:fd7f89d53aea0e7d12a08fc8366a5d7d532d7bdf253b042d1e4fd33398ca6f17", size = 295871, upload-time = "2026-04-28T21:23:24.497Z" },
+    { url = "https://files.pythonhosted.org/packages/37/f4/409010a272ebb1ee7e7ddf4543b4d84d89dcf53c8d425db3c20dc2206e4c/cbor2-6.0.1-cp314-cp314-win_arm64.whl", hash = "sha256:6e8fca9f1860e81e7b78af9d5686380143a2474d6bf4dcae348219cd34013436", size = 286677, upload-time = "2026-04-28T21:23:25.933Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3d/075bd398465bc9fce9a2ad45d4c146f0e9de927348ff2e44d814af4bc84a/cbor2-6.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:943e3824c51312f747b0b164fc4ae96c191eae40685e049b28c747158a8613d0", size = 394250, upload-time = "2026-04-28T21:23:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/3a/925f975f3dc2fd61cec1990e634a88ca041cb31dfde47d6d5a6df492fa4a/cbor2-6.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:f390b24279229499c93f2ba40031fb9dd03cd2fc0d1ae757116013398bb25bc4", size = 436871, upload-time = "2026-04-28T21:23:29.242Z" },
+    { url = "https://files.pythonhosted.org/packages/34/19/4348be4671dd286a10adc1b5182210ddbb2087ed7cb619cf11515bc37721/cbor2-6.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:b8a3cf4a95b219eb10d72e31b6919f47a4928506ae95001e4384531bec5f787d", size = 449349, upload-time = "2026-04-28T21:23:30.66Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0a/3398bfe315162f5871abb4fe8662f4906b963514dc1f2a0e5ddf5579705f/cbor2-6.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:77cf35c614be31c5e8be761328b57ef6aaf43a78301e7df10faa7a8c626d6910", size = 502398, upload-time = "2026-04-28T21:23:31.951Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5d/a61bd7d1bb2df1988bd044352bddaa2cea5cf04a92176e957a7388872d04/cbor2-6.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7d936d14307311d0284f7d448fab47a4d1e279305005ffa733411eb81e0b7d81", size = 516987, upload-time = "2026-04-28T21:23:33.311Z" },
+    { url = "https://files.pythonhosted.org/packages/68/74/77c634d2b8aa3b0c10dd2edc28c4daf4d19b3ee7da3aa3f558397aaf4e38/cbor2-6.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:a4413d99d398858603be036016b59d21c1e6c3a4bb9d12fb9ccf4f8509afde05", size = 290210, upload-time = "2026-04-28T21:23:34.843Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/3a/347c49eb0c959a4342132de8b141af27733ddc873fdc84a17354cdb8bdab/cbor2-6.0.1-cp314-cp314t-win_arm64.whl", hash = "sha256:c6fcf7f406a5e5cda5e993d4dbd064b0cb22e84c9800966e2358a9172b3d4684", size = 278801, upload-time = "2026-04-28T21:23:36.35Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -285,6 +328,7 @@ dependencies = [
     { name = "rfc8785" },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "webauthn" },
 ]
 
 [package.dev-dependencies]
@@ -320,6 +364,7 @@ requires-dist = [
     { name = "rfc8785", specifier = ">=0.1.4" },
     { name = "sqlalchemy", specifier = ">=2.0.49,<2.1" },
     { name = "uvicorn", extras = ["standard"] },
+    { name = "webauthn", specifier = ">=2.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -817,6 +862,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -953,6 +1007,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a8/10/e8192be5f38f3e8e7e046716de4cae33d56fd5ae08927a823bb916be36c1/pyjwt-2.12.0.tar.gz", hash = "sha256:2f62390b667cd8257de560b850bb5a883102a388829274147f1d724453f8fb02", size = 102511, upload-time = "2026-03-12T17:15:30.831Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/70/70f895f404d363d291dcf62c12c85fdd47619ad9674ac0f53364d035925a/pyjwt-2.12.0-py3-none-any.whl", hash = "sha256:9bb459d1bdd0387967d287f5656bf7ec2b9a26645d1961628cda1764e087fd6e", size = 29700, upload-time = "2026-03-12T17:15:29.257Z" },
+]
+
+[[package]]
+name = "pyopenssl"
+version = "26.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/51/27a5ad5f939d08f690a326ef9582cda7140555180db71695f6fb747d6a36/pyopenssl-26.2.0.tar.gz", hash = "sha256:8c6fcecd1183a7fc897548dfe388b0cdb7f37e018200d8409cf33959dbe35387", size = 182195, upload-time = "2026-05-04T23:06:09.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/b8/a0e2790ae249d6f38c9f66de7a211621a7ab2650217bcd04e1262f578a56/pyopenssl-26.2.0-py3-none-any.whl", hash = "sha256:4f9d971bc5298b8bc1fab282803da04bf000c755d4ad9d99b52de2569ca19a70", size = 55823, upload-time = "2026-05-04T23:06:08.395Z" },
 ]
 
 [[package]]
@@ -1386,6 +1453,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/95/615e72cd27b85b61eec764a5ca51bd94d40b5adea5ff47567d9ebc4d275a/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:89eef07eee5e9d1fda06e38822ad167a044153457e6fd997f8a858ab7564a336", size = 396117, upload-time = "2025-10-14T15:06:11.28Z" },
     { url = "https://files.pythonhosted.org/packages/c9/81/e7fe958ce8a7fb5c73cc9fb07f5aeaf755e6aa72498c57d760af760c91f8/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce19e06cbda693e9e7686358af9cd6f5d61312ab8b00488bc36f5aabbaf77e24", size = 450493, upload-time = "2025-10-14T15:06:12.321Z" },
     { url = "https://files.pythonhosted.org/packages/6e/d4/ed38dd3b1767193de971e694aa544356e63353c33a85d948166b5ff58b9e/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e6f39af2eab0118338902798b5aa6664f46ff66bc0280de76fca67a7f262a49", size = 457546, upload-time = "2025-10-14T15:06:13.372Z" },
+]
+
+[[package]]
+name = "webauthn"
+version = "2.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cbor2" },
+    { name = "cryptography" },
+    { name = "pyasn1" },
+    { name = "pyopenssl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/f4/9529bcf85ef46c76842b84c66ffa8ec31f18e3aacd1330b62f440077b45b/webauthn-2.7.1.tar.gz", hash = "sha256:2a1ebbfffc4a83e31d3db5d69113944bc49d05fae77770c2d4e388386cb9656e", size = 124256, upload-time = "2026-02-11T23:36:02.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/5b/f73513367a9d34b199de916b44306acfa4027b57f7e22200421212b1f763/webauthn-2.7.1-py3-none-any.whl", hash = "sha256:d57e9613c65e0c6a4db7ee715fb49ebdf3c4a6eb3979729eeb497c99105e8181", size = 71684, upload-time = "2026-02-11T23:36:00.864Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Lands phase **1a/3** of FO-1 (#191) — the passkey enrollment substrate. Two additive Alembic migrations, a py_webauthn 2.x ceremony wrapper, four FastAPI routes, store CRUD methods, and end-to-end tests.

- **Migrations**: `0017_add_user_email` (nullable `email` column + partial unique index `WHERE email IS NOT NULL`) and `0018_webauthn_credentials` (the credential row table — `credential_id` BLOB UNIQUE, `public_key` COSE bytes, `sign_count`, `transports`, `aaguid`, `name`, `created_at`, `last_used_at`, CASCADE FK on `user_id`).
- **Module `cq_server/passkey.py`**: `begin_registration` / `finish_registration` / `begin_authentication` / `finish_authentication`. RP id/origin/name read from `CQ_WEBAUTHN_RP_*` env with localhost defaults. 60s in-process challenge cache keyed on username; injectable for tests via `set_challenge_cache_override`.
- **Routes `cq_server/passkey_routes.py`**: `POST /auth/passkey/{enroll,login}/{begin,finish}` mounted alongside the existing auth router (visible at both `/` and `/api/v1`).
- **Login finish mints a JWT via the existing `auth.create_token`** — FO-1c will swap that for a cookie-bound session token.

## What's NEXT (NOT in this PR)

- **FO-1b** — `invites` table, `email_sender.py`, magic-link signup.
- **FO-1c** — `web_session.py`, cookie-bound JWT with `aud` claim discriminant, session model.
- **FO-2/3/4** — React admin UI surfaces.

#191 stays open. This PR completes only **1a/3**.

## Test plan

- [x] `alembic upgrade head` succeeds on a fresh sqlite (rev → `0018_webauthn_credentials`)
- [x] `alembic downgrade -2` undoes 0017+0018 cleanly back to `0016_xgroup_consent`; re-`upgrade head` is idempotent
- [x] `pytest tests/test_passkey.py` — **6/6 passing** (4 happy-path ceremony tests, 1 fast-404 negative on unknown user, 1 replay-attack negative on same `signCount`)
- [x] `pytest tests/` full suite — **775 passing, 5 skipped, 0 failing** (after updating three pre-existing pin-tests for the new `HEAD_REVISION`)
- [x] `ruff check .` — clean
- [x] `/openapi.json` lists all four endpoints under `/auth/passkey/*` and `/api/v1/auth/passkey/*`

## Files touched

11 files, 6 commits:

- `server/backend/alembic/versions/0017_add_user_email.py` (new)
- `server/backend/alembic/versions/0018_webauthn_credentials.py` (new)
- `server/backend/src/cq_server/passkey.py` (new)
- `server/backend/src/cq_server/passkey_routes.py` (new)
- `server/backend/src/cq_server/store/_sqlite.py` (5 async + 5 sync methods added)
- `server/backend/src/cq_server/app.py` (router import + include)
- `server/backend/src/cq_server/migrations.py` (HEAD_REVISION → `0018_webauthn_credentials`)
- `server/backend/pyproject.toml` (webauthn>=2.0)
- `server/backend/uv.lock` (transitive: cbor2, pyasn1, pyopenssl)
- `server/backend/tests/test_passkey.py` (new, 6 tests)
- 3 pre-existing pin-tests updated for new `HEAD_REVISION`

## Cross-links

- Closes 1a of #191 (FO-1 spec)
- Parent epic: OneZero1ai/8th-layer-core#57
- Narrative: OneZero1ai/8th-layer-core#56

🤖 Generated with [Claude Code](https://claude.com/claude-code)