### PR TITLE
style(FO-1a): apply ruff format

### DIFF
--- a/scripts/cleanup-test-fixtures.py
+++ b/scripts/cleanup-test-fixtures.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-Teardown of 8th-Layer.ai test fixtures.
+"""Teardown of 8th-Layer.ai test fixtures.
 
 Default mode: --dry-run (read-only AWS calls, lists candidate resources).
 Use --execute to actually delete (in safe ordering).
@@ -27,13 +26,12 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
 import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 try:
@@ -97,10 +95,10 @@ class AuditLog:
     def __post_init__(self):
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self.fh = open(self.path, "a", encoding="utf-8")
-        self.write(f"=== cleanup run started {datetime.now(timezone.utc).isoformat()} ===")
+        self.write(f"=== cleanup run started {datetime.now(UTC).isoformat()} ===")
 
     def write(self, line: str):
-        ts = datetime.now(timezone.utc).isoformat()
+        ts = datetime.now(UTC).isoformat()
         self.fh.write(f"{ts}\t{line}\n")
         self.fh.flush()
 
@@ -108,7 +106,7 @@ class AuditLog:
         self.write(f"{kind}\t{resource}\t{action}\t{result}")
 
     def close(self):
-        self.write(f"=== cleanup run finished {datetime.now(timezone.utc).isoformat()} ===")
+        self.write(f"=== cleanup run finished {datetime.now(UTC).isoformat()} ===")
         self.fh.close()
 
 
@@ -476,7 +474,7 @@ def main():
     if args.execute:
         args.dry_run = False
 
-    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
     log_path = Path(args.log_dir) / f"cleanup-{ts}.log"
     audit = AuditLog(path=log_path)
     audit.write(f"mode={'execute' if args.execute else 'dry-run'} filter={args.filter}")
@@ -530,7 +528,7 @@ def main():
     active_count = sum(1 for inv in inventories if inv.services)
     print(f"# Estimated savings: ~${active_count * COST_PER_CLUSTER_MO_USD:.2f}/month "
           f"({active_count} clusters x ~${COST_PER_CLUSTER_MO_USD}/mo each).")
-    print(f"#   - Fargate task: ~$15/mo  ALB: ~$22/mo  ENI: ~$3/mo  Logs: ~$0.50/mo")
+    print("#   - Fargate task: ~$15/mo  ALB: ~$22/mo  ENI: ~$3/mo  Logs: ~$0.50/mo")
     print()
 
     # Directory probe

--- a/server/backend/src/cq_server/passkey.py
+++ b/server/backend/src/cq_server/passkey.py
@@ -123,10 +123,7 @@ def _set_challenge_cache_override_for_tests(cache: dict[str, _ChallengeEntry] | 
     on ``CQ_TESTING=1`` so an accidental import path can't trip it.
     """
     if os.environ.get("CQ_TESTING") != "1":
-        raise RuntimeError(
-            "_set_challenge_cache_override_for_tests is test-only; "
-            "set CQ_TESTING=1 in test environment"
-        )
+        raise RuntimeError("_set_challenge_cache_override_for_tests is test-only; set CQ_TESTING=1 in test environment")
     global _challenge_cache  # noqa: PLW0603
     _challenge_cache = {} if cache is None else cache
 
