### PR TITLE
review(FO-1a): apply 8l-reviewer MEDIUM hardening fixes

### DIFF
--- a/server/backend/src/cq_server/passkey.py
+++ b/server/backend/src/cq_server/passkey.py
@@ -58,14 +58,40 @@ DEFAULT_RP_NAME = "8th-Layer.ai (dev)"
 CHALLENGE_TTL_SECONDS = 60
 
 
+def _is_dev_env() -> bool:
+    return os.environ.get("CQ_ENV", "dev").lower() == "dev"
+
+
 def rp_id() -> str:
-    """Return the RP ID used in registration / authentication options."""
-    return os.environ.get("CQ_WEBAUTHN_RP_ID", DEFAULT_RP_ID)
+    """Return the RP ID used in registration / authentication options.
+
+    Refuses to silently default in non-dev: a misconfigured production
+    deploy that ships without ``CQ_WEBAUTHN_RP_ID`` would silently bind
+    every credential to ``localhost``, which is a config-failure-mode
+    we'd rather catch loud at startup than silently break in prod.
+    """
+    val = os.environ.get("CQ_WEBAUTHN_RP_ID", "").strip()
+    if not val:
+        if not _is_dev_env():
+            raise RuntimeError("CQ_WEBAUTHN_RP_ID is required in non-dev environments")
+        return DEFAULT_RP_ID
+    return val
 
 
 def rp_origin() -> str:
-    """Return the RP origin (URL) used to verify clientDataJSON."""
-    return os.environ.get("CQ_WEBAUTHN_RP_ORIGIN", DEFAULT_RP_ORIGIN)
+    """Return the RP origin (URL) used to verify clientDataJSON.
+
+    Same fail-loud semantics as ``rp_id()`` plus an https-only check
+    in non-dev so a typo'd ``http://`` URL doesn't sneak through.
+    """
+    val = os.environ.get("CQ_WEBAUTHN_RP_ORIGIN", "").strip()
+    if not val:
+        if not _is_dev_env():
+            raise RuntimeError("CQ_WEBAUTHN_RP_ORIGIN is required in non-dev environments")
+        return DEFAULT_RP_ORIGIN
+    if not _is_dev_env() and not val.startswith("https://"):
+        raise RuntimeError("CQ_WEBAUTHN_RP_ORIGIN must use https:// in non-dev environments")
+    return val
 
 
 def rp_name() -> str:
@@ -88,14 +114,28 @@ class _ChallengeEntry:
 _challenge_cache: dict[str, _ChallengeEntry] = {}
 
 
-def set_challenge_cache_override(cache: dict[str, _ChallengeEntry] | None) -> None:
+def _set_challenge_cache_override_for_tests(cache: dict[str, _ChallengeEntry] | None) -> None:
     """Inject a challenge cache dict for tests; pass ``None`` to reset.
 
     Tests use this to assert on cache state and to ensure isolation
-    between cases. Production code never calls this.
+    between cases. Production code never calls this — the underscore
+    prefix is the lint-catchable signal. The function is also gated
+    on ``CQ_TESTING=1`` so an accidental import path can't trip it.
     """
+    if os.environ.get("CQ_TESTING") != "1":
+        raise RuntimeError(
+            "_set_challenge_cache_override_for_tests is test-only; "
+            "set CQ_TESTING=1 in test environment"
+        )
     global _challenge_cache  # noqa: PLW0603
     _challenge_cache = {} if cache is None else cache
+
+
+# NOTE on horizontal scaling (FO-1c follow-up): this dict is per-process.
+# /enroll/begin landing on replica A and /enroll/finish on replica B
+# will fail with "challenge missing or expired". Acceptable for FO-1a's
+# single-task ECS deployment. Must move to Redis or DynamoDB-with-TTL
+# before any load-balanced multi-replica deployment.
 
 
 def _store_challenge(username: str, challenge: bytes, *, user_id_bytes: bytes | None = None) -> None:

