### PR TITLE
feat(auth): FO-1b — magic-link invite + SES email (closes 1b of #191)

### DIFF
--- a/server/backend/alembic/versions/0019_invites.py
+++ b/server/backend/alembic/versions/0019_invites.py
@@ -1,0 +1,117 @@
+"""FO-1b: ``invites`` table — magic-link invite minting + redeem state.
+
+Revision ID: 0019_invites
+Revises: 0018_webauthn_credentials
+Create Date: 2026-05-10
+
+Founder Onboarding (#191, phase 1b). Single-use, signed-JWT-backed
+magic-link invites. The JWT is the bearer; this table records the
+issuance + lifecycle so single-use is enforceable atomically (UPDATE …
+WHERE claimed_at IS NULL pattern, gated by the ``UNIQUE(jti)`` index).
+
+Schema mirrors the FO-1 spec on issue #191:
+
+* ``jti`` carries the JWT id (uuid4 hex); ``UNIQUE`` because two
+  invites can never share a jti — the canonical single-use anchor.
+* ``role`` is ``'enterprise_admin' | 'l2_admin' | 'user'``; ``target_l2_id``
+  is nullable because an enterprise-admin invite has no specific L2.
+* ``issued_by`` / ``claimed_by`` reference ``users(id)``; the FK is the
+  admin who minted the invite and the user who redeemed it (if any).
+* Timestamps are TEXT (ISO 8601) per the existing convention used by
+  ``users``, ``api_keys``, ``xgroup_consent``, etc.
+
+Indexes:
+
+* ``idx_invites_email`` — admin "list invites for foo@bar" lookups +
+  duplicate-email guard at mint time (we *allow* duplicates, but the
+  index makes the existence check cheap).
+* ``idx_invites_status`` — composite over the three lifecycle columns
+  used by ``GET /api/v1/admin/invites?status=...`` filtering.
+
+# Idempotency
+
+Standard ``_table_exists`` guard mirrors every migration in the chain.
+Re-run is a no-op. Downgrade drops the indexes then the table.
+
+# Chain note
+
+Depends on FO-1a's ``0018_webauthn_credentials``. FO-1a lands first;
+this migration sits on top. On a fresh DB without 0017/0018 the chain
+will not resolve — see PR body for merge ordering.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0019_invites"
+down_revision: str | Sequence[str] | None = "0018_webauthn_credentials"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _table_exists(bind: sa.engine.Connection, table_name: str) -> bool:
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def upgrade() -> None:
+    """Create the ``invites`` table + lookup indexes."""
+    bind = op.get_bind()
+
+    if _table_exists(bind, "invites"):
+        return
+
+    op.create_table(
+        "invites",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        # JWT id — the single-use anchor. UNIQUE so two invites can never
+        # collide on jti even if mint() is called concurrently.
+        sa.Column("jti", sa.Text(), nullable=False),
+        sa.Column("email", sa.Text(), nullable=False),
+        sa.Column("role", sa.Text(), nullable=False),
+        # Nullable for ``role='enterprise_admin'`` invites — no L2 yet.
+        sa.Column("target_l2_id", sa.Text(), nullable=True),
+        sa.Column(
+            "issued_by",
+            sa.Integer(),
+            sa.ForeignKey("users.id"),
+            nullable=False,
+        ),
+        sa.Column("issued_at", sa.Text(), nullable=False),
+        sa.Column("expires_at", sa.Text(), nullable=False),
+        sa.Column("claimed_at", sa.Text(), nullable=True),
+        sa.Column(
+            "claimed_by",
+            sa.Integer(),
+            sa.ForeignKey("users.id"),
+            nullable=True,
+        ),
+        sa.Column("revoked_at", sa.Text(), nullable=True),
+        sa.UniqueConstraint("jti", name="uq_invites_jti"),
+        sqlite_autoincrement=True,
+    )
+    op.create_index("idx_invites_email", "invites", ["email"])
+    op.create_index(
+        "idx_invites_status",
+        "invites",
+        ["claimed_at", "revoked_at", "expires_at"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the indexes and table."""
+    bind = op.get_bind()
+    if not _table_exists(bind, "invites"):
+        return
+
+    inspector = sa.inspect(bind)
+    idx_names = {idx["name"] for idx in inspector.get_indexes("invites")}
+    if "idx_invites_status" in idx_names:
+        op.drop_index("idx_invites_status", table_name="invites")
+    if "idx_invites_email" in idx_names:
+        op.drop_index("idx_invites_email", table_name="invites")
+    op.drop_table("invites")

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -34,6 +34,7 @@ from .db_url import resolve_sqlite_db_path
 from .deps import API_KEY_PEPPER_ENV
 from .embed import compose_text, embed_text
 from .embed import model_id as embed_model_id
+from .invite_routes import router as invite_router
 from .migrations import run_migrations
 from .network import router as network_router
 from .passkey_routes import router as passkey_router
@@ -410,6 +411,7 @@ api_router.include_router(reflect_router, prefix="/reflect", tags=["reflect"])
 api_router.include_router(activity_router)
 api_router.include_router(crosstalk_router)
 api_router.include_router(admin_xgroup_consent_router)
+api_router.include_router(invite_router)
 
 
 @api_router.get("/health")

--- a/server/backend/src/cq_server/email_sender.py
+++ b/server/backend/src/cq_server/email_sender.py
@@ -1,0 +1,267 @@
+"""Email sending — boto3 SES wrapper for invite delivery (FO-1b).
+
+The production sender (``EmailSender``) wraps a boto3 SES v1 client. The
+mock variant (``MockEmailSender``) captures sends in memory so tests can
+assert on subject / recipient / body without touching AWS.
+
+Both classes share the same ``send_invite(...)`` shape so callers
+inject the wiring at construction time and never branch on type.
+
+# Why SES v1 (not SESv2)
+
+The AWS account that ships 8th-Layer.ai's invite-domain identity is
+already configured for SES v1; the v2 surface is only marginally
+different and we have no need for the extra features (bulk send,
+template engine) right now. Stay on v1; revisit if we want
+``SendBulkEmail``-style batching later.
+
+# Sandbox vs production
+
+Outside SES sandbox, ``send_email`` works against any verified-sender
+identity. Inside the sandbox, the *recipient* must also be verified —
+the operator runs the sandbox-exit ticket separately (agent#198). This
+module is identical across the two; the difference is operator-side
+(IAM + SES-identity setup), not code.
+
+# Source identity + region
+
+* ``CQ_INVITE_FROM_EMAIL`` — the From: header. Defaults to
+  ``invites@8th-layer.ai`` per FO-1 spec.
+* ``CQ_AWS_REGION`` — the SES regional endpoint. Defaults to
+  ``us-east-1`` (matches the ``orion`` profile + Bedrock region).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+DEFAULT_FROM_EMAIL = "invites@8th-layer.ai"
+DEFAULT_AWS_REGION = "us-east-1"
+
+
+def _from_email() -> str:
+    return os.environ.get("CQ_INVITE_FROM_EMAIL", DEFAULT_FROM_EMAIL)
+
+
+def _aws_region() -> str:
+    return os.environ.get("CQ_AWS_REGION", DEFAULT_AWS_REGION)
+
+
+def _public_host(default: str = "https://app.8th-layer.ai") -> str:
+    """Return the public host used to build the claim URL.
+
+    ``CQ_PUBLIC_HOST`` is the production override. Falls back to the
+    well-known marketing domain — never to ``localhost`` because invite
+    emails sent from a localhost-baseurl would dead-link.
+    """
+    return os.environ.get("CQ_PUBLIC_HOST", default)
+
+
+def _claim_url(jwt: str, *, host: str | None = None) -> str:
+    base = (host or _public_host()).rstrip("/")
+    return f"{base}/invite/{jwt}"
+
+
+def _render_subject(inviter_name: str, enterprise_name: str) -> str:
+    return f"{inviter_name} invited you to {enterprise_name}"
+
+
+def _render_text_body(
+    *,
+    inviter_name: str,
+    enterprise_name: str,
+    expiry_iso: str,
+    claim_url: str,
+) -> str:
+    return (
+        "Hi,\n"
+        "\n"
+        f"{inviter_name} has invited you to join {enterprise_name} on 8th-Layer.ai.\n"
+        "\n"
+        f"Click below to claim your account. This link is single-use and expires on {expiry_iso}.\n"
+        "\n"
+        f"  {claim_url}\n"
+        "\n"
+        "If you didn't expect this email, you can safely ignore it.\n"
+        "\n"
+        "— 8th-Layer.ai\n"
+    )
+
+
+def _render_html_body(
+    *,
+    inviter_name: str,
+    enterprise_name: str,
+    expiry_iso: str,
+    claim_url: str,
+) -> str:
+    """Plain HTML — high-deliverability bias, no images / minimal CSS."""
+    return (
+        "<!doctype html>"
+        '<html lang="en"><head><meta charset="utf-8">'
+        f"<title>{_render_subject(inviter_name, enterprise_name)}</title>"
+        "</head>"
+        '<body style="font-family:system-ui,sans-serif;color:#222;'
+        'background:#fff;padding:24px;max-width:560px;margin:auto;">'
+        "<p>Hi,</p>"
+        f"<p><strong>{inviter_name}</strong> has invited you to join "
+        f"<strong>{enterprise_name}</strong> on 8th-Layer.ai.</p>"
+        "<p>Click below to claim your account. This link is single-use "
+        f"and expires on <strong>{expiry_iso}</strong>.</p>"
+        '<p style="margin:24px 0;">'
+        f'<a href="{claim_url}" '
+        'style="background:#111;color:#fff;padding:12px 20px;'
+        'text-decoration:none;border-radius:6px;display:inline-block;">'
+        "Claim your account</a></p>"
+        '<p style="font-size:13px;color:#666;">'
+        "If the button above doesn't work, paste this link into your "
+        f'browser:<br><a href="{claim_url}">{claim_url}</a></p>'
+        '<p style="font-size:13px;color:#666;">'
+        "If you didn't expect this email, you can safely ignore it.</p>"
+        '<p style="font-size:13px;color:#666;">— 8th-Layer.ai</p>'
+        "</body></html>"
+    )
+
+
+class EmailSender:
+    """boto3-backed SES sender. One instance per process is fine.
+
+    The boto3 client is lazy-initialised on first send so import time is
+    cheap and unit tests that never call ``send_invite`` don't pay the
+    boto3 import cost.
+    """
+
+    def __init__(
+        self,
+        *,
+        from_email: str | None = None,
+        region: str | None = None,
+        public_host: str | None = None,
+    ) -> None:
+        """Build the sender; resolves env-driven defaults at construction."""
+        self._from_email = from_email or _from_email()
+        self._region = region or _aws_region()
+        self._public_host = public_host  # None → resolved per-call
+        self._client: Any = None
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            import boto3  # local import — keeps cold-start cost off the import graph
+
+            self._client = boto3.client("ses", region_name=self._region)
+        return self._client
+
+    def send_invite(
+        self,
+        to: str,
+        jwt: str,
+        inviter_name: str,
+        enterprise_name: str,
+        expiry: datetime,
+    ) -> dict[str, Any]:
+        """Send an invite email. Returns the SES response (or raises).
+
+        ``expiry`` is rendered as an ISO 8601 string in the email body
+        — the reader sees the deadline; the JWT enforces it.
+        """
+        claim_url = _claim_url(jwt, host=self._public_host)
+        expiry_iso = expiry.isoformat()
+        subject = _render_subject(inviter_name, enterprise_name)
+        text_body = _render_text_body(
+            inviter_name=inviter_name,
+            enterprise_name=enterprise_name,
+            expiry_iso=expiry_iso,
+            claim_url=claim_url,
+        )
+        html_body = _render_html_body(
+            inviter_name=inviter_name,
+            enterprise_name=enterprise_name,
+            expiry_iso=expiry_iso,
+            claim_url=claim_url,
+        )
+
+        client = self._get_client()
+        return client.send_email(
+            Source=self._from_email,
+            Destination={"ToAddresses": [to]},
+            Message={
+                "Subject": {"Data": subject, "Charset": "UTF-8"},
+                "Body": {
+                    "Text": {"Data": text_body, "Charset": "UTF-8"},
+                    "Html": {"Data": html_body, "Charset": "UTF-8"},
+                },
+            },
+        )
+
+
+@dataclass
+class CapturedEmail:
+    """In-memory representation of a send for test assertions."""
+
+    to: str
+    jwt: str
+    inviter_name: str
+    enterprise_name: str
+    expiry: datetime
+    subject: str
+    text_body: str
+    html_body: str
+    claim_url: str
+
+
+@dataclass
+class MockEmailSender:
+    """Test double — captures every ``send_invite`` call.
+
+    Public attribute: ``sent`` is the captured-call list, in order.
+    Tests assert on ``sent[-1].to``, ``sent[-1].subject``, etc.
+    """
+
+    from_email: str = field(default_factory=_from_email)
+    public_host: str | None = None
+    sent: list[CapturedEmail] = field(default_factory=list)
+
+    def send_invite(
+        self,
+        to: str,
+        jwt: str,
+        inviter_name: str,
+        enterprise_name: str,
+        expiry: datetime,
+    ) -> dict[str, Any]:
+        """Capture the would-be send and return a fake SES MessageId."""
+        claim_url = _claim_url(jwt, host=self.public_host)
+        expiry_iso = expiry.isoformat()
+        subject = _render_subject(inviter_name, enterprise_name)
+        text_body = _render_text_body(
+            inviter_name=inviter_name,
+            enterprise_name=enterprise_name,
+            expiry_iso=expiry_iso,
+            claim_url=claim_url,
+        )
+        html_body = _render_html_body(
+            inviter_name=inviter_name,
+            enterprise_name=enterprise_name,
+            expiry_iso=expiry_iso,
+            claim_url=claim_url,
+        )
+        self.sent.append(
+            CapturedEmail(
+                to=to,
+                jwt=jwt,
+                inviter_name=inviter_name,
+                enterprise_name=enterprise_name,
+                expiry=expiry,
+                subject=subject,
+                text_body=text_body,
+                html_body=html_body,
+                claim_url=claim_url,
+            )
+        )
+        return {"MessageId": f"mock-{len(self.sent)}"}

--- a/server/backend/src/cq_server/invite_routes.py
+++ b/server/backend/src/cq_server/invite_routes.py
@@ -311,8 +311,7 @@ async def get_invite_metadata_route(
             raise HTTPException(status_code=410, detail="invite already claimed")
         raise HTTPException(status_code=410, detail="invite expired")
 
-    issuer = await store.get_user_by_id(invite.issued_by) if hasattr(store, "get_user_by_id") else None
-    inviter_username = issuer["username"] if issuer else _lookup_username(store, invite.issued_by)
+    inviter_username = _lookup_username(store, invite.issued_by)
     return ClaimMetadata(
         email=invite.email,
         role=invite.role,

--- a/server/backend/src/cq_server/invite_routes.py
+++ b/server/backend/src/cq_server/invite_routes.py
@@ -1,0 +1,406 @@
+"""Invite HTTP routes — FO-1b magic-link surface.
+
+Two route groups under one router:
+
+* ``/admin/invites/*`` — admin-gated mint / list / revoke.
+* ``/invites/{jwt}/...`` — public; signature + lifecycle gated.
+
+Auth shape:
+
+* The admin endpoints chain ``require_admin`` (existing dep). The body
+  carries the mint params; the response intentionally omits the JWT so
+  the only path the bearer reaches is the email channel — see Decision
+  doc on FO-1 spec on issue #191.
+* The public endpoints take the JWT in the URL path. ``/invites/{jwt}``
+  returns claim-page metadata; ``/invites/{jwt}/claim`` consumes the
+  invite and provisions a session bearer.
+
+# Why no JWT in the response
+
+A canonical anti-pattern is "mint endpoint returns the bearer; admin
+saves it; admin sends it themselves." Two failure modes follow: (a) the
+bearer leaks through admin-side logs / screenshots; (b) the admin side
+becomes a second send-channel that has to be hardened. Returning only
+metadata pushes both off the platform — the email channel is the only
+delivery path, so SES + DKIM + bounces are the failure surface, not the
+admin UI.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel, Field, field_validator
+
+from .auth import _get_jwt_secret, create_token, require_admin
+from .deps import get_store
+from .email_sender import EmailSender, MockEmailSender
+from .invites import (
+    Invite,
+    InviteRole,
+    claim_invite,
+    ensure_user,
+    list_invites,
+    mint_invite,
+    revoke_invite,
+    validate_invite_jwt,
+)
+from .store._sqlite import SqliteStore
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Email-sender dependency — mockable per-app.
+# ---------------------------------------------------------------------------
+
+
+_email_sender: EmailSender | MockEmailSender | None = None
+
+
+def get_email_sender() -> EmailSender | MockEmailSender:
+    """FastAPI dependency → resolves the process-wide email sender.
+
+    Tests override this dep with ``app.dependency_overrides`` to swap
+    in a ``MockEmailSender`` instance and assert on captured sends.
+    """
+    global _email_sender
+    if _email_sender is None:
+        _email_sender = EmailSender()
+    return _email_sender
+
+
+# ---------------------------------------------------------------------------
+# Pydantic shapes
+# ---------------------------------------------------------------------------
+
+
+class CreateInviteRequest(BaseModel):
+    """Admin → mint body. Issue #191 §FO-1b spec."""
+
+    email: str
+    role: Literal["enterprise_admin", "l2_admin", "user"]
+    target_l2_id: str | None = Field(
+        default=None,
+        description="Required for non-enterprise_admin roles; ignored for enterprise_admin.",
+    )
+    enterprise_name: str = Field(
+        default="8th-Layer.ai",
+        description="Display name rendered in the invite email subject + body.",
+    )
+
+    @field_validator("email")
+    @classmethod
+    def _basic_email_shape(cls, value: str) -> str:
+        # Minimal sanity check — full RFC 5322 is overkill. We rely on
+        # SES to reject mis-routed mail; the goal here is to catch
+        # obvious typos at the API edge before we burn a JWT mint.
+        if "@" not in value or value.startswith("@") or value.endswith("@"):
+            raise ValueError("invalid email address")
+        return value.strip()
+
+
+class InvitePublic(BaseModel):
+    """Public/admin view of an invite row — never includes the JWT bearer."""
+
+    id: int
+    email: str
+    role: str
+    target_l2_id: str | None
+    issued_by: int
+    issued_at: str
+    expires_at: str
+    claimed_at: str | None
+    claimed_by: int | None
+    revoked_at: str | None
+    status: str
+
+
+class InvitesPublic(BaseModel):
+    """Collection wrapper, mirroring ``ApiKeysPublic``."""
+
+    data: list[InvitePublic]
+    count: int
+
+
+class ClaimMetadata(BaseModel):
+    """Public-facing claim-page payload — what the invite acceptor sees."""
+
+    email: str
+    role: str
+    target_l2_id: str | None
+    inviter_username: str
+    expires_at: str
+
+
+class ClaimRequest(BaseModel):
+    """Body for ``POST /invites/{jwt}/claim``.
+
+    V1 only: username + password. Passkey enrollment is a follow-up
+    step in FO-1d (the WebAuthn ``register`` flow). The session bearer
+    returned here lets the user reach FO-1d's enrollment endpoint.
+    """
+
+    username: str = Field(min_length=1, max_length=64)
+    password: str = Field(min_length=8, max_length=128)
+
+
+class ClaimResponse(BaseModel):
+    """Response body — session bearer + identity."""
+
+    token: str
+    username: str
+
+
+def _to_public(invite: Invite) -> InvitePublic:
+    return InvitePublic(
+        id=invite.id,
+        email=invite.email,
+        role=invite.role,
+        target_l2_id=invite.target_l2_id,
+        issued_by=invite.issued_by,
+        issued_at=invite.issued_at,
+        expires_at=invite.expires_at,
+        claimed_at=invite.claimed_at,
+        claimed_by=invite.claimed_by,
+        revoked_at=invite.revoked_at,
+        status=invite.status,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Router
+# ---------------------------------------------------------------------------
+
+
+router = APIRouter(tags=["invites"])
+
+
+@router.post("/admin/invites", status_code=201, response_model=InvitePublic)
+async def create_invite_route(
+    request: CreateInviteRequest,
+    fastapi_request: Request,  # noqa: ARG001 — reserved for future host-derivation
+    admin_username: str = Depends(require_admin),
+    store: SqliteStore = Depends(get_store),
+    email_sender: EmailSender | MockEmailSender = Depends(get_email_sender),
+) -> InvitePublic:
+    """Mint an invite + send the email. Returns metadata; never the JWT.
+
+    Validation:
+      * ``role != "enterprise_admin"`` → ``target_l2_id`` is required.
+      * Caller must be admin (``require_admin``).
+    """
+    admin = await store.get_user(admin_username)
+    if admin is None:
+        raise HTTPException(status_code=404, detail="Admin user not found")
+
+    if request.role != "enterprise_admin" and not request.target_l2_id:
+        raise HTTPException(
+            status_code=422,
+            detail="target_l2_id is required for non-enterprise_admin roles",
+        )
+
+    try:
+        invite, token = mint_invite(
+            store,
+            email=request.email,
+            role=request.role,  # type: ignore[arg-type]
+            target_l2_id=request.target_l2_id,
+            issued_by=int(admin["id"]),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    expiry = datetime.fromisoformat(invite.expires_at)
+    try:
+        email_sender.send_invite(
+            to=str(request.email),
+            jwt=token,
+            inviter_name=admin_username,
+            enterprise_name=request.enterprise_name,
+            expiry=expiry,
+        )
+    except Exception:  # noqa: BLE001
+        # Mint succeeded but email failed — we keep the row and surface
+        # the failure. Admin can revoke + retry; we do NOT roll back
+        # because the JWT is already minted and a parallel SES retry
+        # could deliver the original token if we re-mint with a new jti.
+        log.exception("invite email send failed for invite_id=%s", invite.id)
+        raise HTTPException(
+            status_code=502,
+            detail="invite minted but email delivery failed; revoke + retry",
+        ) from None
+
+    return _to_public(invite)
+
+
+@router.get("/admin/invites", response_model=InvitesPublic)
+async def list_invites_route(
+    status: Literal["pending", "claimed", "expired", "revoked"] | None = Query(default=None),
+    _admin_username: str = Depends(require_admin),
+    store: SqliteStore = Depends(get_store),
+) -> InvitesPublic:
+    """List invites, optionally filtered by lifecycle ``status``."""
+    invites = list_invites(store, status=status)
+    return InvitesPublic(
+        data=[_to_public(inv) for inv in invites],
+        count=len(invites),
+    )
+
+
+@router.delete("/admin/invites/{invite_id}", response_model=InvitePublic)
+async def revoke_invite_route(
+    invite_id: int,
+    admin_username: str = Depends(require_admin),
+    store: SqliteStore = Depends(get_store),
+) -> InvitePublic:
+    """Revoke an invite. Idempotent — repeated revokes return the same row."""
+    admin = await store.get_user(admin_username)
+    if admin is None:
+        raise HTTPException(status_code=404, detail="Admin user not found")
+    invite = revoke_invite(store, invite_id=invite_id, by_user_id=int(admin["id"]))
+    if invite is None:
+        raise HTTPException(status_code=404, detail="Invite not found")
+    return _to_public(invite)
+
+
+@router.get("/invites/{token}", response_model=ClaimMetadata)
+async def get_invite_metadata_route(
+    token: str,
+    store: SqliteStore = Depends(get_store),
+) -> ClaimMetadata:
+    """Public — render the claim page using the JWT bearer in the URL.
+
+    Returns ``410 Gone`` for any non-pending invite (revoked / expired
+    / claimed) so the claim page renders a single, unambiguous "this
+    link is no longer valid" state. ``404`` is reserved for "the JWT
+    has no matching DB row" — i.e. forgery / unknown jti.
+    """
+    invite = validate_invite_jwt(token, store)
+    if invite is None:
+        # Distinguish forgery from lifecycle for the right status code.
+        # Re-decode locally to see if the bearer is at least signed.
+        import jwt as pyjwt
+
+        try:
+            payload = pyjwt.decode(
+                token,
+                _get_jwt_secret(),
+                algorithms=["HS256"],
+                audience="invite",
+                issuer="8th-layer.ai",
+                options={"require": ["jti"]},
+            )
+        except pyjwt.ExpiredSignatureError as exc:
+            raise HTTPException(status_code=410, detail="invite expired") from exc
+        except pyjwt.PyJWTError as exc:
+            raise HTTPException(status_code=404, detail="invite not found") from exc
+        # Signed + non-expired but DB lookup or status said no — likely
+        # claimed/revoked. Re-fetch by jti for the right discriminant.
+        from .invites import _get_by_jti
+
+        row = _get_by_jti(store, payload["jti"])
+        if row is None:
+            raise HTTPException(status_code=404, detail="invite not found")
+        if row.revoked_at is not None:
+            raise HTTPException(status_code=410, detail="invite revoked")
+        if row.claimed_at is not None:
+            raise HTTPException(status_code=410, detail="invite already claimed")
+        raise HTTPException(status_code=410, detail="invite expired")
+
+    issuer = await store.get_user_by_id(invite.issued_by) if hasattr(store, "get_user_by_id") else None
+    inviter_username = issuer["username"] if issuer else _lookup_username(store, invite.issued_by)
+    return ClaimMetadata(
+        email=invite.email,
+        role=invite.role,
+        target_l2_id=invite.target_l2_id,
+        inviter_username=inviter_username or "admin",
+        expires_at=invite.expires_at,
+    )
+
+
+def _lookup_username(store: SqliteStore, user_id: int) -> str | None:
+    """Sync helper — fetch ``users.username`` by ``users.id`` directly."""
+    from sqlalchemy import text
+
+    with store._engine.connect() as conn:  # noqa: SLF001
+        row = conn.execute(
+            text("SELECT username FROM users WHERE id = :id"),
+            {"id": user_id},
+        ).fetchone()
+    return row[0] if row else None
+
+
+@router.post("/invites/{token}/claim", response_model=ClaimResponse)
+async def claim_invite_route(
+    token: str,
+    request: ClaimRequest,
+    store: SqliteStore = Depends(get_store),
+) -> ClaimResponse:
+    """Public — accept the invite, provision the user, return a session bearer.
+
+    Single-use enforcement is in ``invites.claim_invite``; this route
+    only translates the discriminated outcome into the right HTTP code.
+    """
+    # Validate the JWT shape early so we can return the user-friendly
+    # status before doing any user creation work.
+    metadata = validate_invite_jwt(token, store)
+    if metadata is None:
+        # Surface the same per-status mapping as the GET handler.
+        import jwt as pyjwt
+
+        try:
+            payload = pyjwt.decode(
+                token,
+                _get_jwt_secret(),
+                algorithms=["HS256"],
+                audience="invite",
+                issuer="8th-layer.ai",
+                options={"require": ["jti"]},
+            )
+        except pyjwt.ExpiredSignatureError as exc:
+            raise HTTPException(status_code=410, detail="invite expired") from exc
+        except pyjwt.PyJWTError as exc:
+            raise HTTPException(status_code=404, detail="invite not found") from exc
+        from .invites import _get_by_jti
+
+        row = _get_by_jti(store, payload["jti"])
+        if row is None:
+            raise HTTPException(status_code=404, detail="invite not found")
+        if row.revoked_at is not None:
+            raise HTTPException(status_code=410, detail="invite revoked")
+        if row.claimed_at is not None:
+            raise HTTPException(status_code=409, detail="invite already claimed")
+        raise HTTPException(status_code=410, detail="invite expired")
+
+    user_id = await ensure_user(
+        store,
+        username=request.username,
+        password=request.password,
+        email=metadata.email,
+    )
+
+    outcome = claim_invite(store, token=token, claiming_user_id=user_id)
+    if outcome.kind == "ok":
+        session = create_token(request.username, secret=_get_jwt_secret())
+        return ClaimResponse(token=session, username=request.username)
+    if outcome.kind == "already_claimed":
+        raise HTTPException(status_code=409, detail="invite already claimed")
+    if outcome.kind == "revoked":
+        raise HTTPException(status_code=410, detail="invite revoked")
+    if outcome.kind == "expired":
+        raise HTTPException(status_code=410, detail="invite expired")
+    raise HTTPException(status_code=404, detail="invite not found")
+
+
+# Re-export role type for routers that consume the same vocabulary.
+__all__ = [
+    "InviteRole",
+    "InvitesPublic",
+    "InvitePublic",
+    "router",
+    "get_email_sender",
+]

--- a/server/backend/src/cq_server/invites.py
+++ b/server/backend/src/cq_server/invites.py
@@ -120,8 +120,7 @@ class Invite:
 
 
 _SELECT_COLUMNS = (
-    "id, jti, email, role, target_l2_id, issued_by, issued_at, "
-    "expires_at, claimed_at, claimed_by, revoked_at"
+    "id, jti, email, role, target_l2_id, issued_by, issued_at, expires_at, claimed_at, claimed_by, revoked_at"
 )
 
 
@@ -363,11 +362,7 @@ def list_invites(
 ) -> list[Invite]:
     """Return invites filtered by lifecycle status (None → all)."""
     with store._engine.connect() as conn:  # noqa: SLF001
-        rows = conn.execute(
-            text(
-                f"SELECT {_SELECT_COLUMNS} FROM invites ORDER BY issued_at DESC"
-            )
-        ).fetchall()
+        rows = conn.execute(text(f"SELECT {_SELECT_COLUMNS} FROM invites ORDER BY issued_at DESC")).fetchall()
     invites = [Invite.from_row(r) for r in rows]
     if status is None:
         return invites
@@ -401,9 +396,7 @@ def revoke_invite(
     now_iso = datetime.now(UTC).isoformat()
     with store._engine.begin() as conn:  # noqa: SLF001
         conn.execute(
-            text(
-                "UPDATE invites SET revoked_at = :now WHERE id = :id AND revoked_at IS NULL"
-            ),
+            text("UPDATE invites SET revoked_at = :now WHERE id = :id AND revoked_at IS NULL"),
             {"now": now_iso, "id": invite_id},
         )
     return _get_by_id(store, invite_id)

--- a/server/backend/src/cq_server/invites.py
+++ b/server/backend/src/cq_server/invites.py
@@ -1,0 +1,445 @@
+"""Invite minting / validation / claim — FO-1b.
+
+The bearer is a signed JWT (HS256, signed with ``CQ_JWT_SECRET`` —
+the same secret as login JWTs). The token carries:
+
+  {
+    "sub": email,
+    "role": role,
+    "target_l2_id": ... | None,
+    "iss": "8th-layer.ai",
+    "aud": "invite",
+    "iat": ...,
+    "exp": ...,
+    "jti": uuid4().hex
+  }
+
+``aud="invite"`` is the discriminant that prevents an invite token from
+being accepted at the ``/auth/me`` (session-aud) gate. Login tokens use
+``aud=self_l2_id()`` per ``auth.create_token``; invites use the
+constant ``"invite"`` so the verifier rejects mismatches structurally.
+
+Single-use enforcement layers: (a) ``UNIQUE(jti)`` index on
+``invites.jti`` blocks duplicate inserts at mint; (b) the claim path
+runs an atomic ``UPDATE invites SET claimed_at = ?, claimed_by = ?
+WHERE id = ? AND claimed_at IS NULL AND revoked_at IS NULL`` and
+treats ``rowcount == 0`` as "already-claimed/revoked → 409".
+
+Note: ``aud="invite"`` is intentionally NOT one of the per-L2 ids the
+login path uses. Cross-L2 invite verification is a non-goal for v1
+(invites are minted on the same L2 they're redeemed on); the
+``"invite"`` audience-as-purpose discriminant is the simplest way to
+keep the two surfaces from leaking into each other.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, Literal
+
+import jwt
+from sqlalchemy import text
+
+from .auth import _get_jwt_secret, hash_password
+from .store._sqlite import SqliteStore
+
+log = logging.getLogger(__name__)
+
+INVITE_ISSUER = "8th-layer.ai"
+INVITE_AUDIENCE = "invite"
+DEFAULT_TTL_HOURS = 72
+
+InviteRole = Literal["enterprise_admin", "l2_admin", "user"]
+InviteStatus = Literal["pending", "claimed", "expired", "revoked"]
+
+
+def _ttl_hours() -> int:
+    raw = os.environ.get("CQ_INVITE_TTL_HOURS")
+    if not raw:
+        return DEFAULT_TTL_HOURS
+    try:
+        return int(raw)
+    except ValueError:
+        log.warning("invalid CQ_INVITE_TTL_HOURS=%r; falling back to default", raw)
+        return DEFAULT_TTL_HOURS
+
+
+@dataclass
+class Invite:
+    """In-memory representation of one row in ``invites``."""
+
+    id: int
+    jti: str
+    email: str
+    role: str
+    target_l2_id: str | None
+    issued_by: int
+    issued_at: str
+    expires_at: str
+    claimed_at: str | None
+    claimed_by: int | None
+    revoked_at: str | None
+
+    @classmethod
+    def from_row(cls, row: Any) -> Invite:
+        """Build an ``Invite`` from a SQLAlchemy row tuple in ``_SELECT_COLUMNS`` order."""
+        return cls(
+            id=int(row[0]),
+            jti=row[1],
+            email=row[2],
+            role=row[3],
+            target_l2_id=row[4],
+            issued_by=int(row[5]),
+            issued_at=row[6],
+            expires_at=row[7],
+            claimed_at=row[8],
+            claimed_by=int(row[9]) if row[9] is not None else None,
+            revoked_at=row[10],
+        )
+
+    @property
+    def status(self) -> InviteStatus:
+        """Lifecycle classification — ``pending`` / ``claimed`` / ``expired`` / ``revoked``."""
+        if self.revoked_at is not None:
+            return "revoked"
+        if self.claimed_at is not None:
+            return "claimed"
+        try:
+            expires = datetime.fromisoformat(self.expires_at)
+        except ValueError:
+            return "pending"
+        if expires.tzinfo is None:
+            expires = expires.replace(tzinfo=UTC)
+        if expires <= datetime.now(UTC):
+            return "expired"
+        return "pending"
+
+
+_SELECT_COLUMNS = (
+    "id, jti, email, role, target_l2_id, issued_by, issued_at, "
+    "expires_at, claimed_at, claimed_by, revoked_at"
+)
+
+
+def _encode_jwt(
+    *,
+    email: str,
+    role: str,
+    target_l2_id: str | None,
+    issued_at: datetime,
+    expires_at: datetime,
+    jti: str,
+) -> str:
+    """Sign the invite JWT with the server's JWT secret."""
+    payload: dict[str, Any] = {
+        "sub": email,
+        "role": role,
+        "target_l2_id": target_l2_id,
+        "iss": INVITE_ISSUER,
+        "aud": INVITE_AUDIENCE,
+        "iat": issued_at,
+        "exp": expires_at,
+        "jti": jti,
+    }
+    return jwt.encode(payload, _get_jwt_secret(), algorithm="HS256")
+
+
+def _decode_jwt(token: str) -> dict[str, Any]:
+    """Verify signature + expiry + iss/aud structure. Raises ``jwt.PyJWTError``."""
+    return jwt.decode(
+        token,
+        _get_jwt_secret(),
+        algorithms=["HS256"],
+        audience=INVITE_AUDIENCE,
+        issuer=INVITE_ISSUER,
+        options={"require": ["iss", "aud", "sub", "exp", "jti"]},
+    )
+
+
+def mint_invite(
+    store: SqliteStore,
+    *,
+    email: str,
+    role: InviteRole,
+    target_l2_id: str | None,
+    issued_by: int,
+    ttl_hours: int | None = None,
+) -> tuple[Invite, str]:
+    """Create an invite row + return (Invite, signed JWT bearer).
+
+    The JWT is the only place the bearer ever exists in plaintext —
+    callers must email it directly and never persist it. The DB only
+    holds ``jti`` (for single-use enforcement) and lifecycle metadata.
+    """
+    if role == "enterprise_admin" and target_l2_id is not None:
+        # An enterprise-admin invite is bound to the Enterprise, not a
+        # specific L2 — defensive nudge so the API can't write a
+        # contradictory row even if an admin builds the request wrong.
+        target_l2_id = None
+    if role != "enterprise_admin" and target_l2_id is None:
+        raise ValueError("target_l2_id is required for non-enterprise_admin roles")
+
+    now = datetime.now(UTC)
+    ttl = ttl_hours if ttl_hours is not None else _ttl_hours()
+    expires_at = now + timedelta(hours=ttl)
+    jti = uuid.uuid4().hex
+    token = _encode_jwt(
+        email=email,
+        role=role,
+        target_l2_id=target_l2_id,
+        issued_at=now,
+        expires_at=expires_at,
+        jti=jti,
+    )
+
+    issued_at_iso = now.isoformat()
+    expires_at_iso = expires_at.isoformat()
+    with store._engine.begin() as conn:  # noqa: SLF001
+        result = conn.execute(
+            text(
+                "INSERT INTO invites "
+                "(jti, email, role, target_l2_id, issued_by, issued_at, expires_at) "
+                "VALUES (:jti, :email, :role, :target_l2_id, :issued_by, :issued_at, :expires_at)"
+            ),
+            {
+                "jti": jti,
+                "email": email,
+                "role": role,
+                "target_l2_id": target_l2_id,
+                "issued_by": issued_by,
+                "issued_at": issued_at_iso,
+                "expires_at": expires_at_iso,
+            },
+        )
+        invite_id = int(result.lastrowid or 0)
+
+    invite = Invite(
+        id=invite_id,
+        jti=jti,
+        email=email,
+        role=role,
+        target_l2_id=target_l2_id,
+        issued_by=issued_by,
+        issued_at=issued_at_iso,
+        expires_at=expires_at_iso,
+        claimed_at=None,
+        claimed_by=None,
+        revoked_at=None,
+    )
+    return invite, token
+
+
+def validate_invite_jwt(token: str, store: SqliteStore) -> Invite | None:
+    """Validate signature/expiry/iss/aud + DB lifecycle. Returns ``None`` on any failure.
+
+    A return of ``None`` means "do not surface this invite to the
+    caller" — callers map to 410/404 as appropriate. Distinguish
+    expired vs revoked vs claimed via the row status when you need
+    granular HTTP status codes.
+    """
+    try:
+        payload = _decode_jwt(token)
+    except jwt.PyJWTError:
+        return None
+    jti = payload.get("jti")
+    if not jti:
+        return None
+    invite = _get_by_jti(store, jti)
+    if invite is None:
+        return None
+    if invite.status != "pending":
+        return None
+    return invite
+
+
+def _get_by_jti(store: SqliteStore, jti: str) -> Invite | None:
+    with store._engine.connect() as conn:  # noqa: SLF001
+        row = conn.execute(
+            text(f"SELECT {_SELECT_COLUMNS} FROM invites WHERE jti = :jti"),
+            {"jti": jti},
+        ).fetchone()
+    if row is None:
+        return None
+    return Invite.from_row(row)
+
+
+def _get_by_id(store: SqliteStore, invite_id: int) -> Invite | None:
+    with store._engine.connect() as conn:  # noqa: SLF001
+        row = conn.execute(
+            text(f"SELECT {_SELECT_COLUMNS} FROM invites WHERE id = :id"),
+            {"id": invite_id},
+        ).fetchone()
+    if row is None:
+        return None
+    return Invite.from_row(row)
+
+
+@dataclass
+class ClaimOutcome:
+    """Discriminated result for ``claim_invite``.
+
+    Used by the route layer to map to the right HTTP status:
+      * ``ok`` → 200, with ``invite`` populated
+      * ``not_found`` → 404 (signature mismatch / unknown jti)
+      * ``expired`` → 410
+      * ``revoked`` → 410
+      * ``already_claimed`` → 409
+    """
+
+    kind: Literal["ok", "not_found", "expired", "revoked", "already_claimed"]
+    invite: Invite | None = None
+
+
+def claim_invite(
+    store: SqliteStore,
+    *,
+    token: str,
+    claiming_user_id: int,
+) -> ClaimOutcome:
+    """Atomically mark an invite ``claimed_at = now`` if pending.
+
+    The ``UPDATE … WHERE claimed_at IS NULL AND revoked_at IS NULL``
+    pattern is the single-use guarantee: two concurrent claims race to
+    the UPDATE; whichever lands first wins via row-lock; the second
+    sees ``rowcount == 0`` and is rejected.
+    """
+    try:
+        payload = _decode_jwt(token)
+    except jwt.ExpiredSignatureError:
+        return ClaimOutcome(kind="expired")
+    except jwt.PyJWTError:
+        return ClaimOutcome(kind="not_found")
+
+    jti = payload.get("jti")
+    if not jti:
+        return ClaimOutcome(kind="not_found")
+
+    invite = _get_by_jti(store, jti)
+    if invite is None:
+        return ClaimOutcome(kind="not_found")
+
+    # Status checks BEFORE the atomic UPDATE so we can return the right
+    # HTTP code; the UPDATE is still the authority.
+    status_at_read = invite.status
+    if status_at_read == "claimed":
+        return ClaimOutcome(kind="already_claimed", invite=invite)
+    if status_at_read == "revoked":
+        return ClaimOutcome(kind="revoked", invite=invite)
+    if status_at_read == "expired":
+        return ClaimOutcome(kind="expired", invite=invite)
+
+    now_iso = datetime.now(UTC).isoformat()
+    with store._engine.begin() as conn:  # noqa: SLF001
+        result = conn.execute(
+            text(
+                "UPDATE invites SET claimed_at = :now, claimed_by = :user_id "
+                "WHERE id = :id AND claimed_at IS NULL AND revoked_at IS NULL"
+            ),
+            {"now": now_iso, "user_id": claiming_user_id, "id": invite.id},
+        )
+        if (result.rowcount or 0) == 0:
+            # Lost the race — re-read to surface the now-current state.
+            current = _get_by_id(store, invite.id)
+            if current is None:
+                return ClaimOutcome(kind="not_found")
+            if current.revoked_at is not None:
+                return ClaimOutcome(kind="revoked", invite=current)
+            if current.claimed_at is not None:
+                return ClaimOutcome(kind="already_claimed", invite=current)
+            return ClaimOutcome(kind="not_found", invite=current)
+
+    refreshed = _get_by_id(store, invite.id)
+    return ClaimOutcome(kind="ok", invite=refreshed or invite)
+
+
+def list_invites(
+    store: SqliteStore,
+    *,
+    status: InviteStatus | None = None,
+) -> list[Invite]:
+    """Return invites filtered by lifecycle status (None → all)."""
+    with store._engine.connect() as conn:  # noqa: SLF001
+        rows = conn.execute(
+            text(
+                f"SELECT {_SELECT_COLUMNS} FROM invites ORDER BY issued_at DESC"
+            )
+        ).fetchall()
+    invites = [Invite.from_row(r) for r in rows]
+    if status is None:
+        return invites
+    return [inv for inv in invites if inv.status == status]
+
+
+def revoke_invite(
+    store: SqliteStore,
+    *,
+    invite_id: int,
+    by_user_id: int,
+) -> Invite | None:
+    """Mark the invite ``revoked_at = now``. Returns the updated row.
+
+    Returns ``None`` when the row doesn't exist. Idempotent — repeated
+    revokes leave ``revoked_at`` at the first revoke time so the audit
+    record points at the original action.
+    """
+    # ``by_user_id`` is captured for activity-log audit trails — kept
+    # in the signature even though the column isn't denormalised on the
+    # invites row (the activity_log table is the source of truth for
+    # who did what).
+    del by_user_id
+
+    invite = _get_by_id(store, invite_id)
+    if invite is None:
+        return None
+    if invite.revoked_at is not None:
+        return invite
+
+    now_iso = datetime.now(UTC).isoformat()
+    with store._engine.begin() as conn:  # noqa: SLF001
+        conn.execute(
+            text(
+                "UPDATE invites SET revoked_at = :now WHERE id = :id AND revoked_at IS NULL"
+            ),
+            {"now": now_iso, "id": invite_id},
+        )
+    return _get_by_id(store, invite_id)
+
+
+# ---------------------------------------------------------------------------
+# User creation helper for the claim path.
+# ---------------------------------------------------------------------------
+
+
+async def ensure_user(
+    store: SqliteStore,
+    *,
+    username: str,
+    password: str,
+    email: str,
+) -> int:
+    """Create-or-fetch the user record for an invite-claimer.
+
+    If a user with this ``username`` already exists, the existing row's
+    id is returned (no password rotation, no email mutation — that's
+    out of scope for FO-1b). Otherwise we hash the password and insert,
+    then return the new user's id.
+
+    The ``email`` argument is currently unused by the create path
+    (FO-1a's ``users.email`` column is additive but ``create_user``
+    hasn't been extended to write it yet); the parameter is in the
+    signature so FO-1c can wire it without touching every caller.
+    """
+    del email
+
+    existing = await store.get_user(username)
+    if existing is not None:
+        return int(existing["id"])
+    await store.create_user(username, hash_password(password))
+    fresh = await store.get_user(username)
+    if fresh is None:  # pragma: no cover — race that breaks the world
+        raise RuntimeError("user creation succeeded but lookup returned None")
+    return int(fresh["id"])

--- a/server/backend/src/cq_server/migrations.py
+++ b/server/backend/src/cq_server/migrations.py
@@ -36,7 +36,7 @@ BASELINE_REVISION = "0001"
 # Phase 2 (task #100) — chain head after porting fork-delta tables to
 # Alembic. Update this string when adding a new migration so test
 # assertions and ops scripts stay in sync with the actual chain head.
-HEAD_REVISION = "0018_webauthn_credentials"
+HEAD_REVISION = "0019_invites"
 
 
 def _find_alembic_ini() -> Path:

--- a/server/backend/tests/test_default_enterprise_backfill.py
+++ b/server/backend/tests/test_default_enterprise_backfill.py
@@ -407,7 +407,6 @@ class TestIdempotencyAndChain:
         ``run_migrations`` silently misses the new revision on stamped
         DBs. Pin the constant so the chain head is the source of truth.
         """
-        # Bumped to 0018_webauthn_credentials (FO-1a — passkey enrollment
-        # substrate, #191). Chains after 0017_add_user_email (additive
-        # ``email`` column on ``users``).
-        assert HEAD_REVISION == "0018_webauthn_credentials"
+        # Bumped to 0016_xgroup_consent (Phase 1.0b — Decision 28).
+        # Chains after 0015_phase_1_0c_aigrp_peers_pair_secret_ref.
+        assert HEAD_REVISION == "0019_invites"

--- a/server/backend/tests/test_invites.py
+++ b/server/backend/tests/test_invites.py
@@ -1,0 +1,547 @@
+"""Tests for FO-1b magic-link invites.
+
+Covers:
+
+* mint → email captured by ``MockEmailSender``
+* validate-good / validate-bad-signature / validate-expired
+* claim-once-succeeds / double-claim-fails-409
+* expired-fails-410 / revoked-fails-410
+* list with status filter (pending / claimed / revoked)
+* admin-only gating on POST /api/v1/admin/invites
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import bcrypt
+import jwt as pyjwt
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from cq_server.app import _get_store, app
+from cq_server.auth import _get_jwt_secret, hash_password
+from cq_server.email_sender import MockEmailSender
+from cq_server.invite_routes import get_email_sender
+from cq_server.invites import (
+    INVITE_AUDIENCE,
+    INVITE_ISSUER,
+    claim_invite,
+    list_invites,
+    mint_invite,
+    revoke_invite,
+    validate_invite_jwt,
+)
+
+ADMIN = "admin@8th-layer"
+NON_ADMIN = "regular@8th-layer"
+INVITEE_EMAIL = "newuser@example.com"
+
+
+@pytest.fixture
+def mock_sender() -> MockEmailSender:
+    return MockEmailSender()
+
+
+@pytest.fixture
+def client(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_sender: MockEmailSender,
+) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "invites.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    monkeypatch.setenv("CQ_PUBLIC_HOST", "https://test.8th-layer.ai")
+
+    app.dependency_overrides[get_email_sender] = lambda: mock_sender
+    with TestClient(app) as c:
+        store = _get_store()
+        pw = bcrypt.hashpw(b"password123", bcrypt.gensalt()).decode()
+        store.sync.create_user(ADMIN, pw)
+        store.sync.create_user(NON_ADMIN, pw)
+        store.sync.set_user_role(ADMIN, "admin")
+        yield c
+    app.dependency_overrides.pop(get_email_sender, None)
+
+
+def _login(client: TestClient, username: str, password: str = "password123") -> str:
+    resp = client.post(
+        "/api/v1/auth/login",
+        json={"username": username, "password": password},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _admin_headers(client: TestClient) -> dict[str, str]:
+    return {"Authorization": f"Bearer {_login(client, ADMIN)}"}
+
+
+def _non_admin_headers(client: TestClient) -> dict[str, str]:
+    return {"Authorization": f"Bearer {_login(client, NON_ADMIN)}"}
+
+
+# ---------------------------------------------------------------------------
+# Unit-level tests against the invites module.
+# ---------------------------------------------------------------------------
+
+
+class TestMintAndValidate:
+    def _admin_id(self, store: object) -> int:
+        with store._engine.connect() as conn:  # type: ignore[attr-defined]
+            row = conn.execute(
+                text("SELECT id FROM users WHERE username = :u"),
+                {"u": ADMIN},
+            ).fetchone()
+        assert row is not None
+        return int(row[0])
+
+    def test_mint_returns_jwt_with_correct_claims(self, client: TestClient) -> None:
+        store = _get_store()
+        admin_id = self._admin_id(store)
+        invite, token = mint_invite(
+            store,
+            email=INVITEE_EMAIL,
+            role="user",
+            target_l2_id="acme/eng",
+            issued_by=admin_id,
+        )
+        payload = pyjwt.decode(
+            token,
+            _get_jwt_secret(),
+            algorithms=["HS256"],
+            audience=INVITE_AUDIENCE,
+            issuer=INVITE_ISSUER,
+        )
+        assert payload["sub"] == INVITEE_EMAIL
+        assert payload["role"] == "user"
+        assert payload["target_l2_id"] == "acme/eng"
+        assert payload["jti"] == invite.jti
+
+    def test_validate_good_token(self, client: TestClient) -> None:
+        store = _get_store()
+        admin_id = self._admin_id(store)
+        invite, token = mint_invite(
+            store,
+            email=INVITEE_EMAIL,
+            role="l2_admin",
+            target_l2_id="acme/eng",
+            issued_by=admin_id,
+        )
+        result = validate_invite_jwt(token, store)
+        assert result is not None
+        assert result.id == invite.id
+        assert result.email == INVITEE_EMAIL
+
+    def test_validate_bad_signature(self, client: TestClient) -> None:
+        store = _get_store()
+        admin_id = self._admin_id(store)
+        _, token = mint_invite(
+            store,
+            email=INVITEE_EMAIL,
+            role="user",
+            target_l2_id="acme/eng",
+            issued_by=admin_id,
+        )
+        # Tamper the signature.
+        head, payload, _sig = token.rsplit(".", 2)
+        bad = f"{head}.{payload}.AAAAAAAAAAAAAAAAAAAA"
+        assert validate_invite_jwt(bad, store) is None
+
+    def test_validate_expired(self, client: TestClient) -> None:
+        store = _get_store()
+        admin_id = self._admin_id(store)
+        _, token = mint_invite(
+            store,
+            email=INVITEE_EMAIL,
+            role="user",
+            target_l2_id="acme/eng",
+            issued_by=admin_id,
+            ttl_hours=0,
+        )
+        time.sleep(1.1)
+        assert validate_invite_jwt(token, store) is None
+
+
+class TestClaim:
+    def _admin_id(self, store: object) -> int:
+        with store._engine.connect() as conn:  # type: ignore[attr-defined]
+            row = conn.execute(
+                text("SELECT id FROM users WHERE username = :u"),
+                {"u": ADMIN},
+            ).fetchone()
+        assert row is not None
+        return int(row[0])
+
+    def test_claim_once_succeeds(self, client: TestClient) -> None:
+        store = _get_store()
+        admin_id = self._admin_id(store)
+        _, token = mint_invite(
+            store,
+            email=INVITEE_EMAIL,
+            role="user",
+            target_l2_id="acme/eng",
+            issued_by=admin_id,
+        )
+        # Pretend a user already exists; provide their id.
+        store.sync.create_user("claimer", hash_password("password123"))
+        with store._engine.connect() as conn:  # type: ignore[attr-defined]
+            row = conn.execute(
+                text("SELECT id FROM users WHERE username = :u"),
+                {"u": "claimer"},
+            ).fetchone()
+        assert row is not None
+        outcome = claim_invite(store, token=token, claiming_user_id=int(row[0]))
+        assert outcome.kind == "ok"
+        assert outcome.invite is not None
+        assert outcome.invite.claimed_at is not None
+
+    def test_double_claim_fails(self, client: TestClient) -> None:
+        store = _get_store()
+        admin_id = self._admin_id(store)
+        _, token = mint_invite(
+            store,
+            email=INVITEE_EMAIL,
+            role="user",
+            target_l2_id="acme/eng",
+            issued_by=admin_id,
+        )
+        store.sync.create_user("claimer", hash_password("password123"))
+        with store._engine.connect() as conn:  # type: ignore[attr-defined]
+            row = conn.execute(
+                text("SELECT id FROM users WHERE username = :u"),
+                {"u": "claimer"},
+            ).fetchone()
+        assert row is not None
+        first = claim_invite(store, token=token, claiming_user_id=int(row[0]))
+        assert first.kind == "ok"
+        second = claim_invite(store, token=token, claiming_user_id=int(row[0]))
+        assert second.kind == "already_claimed"
+
+    def test_claim_after_revoke_fails(self, client: TestClient) -> None:
+        store = _get_store()
+        admin_id = self._admin_id(store)
+        invite, token = mint_invite(
+            store,
+            email=INVITEE_EMAIL,
+            role="user",
+            target_l2_id="acme/eng",
+            issued_by=admin_id,
+        )
+        revoke_invite(store, invite_id=invite.id, by_user_id=admin_id)
+        store.sync.create_user("claimer", hash_password("password123"))
+        with store._engine.connect() as conn:  # type: ignore[attr-defined]
+            row = conn.execute(
+                text("SELECT id FROM users WHERE username = :u"),
+                {"u": "claimer"},
+            ).fetchone()
+        assert row is not None
+        outcome = claim_invite(store, token=token, claiming_user_id=int(row[0]))
+        assert outcome.kind == "revoked"
+
+    def test_claim_expired_fails(self, client: TestClient) -> None:
+        store = _get_store()
+        admin_id = self._admin_id(store)
+        _, token = mint_invite(
+            store,
+            email=INVITEE_EMAIL,
+            role="user",
+            target_l2_id="acme/eng",
+            issued_by=admin_id,
+            ttl_hours=0,
+        )
+        time.sleep(1.1)
+        store.sync.create_user("claimer", hash_password("password123"))
+        with store._engine.connect() as conn:  # type: ignore[attr-defined]
+            row = conn.execute(
+                text("SELECT id FROM users WHERE username = :u"),
+                {"u": "claimer"},
+            ).fetchone()
+        assert row is not None
+        outcome = claim_invite(store, token=token, claiming_user_id=int(row[0]))
+        assert outcome.kind == "expired"
+
+
+class TestList:
+    def _admin_id(self, store: object) -> int:
+        with store._engine.connect() as conn:  # type: ignore[attr-defined]
+            row = conn.execute(
+                text("SELECT id FROM users WHERE username = :u"),
+                {"u": ADMIN},
+            ).fetchone()
+        assert row is not None
+        return int(row[0])
+
+    def test_list_filter_by_status(self, client: TestClient) -> None:
+        store = _get_store()
+        admin_id = self._admin_id(store)
+
+        # Pending
+        mint_invite(
+            store,
+            email="pending@example.com",
+            role="user",
+            target_l2_id="acme/eng",
+            issued_by=admin_id,
+        )
+        # Revoked
+        rev_invite, _ = mint_invite(
+            store,
+            email="revoked@example.com",
+            role="user",
+            target_l2_id="acme/eng",
+            issued_by=admin_id,
+        )
+        revoke_invite(store, invite_id=rev_invite.id, by_user_id=admin_id)
+
+        all_invites = list_invites(store)
+        assert len(all_invites) == 2
+        pending_only = list_invites(store, status="pending")
+        assert len(pending_only) == 1
+        assert pending_only[0].email == "pending@example.com"
+        revoked_only = list_invites(store, status="revoked")
+        assert len(revoked_only) == 1
+        assert revoked_only[0].email == "revoked@example.com"
+
+
+# ---------------------------------------------------------------------------
+# HTTP-level tests.
+# ---------------------------------------------------------------------------
+
+
+class TestAdminInviteHTTP:
+    def test_mint_sends_email_and_omits_jwt(
+        self,
+        client: TestClient,
+        mock_sender: MockEmailSender,
+    ) -> None:
+        resp = client.post(
+            "/api/v1/admin/invites",
+            json={
+                "email": INVITEE_EMAIL,
+                "role": "user",
+                "target_l2_id": "acme/eng",
+                "enterprise_name": "Acme",
+            },
+            headers=_admin_headers(client),
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["email"] == INVITEE_EMAIL
+        assert body["status"] == "pending"
+        # No JWT bearer should appear in the response.
+        assert "token" not in body
+        assert "jwt" not in body
+        # Email was captured.
+        assert len(mock_sender.sent) == 1
+        captured = mock_sender.sent[0]
+        assert captured.to == INVITEE_EMAIL
+        assert "Acme" in captured.subject
+        assert ADMIN in captured.subject
+        assert captured.claim_url.startswith("https://test.8th-layer.ai/invite/")
+
+    def test_mint_requires_admin(self, client: TestClient) -> None:
+        resp = client.post(
+            "/api/v1/admin/invites",
+            json={"email": INVITEE_EMAIL, "role": "user", "target_l2_id": "acme/eng"},
+            headers=_non_admin_headers(client),
+        )
+        assert resp.status_code == 403
+
+    def test_mint_unauthenticated(self, client: TestClient) -> None:
+        resp = client.post(
+            "/api/v1/admin/invites",
+            json={"email": INVITEE_EMAIL, "role": "user", "target_l2_id": "acme/eng"},
+        )
+        assert resp.status_code == 401
+
+    def test_mint_target_l2_required_for_non_enterprise_admin(
+        self,
+        client: TestClient,
+    ) -> None:
+        resp = client.post(
+            "/api/v1/admin/invites",
+            json={"email": INVITEE_EMAIL, "role": "user"},
+            headers=_admin_headers(client),
+        )
+        assert resp.status_code == 422
+
+    def test_list_with_status_filter(
+        self,
+        client: TestClient,
+        mock_sender: MockEmailSender,  # noqa: ARG002
+    ) -> None:
+        # Mint two; revoke one.
+        for email in ("a@example.com", "b@example.com"):
+            client.post(
+                "/api/v1/admin/invites",
+                json={"email": email, "role": "user", "target_l2_id": "acme/eng"},
+                headers=_admin_headers(client),
+            )
+        resp = client.get(
+            "/api/v1/admin/invites",
+            headers=_admin_headers(client),
+        )
+        assert resp.status_code == 200
+        all_body = resp.json()
+        assert all_body["count"] == 2
+
+        # Revoke the first one and confirm filter works.
+        first_id = all_body["data"][-1]["id"]  # ordered DESC; oldest is last
+        del_resp = client.delete(
+            f"/api/v1/admin/invites/{first_id}",
+            headers=_admin_headers(client),
+        )
+        assert del_resp.status_code == 200
+        assert del_resp.json()["status"] == "revoked"
+
+        pending_resp = client.get(
+            "/api/v1/admin/invites?status=pending",
+            headers=_admin_headers(client),
+        )
+        assert pending_resp.status_code == 200
+        assert pending_resp.json()["count"] == 1
+
+        revoked_resp = client.get(
+            "/api/v1/admin/invites?status=revoked",
+            headers=_admin_headers(client),
+        )
+        assert revoked_resp.status_code == 200
+        assert revoked_resp.json()["count"] == 1
+
+
+class TestPublicClaimHTTP:
+    def test_get_metadata_then_claim(
+        self,
+        client: TestClient,
+        mock_sender: MockEmailSender,
+    ) -> None:
+        client.post(
+            "/api/v1/admin/invites",
+            json={"email": INVITEE_EMAIL, "role": "user", "target_l2_id": "acme/eng"},
+            headers=_admin_headers(client),
+        )
+        token = mock_sender.sent[0].jwt
+
+        meta_resp = client.get(f"/api/v1/invites/{token}")
+        assert meta_resp.status_code == 200, meta_resp.text
+        meta = meta_resp.json()
+        assert meta["email"] == INVITEE_EMAIL
+        assert meta["role"] == "user"
+        assert meta["inviter_username"] == ADMIN
+
+        claim_resp = client.post(
+            f"/api/v1/invites/{token}/claim",
+            json={"username": "newcomer", "password": "password123"},
+        )
+        assert claim_resp.status_code == 200, claim_resp.text
+        claim_body = claim_resp.json()
+        assert claim_body["username"] == "newcomer"
+        assert claim_body["token"]
+
+    def test_double_claim_returns_409(
+        self,
+        client: TestClient,
+        mock_sender: MockEmailSender,
+    ) -> None:
+        client.post(
+            "/api/v1/admin/invites",
+            json={"email": INVITEE_EMAIL, "role": "user", "target_l2_id": "acme/eng"},
+            headers=_admin_headers(client),
+        )
+        token = mock_sender.sent[0].jwt
+
+        first = client.post(
+            f"/api/v1/invites/{token}/claim",
+            json={"username": "newcomer", "password": "password123"},
+        )
+        assert first.status_code == 200
+        second = client.post(
+            f"/api/v1/invites/{token}/claim",
+            json={"username": "newcomer2", "password": "password123"},
+        )
+        assert second.status_code == 409
+
+    def test_expired_returns_410(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_sender: MockEmailSender,
+    ) -> None:
+        monkeypatch.setenv("CQ_INVITE_TTL_HOURS", "0")
+        client.post(
+            "/api/v1/admin/invites",
+            json={"email": INVITEE_EMAIL, "role": "user", "target_l2_id": "acme/eng"},
+            headers=_admin_headers(client),
+        )
+        token = mock_sender.sent[0].jwt
+        time.sleep(1.1)
+
+        resp = client.get(f"/api/v1/invites/{token}")
+        assert resp.status_code == 410
+        claim_resp = client.post(
+            f"/api/v1/invites/{token}/claim",
+            json={"username": "newcomer", "password": "password123"},
+        )
+        assert claim_resp.status_code == 410
+
+    def test_revoked_returns_410(
+        self,
+        client: TestClient,
+        mock_sender: MockEmailSender,
+    ) -> None:
+        mint_resp = client.post(
+            "/api/v1/admin/invites",
+            json={"email": INVITEE_EMAIL, "role": "user", "target_l2_id": "acme/eng"},
+            headers=_admin_headers(client),
+        )
+        invite_id = mint_resp.json()["id"]
+        token = mock_sender.sent[0].jwt
+        client.delete(
+            f"/api/v1/admin/invites/{invite_id}",
+            headers=_admin_headers(client),
+        )
+
+        resp = client.get(f"/api/v1/invites/{token}")
+        assert resp.status_code == 410
+        claim_resp = client.post(
+            f"/api/v1/invites/{token}/claim",
+            json={"username": "newcomer", "password": "password123"},
+        )
+        assert claim_resp.status_code == 410
+
+    def test_bad_signature_returns_404(self, client: TestClient) -> None:
+        # Build a token signed with a different secret.
+        now = datetime.now(UTC)
+        bogus = pyjwt.encode(
+            {
+                "sub": "fake@example.com",
+                "role": "user",
+                "target_l2_id": None,
+                "iss": INVITE_ISSUER,
+                "aud": INVITE_AUDIENCE,
+                "iat": now,
+                "exp": now + timedelta(hours=1),
+                "jti": "deadbeef",
+            },
+            "wrong-secret",
+            algorithm="HS256",
+        )
+        resp = client.get(f"/api/v1/invites/{bogus}")
+        assert resp.status_code == 404
+
+
+class TestOpenAPIVisibility:
+    def test_invite_endpoints_in_openapi(self, client: TestClient) -> None:
+        spec = client.get("/openapi.json").json()
+        paths = spec["paths"]
+        # Routes are mounted under both / and /api/v1; assert the v1 mount.
+        assert "/api/v1/admin/invites" in paths
+        assert "/api/v1/admin/invites/{invite_id}" in paths
+        assert "/api/v1/invites/{token}" in paths
+        assert "/api/v1/invites/{token}/claim" in paths

--- a/server/backend/tests/test_migration_0011_activity_log.py
+++ b/server/backend/tests/test_migration_0011_activity_log.py
@@ -473,13 +473,13 @@ class TestHeadRevisionAndHistory:
         is the source of truth for ops scripts and stamp logic."""
         from cq_server.migrations import HEAD_REVISION
 
-        # Bumped by 0018_webauthn_credentials (FO-1a passkey enrollment
-        # substrate, #191) — chains after 0017_add_user_email. Earlier
-        # bumps: 0016 (Phase 1.0b xgroup_consent + AIGRP key protocols),
-        # 0015 (Phase 1.0c — Decision 27/28 audit gap), 0014 (#124
-        # crosstalk tables), 0013 (#121 finding 3), 0012 (#103), 0011
-        # (#108 Stage 1). Each new migration MUST move this constant.
-        assert HEAD_REVISION == "0018_webauthn_credentials"
+        # Bumped by 0016_xgroup_consent (Phase 1.0b — Decision 28
+        # intra-Enterprise xgroup_consent + AIGRP key protocols).
+        # Earlier bumps: 0015 (Phase 1.0c — Decision 27/28 audit gap),
+        # 0014 (#124 crosstalk tables), 0013 (#121 finding 3), 0012
+        # (#103), 0011 (#108 Stage 1). Each new migration MUST move
+        # this constant.
+        assert HEAD_REVISION == "0019_invites"
 
     @pytest.mark.parametrize("invalid_dir", [None])
     def test_alembic_history_includes_0011(self, invalid_dir: object) -> None:

--- a/server/backend/tests/test_migration_0015_aigrp_peers_pair_secret_ref.py
+++ b/server/backend/tests/test_migration_0015_aigrp_peers_pair_secret_ref.py
@@ -271,11 +271,7 @@ class TestHeadRevisionAndHistory:
     def test_head_revision_constant_was_bumped(self) -> None:
         from cq_server.migrations import HEAD_REVISION
 
-        # NOTE: this pin originally asserted 0015 (the rev introduced by
-        # this test file), then jumped past 0016 unupdated. FO-1a (#191)
-        # bumps to 0018_webauthn_credentials; the lineage 0015 → 0016
-        # → 0017 → 0018 is exercised by ``test_migrations`` regardless.
-        assert HEAD_REVISION == "0018_webauthn_credentials"
+        assert HEAD_REVISION == "0019_invites"
 
     def test_alembic_history_includes_0015(self) -> None:
         repo_root = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary

FO-1b of Founder Onboarding (#191): magic-link invites delivered over SES.
Admins mint single-use, JWT-backed invites; recipients claim via a public
URL containing the JWT. Mint endpoint never returns the bearer — the
email channel is the only delivery path.

* Alembic 0019_invites — new `invites` table per the spec on issue #191.
* `cq_server.email_sender` — boto3 SES v1 wrapper + `MockEmailSender`
  test double. Source identity / region / public-host are env-driven
  (`CQ_INVITE_FROM_EMAIL`, `CQ_AWS_REGION`, `CQ_PUBLIC_HOST`).
* `cq_server.invites` — mint / validate / claim / list / revoke. JWT
  carries `aud="invite"` so the discriminant blocks an invite token
  from reaching session-aud surfaces. Single-use via `UNIQUE(jti)` +
  atomic `UPDATE … WHERE claimed_at IS NULL AND revoked_at IS NULL`.
* `cq_server.invite_routes` — five endpoints under `/api/v1`:
  `POST/GET/DELETE /admin/invites[/{id}]` and
  `GET/POST /invites/{jwt}[/claim]`. Wired into `app.py`.
* TTL 72h default, configurable via `CQ_INVITE_TTL_HOURS`.

Out of scope (deferred): WebAuthn passkey (FO-1a), cookie-bound
`aud="session"` JWTs (FO-1c), React frontend (FO-1d), `/signup` for
fresh Enterprise creation (FO-2).

## Cross-links

* Closes 1b of OneZero1ai/8th-layer-agent#191
* Parent epic: OneZero1ai/8th-layer-core#57
* Narrative: OneZero1ai/8th-layer-core#56

## Dependency note (alembic chain)

This migration's `down_revision = "0018_webauthn_credentials"` chains
onto FO-1a. **FO-1a must merge first.** To make the test suite run
end-to-end while FO-1a is in flight, FO-1a's two migration files are
vendored on this branch (commit `63a1899`). When FO-1a lands first
they merge as identical content; if FO-1a updates before landing,
expect a 1-line resolution.

The 0019 migration itself does not duplicate any FO-1a work — it only
references their schema as a chain ancestor.

## Test plan

- [x] `pytest server/backend/tests -k invite` — **20 passed**
- [x] `pytest server/backend/tests` — full suite, 789 passed, 5 skipped
- [x] `ruff check` — clean
- [x] `MockEmailSender` captures sends in tests; no AWS calls
- [x] All five endpoints visible in `/openapi.json`
- [ ] SES sandbox-exit landed (operator-side, agent#198) — blocks
      production email delivery, not this PR
- [ ] Smoke test against a real SES sender identity once agent#198 closes
- [ ] Wire frontend `/invite/{jwt}` claim page (FO-1d)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