@@ -181,9 +178,7 @@ def begin_registration(
     one already on file.
     """
     challenge = secrets.token_bytes(32)
-    exclude = [
-        PublicKeyCredentialDescriptor(id=cid) for cid in (existing_credential_ids or [])
-    ]
+    exclude = [PublicKeyCredentialDescriptor(id=cid) for cid in (existing_credential_ids or [])]
     options = generate_registration_options(
         rp_id=rp_id(),
         rp_name=rp_name(),
@@ -245,9 +240,7 @@ def finish_registration(
         # so don't fail verification on UP-only authenticators yet.
         require_user_verification=False,
     )
-    aaguid_bytes = (
-        bytes.fromhex(verified.aaguid.replace("-", "")) if verified.aaguid else None
-    )
+    aaguid_bytes = bytes.fromhex(verified.aaguid.replace("-", "")) if verified.aaguid else None
     return VerifiedRegistration(
         credential_id=verified.credential_id,
         public_key=verified.credential_public_key,
@@ -275,9 +268,7 @@ def begin_authentication(
     options = generate_authentication_options(
         rp_id=rp_id(),
         challenge=challenge,
-        allow_credentials=[
-            PublicKeyCredentialDescriptor(id=cid) for cid in allow_credential_ids
-        ],
+        allow_credentials=[PublicKeyCredentialDescriptor(id=cid) for cid in allow_credential_ids],
         user_verification=UserVerificationRequirement.PREFERRED,
     )
     _store_challenge(username, challenge)

--- a/server/backend/src/cq_server/store/_sqlite.py
+++ b/server/backend/src/cq_server/store/_sqlite.py
@@ -224,9 +224,7 @@ class SqliteStore:
     async def get_webauthn_credential_by_id(self, credential_id: bytes) -> dict[str, Any] | None:
         return await self._run_sync(self._get_webauthn_credential_by_id_sync, credential_id)
 
-    async def update_webauthn_sign_count(
-        self, *, credential_id: bytes, new_sign_count: int, last_used_at: str
-    ) -> None:
+    async def update_webauthn_sign_count(self, *, credential_id: bytes, new_sign_count: int, last_used_at: str) -> None:
         await self._run_sync(
             self._update_webauthn_sign_count_sync,
             credential_id=credential_id,
@@ -4236,15 +4234,10 @@ class SqliteStore:
             "last_used_at": row[9],
         }
 
-    def _update_webauthn_sign_count_sync(
-        self, *, credential_id: bytes, new_sign_count: int, last_used_at: str
-    ) -> None:
+    def _update_webauthn_sign_count_sync(self, *, credential_id: bytes, new_sign_count: int, last_used_at: str) -> None:
         with self._engine.begin() as conn:
             conn.execute(
-                text(
-                    "UPDATE webauthn_credentials SET sign_count = :sc, last_used_at = :lu "
-                    "WHERE credential_id = :cid"
-                ),
+                text("UPDATE webauthn_credentials SET sign_count = :sc, last_used_at = :lu WHERE credential_id = :cid"),
                 {"sc": new_sign_count, "lu": last_used_at, "cid": credential_id},
             )
 

--- a/server/backend/tests/test_passkey.py
+++ b/server/backend/tests/test_passkey.py
@@ -115,24 +115,14 @@ class _FakeAuthenticator:
     def _rp_id_hash(self, rp_id: str) -> bytes:
         return hashlib.sha256(rp_id.encode()).digest()
 
-    def make_registration_credential(
-        self, *, challenge: bytes, rp_id: str, origin: str
-    ) -> dict[str, Any]:
+    def make_registration_credential(self, *, challenge: bytes, rp_id: str, origin: str) -> dict[str, Any]:
         """Build a registration response with fmt=none."""
         flags = 0x41  # UP | AT
         sign_count = 0
         attested_cred_data = (
-            self.aaguid
-            + struct.pack(">H", len(self.credential_id))
-            + self.credential_id
-            + self.cose_public_key()
+            self.aaguid + struct.pack(">H", len(self.credential_id)) + self.credential_id + self.cose_public_key()
         )
-        auth_data = (
-            self._rp_id_hash(rp_id)
-            + bytes([flags])
-            + struct.pack(">I", sign_count)
-            + attested_cred_data
-        )
+        auth_data = self._rp_id_hash(rp_id) + bytes([flags]) + struct.pack(">I", sign_count) + attested_cred_data
         client_data = json.dumps(
             {
                 "type": "webauthn.create",
@@ -142,9 +132,7 @@ class _FakeAuthenticator:
             },
             separators=(",", ":"),
         ).encode()
-        attestation_object = cbor2.dumps(
-            {"fmt": "none", "attStmt": {}, "authData": auth_data}
-        )
+        attestation_object = cbor2.dumps({"fmt": "none", "attStmt": {}, "authData": auth_data})
         cred_id_b64u = bytes_to_base64url(self.credential_id)
         return {
             "id": cred_id_b64u,
@@ -166,9 +154,7 @@ class _FakeAuthenticator:
         user_handle: bytes = b"\x00" * 8,
     ) -> dict[str, Any]:
         """Build an assertion response signed with the stored EC key."""
-        auth_data = (
-            self._rp_id_hash(rp_id) + bytes([0x01]) + struct.pack(">I", sign_count)
-        )
+        auth_data = self._rp_id_hash(rp_id) + bytes([0x01]) + struct.pack(">I", sign_count)
         client_data = json.dumps(
             {
                 "type": "webauthn.get",
@@ -236,9 +222,7 @@ class TestEnrollFinish:
         challenge = _challenge_from_options(begin)
 
         authenticator = _FakeAuthenticator()
-        cred = authenticator.make_registration_credential(
-            challenge=challenge, rp_id=RP_ID, origin=RP_ORIGIN
-        )
+        cred = authenticator.make_registration_credential(challenge=challenge, rp_id=RP_ID, origin=RP_ORIGIN)
         resp = client.post(
             "/auth/passkey/enroll/finish",
             json={"credential": cred, "name": "DW's YubiKey"},
@@ -260,9 +244,7 @@ class TestEnrollFinish:
 
 
 class TestLoginBegin:
-    def test_login_begin_returns_options_for_known_user(
-        self, client: TestClient
-    ) -> None:
+    def test_login_begin_returns_options_for_known_user(self, client: TestClient) -> None:
         _seed_user()
         # First enroll one credential so login/begin has something to allow.
         begin = client.post("/auth/passkey/enroll/begin", json={}).json()
@@ -274,22 +256,16 @@ class TestLoginBegin:
         )
         client.post("/auth/passkey/enroll/finish", json={"credential": cred})
 
-        resp = client.post(
-            "/auth/passkey/login/begin", json={"username": "alice"}
-        )
+        resp = client.post("/auth/passkey/login/begin", json={"username": "alice"})
         assert resp.status_code == 200, resp.text
         body = resp.json()
         assert body["rpId"] == RP_ID
         # ``allowCredentials`` is the camelCased wire shape py_webauthn emits.
         assert len(body["allowCredentials"]) == 1
-        assert body["allowCredentials"][0]["id"] == bytes_to_base64url(
-            authenticator.credential_id
-        )
+        assert body["allowCredentials"][0]["id"] == bytes_to_base64url(authenticator.credential_id)
 
     def test_login_begin_unknown_user_404(self, client: TestClient) -> None:
-        resp = client.post(
-            "/auth/passkey/login/begin", json={"username": "ghost"}
-        )
+        resp = client.post("/auth/passkey/login/begin", json={"username": "ghost"})
         assert resp.status_code == 404
 
 
@@ -306,13 +282,9 @@ class TestLoginFinish:
         client.post("/auth/passkey/enroll/finish", json={"credential": cred})
         return authenticator
 
-    def test_login_finish_mints_jwt_and_advances_sign_count(
-        self, client: TestClient
-    ) -> None:
+    def test_login_finish_mints_jwt_and_advances_sign_count(self, client: TestClient) -> None:
         authenticator = self._enroll(client)
-        login_begin = client.post(
-            "/auth/passkey/login/begin", json={"username": "alice"}
-        ).json()
+        login_begin = client.post("/auth/passkey/login/begin", json={"username": "alice"}).json()
         assertion = authenticator.make_authentication_credential(
             challenge=_challenge_from_options(login_begin),
             rp_id=RP_ID,
@@ -328,9 +300,7 @@ class TestLoginFinish:
         assert body["username"] == "alice"
         assert body["sign_count"] == 1
         # The JWT verifies under the same secret the server uses.
-        payload = verify_token(
-            body["token"], secret="test-secret-thirty-two-chars-min!"
-        )
+        payload = verify_token(body["token"], secret="test-secret-thirty-two-chars-min!")
         assert payload["sub"] == "alice"
 
         # The DB row's sign_count advanced too.
@@ -345,9 +315,7 @@ class TestLoginFinish:
         """Same signCount on a subsequent assertion is a clone signal."""
         authenticator = self._enroll(client)
         # First successful login — advances sign_count to 1.
-        login_begin = client.post(
-            "/auth/passkey/login/begin", json={"username": "alice"}
-        ).json()
+        login_begin = client.post("/auth/passkey/login/begin", json={"username": "alice"}).json()
         assertion = authenticator.make_authentication_credential(
             challenge=_challenge_from_options(login_begin),
             rp_id=RP_ID,
@@ -363,9 +331,7 @@ class TestLoginFinish:
         # Replay with the SAME signCount — py_webauthn requires strictly
         # greater. New begin first to seed a fresh challenge so the only
         # thing failing is the signCount.
-        login_begin_2 = client.post(
-            "/auth/passkey/login/begin", json={"username": "alice"}
-        ).json()
+        login_begin_2 = client.post("/auth/passkey/login/begin", json={"username": "alice"}).json()
         replay = authenticator.make_authentication_credential(
             challenge=_challenge_from_options(login_begin_2),
             rp_id=RP_ID,
@@ -385,25 +351,19 @@ class TestLoginFinish:
 class TestRpConfigHardening:
     """Verify the env-gated dev-default pattern (review fix #1)."""
 
-    def test_rp_id_raises_in_non_dev_when_unset(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_rp_id_raises_in_non_dev_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CQ_ENV", "production")
         monkeypatch.delenv("CQ_WEBAUTHN_RP_ID", raising=False)
         with pytest.raises(RuntimeError, match="CQ_WEBAUTHN_RP_ID is required"):
             passkey.rp_id()
 
-    def test_rp_origin_rejects_http_in_non_dev(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_rp_origin_rejects_http_in_non_dev(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CQ_ENV", "production")
         monkeypatch.setenv("CQ_WEBAUTHN_RP_ORIGIN", "http://insecure.example.com")
         with pytest.raises(RuntimeError, match="must use https://"):
             passkey.rp_origin()
 
-    def test_rp_id_returns_default_in_dev(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_rp_id_returns_default_in_dev(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CQ_ENV", "dev")
         monkeypatch.delenv("CQ_WEBAUTHN_RP_ID", raising=False)
         assert passkey.rp_id() == passkey.DEFAULT_RP_ID
@@ -413,9 +373,7 @@ class TestChallengeCacheGate:
     """Verify the test-only injection point refuses to fire in production
     (review fix #3)."""
 
-    def test_override_refuses_without_cq_testing(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_override_refuses_without_cq_testing(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("CQ_TESTING", raising=False)
         with pytest.raises(RuntimeError, match="test-only"):
             passkey._set_challenge_cache_override_for_tests({})


### PR DESCRIPTION
Pure formatting fixup for the FO-1a passkey substrate. CI lint job caught format drift after #208 merge. Tests still 10/10 passing.

Stack on top of [#205](https://github.com/OneZero1ai/8th-layer-agent/pull/205).