--- a/server/backend/src/cq_server/passkey_routes.py
+++ b/server/backend/src/cq_server/passkey_routes.py
@@ -24,27 +24,29 @@ Out of scope here (deferred to FO-1b/c):
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
+from webauthn.helpers.exceptions import (
+    InvalidAuthenticationResponse,
+    InvalidJSONStructure,
+    InvalidRegistrationResponse,
+)
 
 from . import passkey
 from .auth import _get_jwt_secret, create_token, get_current_user
 from .deps import get_store
 from .store._sqlite import SqliteStore
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/auth/passkey", tags=["auth", "passkey"])
 
 
 # --- Request / response shapes -------------------------------------------
-
-
-class EnrollBeginRequest(BaseModel):
-    """Optional human-readable label for the new credential."""
-
-    name: str | None = Field(default=None, max_length=64)
 
 
 class EnrollFinishRequest(BaseModel):
@@ -102,7 +104,6 @@ def _user_id_bytes(user_id: int) -> bytes:
 
 @router.post("/enroll/begin")
 async def enroll_begin(
-    request: EnrollBeginRequest,  # noqa: ARG001 — name is opaque at begin
     username: str = Depends(get_current_user),
     store: SqliteStore = Depends(get_store),
 ) -> dict[str, Any]:
@@ -111,6 +112,8 @@ async def enroll_begin(
     The caller is identified by the existing JWT/API-key auth; we look
     up the user row, build options including any already-enrolled
     credential ids in ``excludeCredentials``, and cache the challenge.
+    The credential ``name`` is supplied at finish time (in
+    ``EnrollFinishRequest``), not begin — begin takes no body.
     """
     user = await store.get_user(username)
     if user is None:
@@ -142,9 +145,20 @@ async def enroll_finish(
             transports=request.transports,
         )
     except ValueError as exc:
+        # ValueError comes from our own `passkey.finish_registration` for
+        # cache-miss / TTL conditions — message is operator-controlled,
+        # safe to surface.
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    except Exception as exc:  # noqa: BLE001 — py_webauthn raises subclasses of Exception
-        raise HTTPException(status_code=400, detail=f"registration verification failed: {exc}") from exc
+    except (
+        InvalidRegistrationResponse,
+        InvalidAuthenticationResponse,
+        InvalidJSONStructure,
+    ) as exc:
+        # py_webauthn-internal failure messages can leak parsed-CBOR
+        # fragments and authenticator-data fields; log server-side, return
+        # a generic 400 to the client.
+        logger.info("passkey enrollment verification failed for %s: %s", username, exc)
+        raise HTTPException(status_code=400, detail="passkey verification failed") from None
 
     transports_csv = ",".join(verified.transports) if verified.transports else None
     row = await store.insert_webauthn_credential(
@@ -232,8 +246,15 @@ async def login_finish(
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    except Exception as exc:  # noqa: BLE001 — py_webauthn replay raises InvalidAuthenticationResponse
-        raise HTTPException(status_code=400, detail=f"authentication failed: {exc}") from exc
+    except (
+        InvalidRegistrationResponse,
+        InvalidAuthenticationResponse,
+        InvalidJSONStructure,
+    ) as exc:
+        # py_webauthn raises InvalidAuthenticationResponse for the
+        # replay-attack / clone-detection path. Don't leak its message.
+        logger.info("passkey login verification failed for %s: %s", request.username, exc)
+        raise HTTPException(status_code=400, detail="passkey verification failed") from None
 
     await store.update_webauthn_sign_count(
         credential_id=verified.credential_id,

--- a/server/backend/tests/test_passkey.py
+++ b/server/backend/tests/test_passkey.py
@@ -59,19 +59,20 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClie
     monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "test.db"))
     monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
     monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    monkeypatch.setenv("CQ_TESTING", "1")
     monkeypatch.setenv("CQ_WEBAUTHN_RP_ID", RP_ID)
     monkeypatch.setenv("CQ_WEBAUTHN_RP_ORIGIN", RP_ORIGIN)
     monkeypatch.setenv("CQ_WEBAUTHN_RP_NAME", RP_NAME)
     # Reset the in-process challenge cache between tests so per-test
     # state never leaks across cases.
-    passkey.set_challenge_cache_override(None)
+    passkey._set_challenge_cache_override_for_tests(None)
     app.dependency_overrides[require_api_key] = lambda: "alice"
     app.dependency_overrides[get_current_user] = lambda: "alice"
     with TestClient(app) as c:
         yield c
     app.dependency_overrides.pop(require_api_key, None)
     app.dependency_overrides.pop(get_current_user, None)
-    passkey.set_challenge_cache_override(None)
+    passkey._set_challenge_cache_override_for_tests(None)
 
 
 def _seed_user(username: str = "alice", password: str = "secret123") -> None:
@@ -376,3 +377,45 @@ class TestLoginFinish:
             json={"username": "alice", "credential": replay},
         )
         assert bad.status_code == 400
+        # Generic detail — py_webauthn's internal exception message is
+        # logged server-side, not surfaced to the client (review fix #2).
+        assert bad.json()["detail"] == "passkey verification failed"
+
+
+class TestRpConfigHardening:
+    """Verify the env-gated dev-default pattern (review fix #1)."""
+
+    def test_rp_id_raises_in_non_dev_when_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CQ_ENV", "production")
+        monkeypatch.delenv("CQ_WEBAUTHN_RP_ID", raising=False)
+        with pytest.raises(RuntimeError, match="CQ_WEBAUTHN_RP_ID is required"):
+            passkey.rp_id()
+
+    def test_rp_origin_rejects_http_in_non_dev(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CQ_ENV", "production")
+        monkeypatch.setenv("CQ_WEBAUTHN_RP_ORIGIN", "http://insecure.example.com")
+        with pytest.raises(RuntimeError, match="must use https://"):
+            passkey.rp_origin()
+
+    def test_rp_id_returns_default_in_dev(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CQ_ENV", "dev")
+        monkeypatch.delenv("CQ_WEBAUTHN_RP_ID", raising=False)
+        assert passkey.rp_id() == passkey.DEFAULT_RP_ID
+
+
+class TestChallengeCacheGate:
+    """Verify the test-only injection point refuses to fire in production
+    (review fix #3)."""
+
+    def test_override_refuses_without_cq_testing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("CQ_TESTING", raising=False)
+        with pytest.raises(RuntimeError, match="test-only"):
+            passkey._set_challenge_cache_override_for_tests({})


### PR DESCRIPTION
Stacked on top of [#205](https://github.com/OneZero1ai/8th-layer-agent/pull/205) — applies 8l-reviewer's three MEDIUM blockers + one LOW cleanup.

## Changes

| # | Fix | File:line |
|---|---|---|
| 1 | RP_ID / RP_ORIGIN env-required + https-only in non-dev (matches `_get_jwt_secret()` pattern) | `passkey.py:61–95` |
| 2 | Narrow except to `webauthn.helpers.exceptions.Invalid*` + log internal message server-side, return generic 400 | `passkey_routes.py:138–158, 226–241` |
| 3 | Rename test-injection function `_set_challenge_cache_override_for_tests` + gate with `CQ_TESTING=1` env | `passkey.py:91–106` |
| 4 (LOW) | Drop unused `EnrollBeginRequest` body model — `enroll/begin` takes no body | `passkey_routes.py:52, 111–116` |

Plus 4 new tests: `TestRpConfigHardening` (3 cases) + `TestChallengeCacheGate` (1 case). Suite: **10/10 passing** (was 6/6).

## Three FO-1c follow-ups identified by reviewer (separate issues to file)

- Per-process challenge cache → Redis/DDB before any horizontal scale-out
- `sign_count=0` platform authenticators — current replay test only catches roaming authenticators; per-session nonce binding needed
- Add `(enterprise_id, group_id)` columns to `webauthn_credentials` once per-L2 isolation flag flips on by default

## Merge order

Squash this PR into #205 OR merge this on top after #205. Either works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)