### PR TITLE
feat(ui): FO-1d — passkey-first login UI + per-L2 branding chrome (closes #199)

### DIFF
--- a/server/backend/alembic/versions/0020_l2_brand.py
+++ b/server/backend/alembic/versions/0020_l2_brand.py
@@ -1,0 +1,101 @@
+"""FO-1d: ``l2_brand`` single-row table — per-L2 brand overrides.
+
+Revision ID: 0020_l2_brand
+Revises: 0019_invites
+Create Date: 2026-05-10
+
+Decision 30 — three-tier branding hierarchy (platform / enterprise / L2).
+This migration lands the L2-tier storage. Platform defaults live in code
+(``cq_server.theme`` constants); Enterprise overrides come from the
+directory record (V1 may stub them); L2 overrides come from this table.
+
+# Single-row enforcement
+
+There is exactly one L2 per L2-host process — the ``CQ_GROUP`` env pins it.
+The brand row therefore holds (label, subaccent_hex, hero_motif) for *this*
+L2 only, never a list. We enforce that with ``CHECK (id = 1)`` so any
+``INSERT`` that doesn't use ``id = 1`` fails fast at the DB layer; readers
+can issue ``SELECT * FROM l2_brand WHERE id = 1`` without scanning.
+
+The table is *initially empty*. The resolver in ``cq_server.theme`` returns
+the L2 layer with ``label = group_id`` (default to the env-pinned group)
+and the optional fields null when the row is absent. The Theming admin
+form (separate epic AS-5) is what populates the row; FO-1d ships only the
+schema + read path.
+
+# Why TEXT
+
+ISO-8601 ``updated_at`` and free-form override values match the existing
+schema convention (``users``, ``api_keys``, ``invites``) — sqlite stores
+TEXT and the Pydantic models on the read side type-coerce.
+
+# Idempotency
+
+Standard ``_table_exists`` guard mirrors every migration in the chain.
+Re-run is a no-op. Downgrade drops the table.
+
+# Chain note
+
+Sits on top of FO-1c's ``0019_invites``. After this migration lands, head
+is ``0020_l2_brand``; ``cq_server.migrations.HEAD_REVISION`` is bumped in
+the same PR.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0020_l2_brand"
+down_revision: str | Sequence[str] | None = "0019_invites"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _table_exists(bind: sa.engine.Connection, table_name: str) -> bool:
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def upgrade() -> None:
+    """Create the single-row ``l2_brand`` table."""
+    bind = op.get_bind()
+
+    if _table_exists(bind, "l2_brand"):
+        return
+
+    op.create_table(
+        "l2_brand",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        # Override of the L2 short label (defaults to ``group_id`` at read
+        # time; only stored here when an admin has explicitly customised).
+        sa.Column("l2_label", sa.Text(), nullable=True),
+        # Optional accent hex (#rrggbb, validated by the API on write).
+        sa.Column("subaccent_hex", sa.Text(), nullable=True),
+        # Catalog identifier for the hero motif — see Decision 30
+        # "Open question 3" recommendation: V1 ships 4 gradient names
+        # ("gradient.cyan-violet" etc.). Storage is opaque; the resolver
+        # just returns it.
+        sa.Column("hero_motif", sa.Text(), nullable=True),
+        sa.Column("updated_at", sa.Text(), nullable=False),
+        sa.Column(
+            "updated_by",
+            sa.Integer(),
+            sa.ForeignKey("users.id"),
+            nullable=True,
+        ),
+        # Single-row anchor: only id=1 is ever a valid row. Coupled with
+        # the resolver's ``WHERE id = 1`` read, this collapses the table
+        # to "exists or doesn't" without a separate flag.
+        sa.CheckConstraint("id = 1", name="ck_l2_brand_single_row"),
+    )
+
+
+def downgrade() -> None:
+    """Drop the table."""
+    bind = op.get_bind()
+    if not _table_exists(bind, "l2_brand"):
+        return
+    op.drop_table("l2_brand")

--- a/server/backend/alembic/versions/0020_l2_brand.py
+++ b/server/backend/alembic/versions/0020_l2_brand.py
@@ -90,6 +90,16 @@ def upgrade() -> None:
         # the resolver's ``WHERE id = 1`` read, this collapses the table
         # to "exists or doesn't" without a separate flag.
         sa.CheckConstraint("id = 1", name="ck_l2_brand_single_row"),
+        # Hex-shape constraint at the storage layer (defense in depth;
+        # 8l-reviewer MEDIUM 1 on PR #219). The AS-5 admin write path
+        # will also validate, but a typo'd direct UPDATE or a future
+        # schema bug shouldn't be able to push a malformed value
+        # through to the React `setProperty` call.
+        sa.CheckConstraint(
+            "subaccent_hex IS NULL OR "
+            "subaccent_hex GLOB '#[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]'",
+            name="ck_l2_brand_subaccent_hex_shape",
+        ),
     )
 
 

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -46,6 +46,7 @@ from .review import router as review_router
 from .scoring import apply_confirmation, apply_flag
 from .store import normalize_domains
 from .store._sqlite import SqliteStore
+from .theme_routes import router as theme_router
 
 _STATIC_DIR = Path(__file__).parent / "static"
 
@@ -413,6 +414,10 @@ api_router.include_router(activity_router)
 api_router.include_router(crosstalk_router)
 api_router.include_router(admin_xgroup_consent_router)
 api_router.include_router(invite_router)
+# FO-1d (#199) — anonymous /theme endpoint for the per-L2 brand chrome.
+# Mounted on api_router so it lives under both / and /api/v1, same as
+# every other API route. Decision 30 sets the spec.
+api_router.include_router(theme_router)
 
 
 @api_router.get("/health")

--- a/server/backend/src/cq_server/migrations.py
+++ b/server/backend/src/cq_server/migrations.py
@@ -36,7 +36,7 @@ BASELINE_REVISION = "0001"
 # Phase 2 (task #100) — chain head after porting fork-delta tables to
 # Alembic. Update this string when adding a new migration so test
 # assertions and ops scripts stay in sync with the actual chain head.
-HEAD_REVISION = "0019_invites"
+HEAD_REVISION = "0020_l2_brand"
 
 
 def _find_alembic_ini() -> Path:

--- a/server/backend/src/cq_server/store/_sqlite.py
+++ b/server/backend/src/cq_server/store/_sqlite.py
@@ -235,6 +235,26 @@ class SqliteStore:
     async def get_user_by_email(self, email: str) -> dict[str, Any] | None:
         return await self._run_sync(self._get_user_by_email_sync, email)
 
+    async def get_l2_brand(self) -> dict[str, Any] | None:
+        """Return the single-row L2 brand override row, or ``None``.
+
+        FO-1d (#199) — the ``l2_brand`` table has a CHECK (id = 1)
+        constraint so at most one row exists. Reader uses ``WHERE id = 1``
+        to make the "row absent" case explicit and the "row present"
+        case a primary-key lookup. Returns ``None`` when the table is
+        empty (admin hasn't customised the L2 brand yet); the resolver
+        in ``cq_server.theme`` falls back to env-pinned defaults.
+        """
+        return await self._run_sync(self._get_l2_brand_sync)
+
+    def _get_l2_brand_sync(self) -> dict[str, Any] | None:
+        stmt = text("SELECT id, l2_label, subaccent_hex, hero_motif, updated_at, updated_by FROM l2_brand WHERE id = 1")
+        with self._engine.connect() as conn:
+            row = conn.execute(stmt).mappings().first()
+        if row is None:
+            return None
+        return dict(row)
+
     async def daily_counts(
         self,
         *,

--- a/server/backend/src/cq_server/theme.py
+++ b/server/backend/src/cq_server/theme.py
@@ -1,0 +1,144 @@
+"""Theme resolver — 3-tier brand hierarchy (FO-1d, Decision 30).
+
+Anonymous endpoint substrate. Resolves the platform / Enterprise / L2
+JSON the React shell consumes via ``GET /api/v1/theme`` to apply CSS
+custom properties at runtime.
+
+# Tier shape
+
+* **platform** — hardcoded constants. The 8th-Layer.ai mark and the
+  cyan/violet/emerald/gold/rose token names. Customers cannot override.
+* **enterprise** — display name + optional logo URL + optional accent
+  hex. V1 stub: returns the env-pinned ``CQ_ENTERPRISE`` as the display
+  name with null logo and null accent. Future: read from the directory
+  record (sprint 3 client) once the Enterprise overrides land in
+  ``directory_client.py``'s announce/peering payload.
+* **l2** — short label + optional sub-accent + optional hero motif.
+  Read from the single-row ``l2_brand`` table (migration 0020).
+  Defaults to the env-pinned ``CQ_GROUP`` if no row exists.
+
+# Caching
+
+The endpoint emits ``Cache-Control: public, max-age=300``. The browser
+revalidates every 5 minutes, which matches the "Theming admin form
+re-publishes" cadence we expect from AS-5. No server-side cache yet —
+the resolver does at most one SQLite read per call which is cheap.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from . import aigrp
+from .store._sqlite import SqliteStore
+
+# --- Platform constants ---------------------------------------------------
+#
+# Mirrors ``server/frontend/src/index.css``'s ``data-theme="8th-layer"``
+# token block. If a value diverges between this dict and the CSS, the CSS
+# wins for actual rendering — this dict is purely for the JSON contract
+# the API surfaces (so external tools, e.g. a marketing-site theme
+# reader, can pull the platform palette without parsing CSS).
+
+PLATFORM_NAME = "8th-Layer.ai"
+PLATFORM_VERSION = "1.0.0"
+PLATFORM_TOKENS: dict[str, str] = {
+    "cyan": "#5bd0ff",
+    "violet": "#a685ff",
+    "emerald": "#10b981",
+    "gold": "#fcd34d",
+    "rose": "#ff5c7c",
+    "ink": "#e6e6e6",
+    "bg-from": "#0a0612",
+    "bg-via": "#07070b",
+    "bg-to": "#040810",
+}
+
+# --- Enterprise stub ------------------------------------------------------
+#
+# V1: derive from the env-pinned ``CQ_ENTERPRISE``. When the directory
+# record carries display-name / logo / accent overrides (post-sprint-3),
+# this resolver will read them; for now it returns a structurally valid
+# response with ``logo_url=None`` and ``accent_hex=None`` so the FE falls
+# back to the platform default cyan via CSS.
+
+
+def _resolve_enterprise() -> dict[str, Any]:
+    """Return the Enterprise tier of the theme.
+
+    V1 stub — display_name = enterprise id, logo and accent are None.
+    The shape is stable so the FE can rely on these keys existing.
+    """
+    enterprise_id = aigrp.enterprise()
+    return {
+        "id": enterprise_id,
+        "display_name": enterprise_id,
+        "logo_url": None,
+        "accent_hex": None,
+        "dark_mode_only": True,
+    }
+
+
+# --- L2 resolver ----------------------------------------------------------
+
+
+async def _resolve_l2(store: SqliteStore) -> dict[str, Any]:
+    """Return the L2 tier of the theme.
+
+    Reads the ``l2_brand`` single-row table; falls back to the env-pinned
+    group id when no override row exists. Always emits a structurally
+    valid object so the FE can rely on key presence.
+    """
+    enterprise_id = aigrp.enterprise()
+    group_id = aigrp.group()
+    row = await store.get_l2_brand()
+
+    if row is None:
+        return {
+            "id": f"{enterprise_id}/{group_id}",
+            "label": group_id,
+            "subaccent_hex": None,
+            "hero_motif": None,
+        }
+    return {
+        "id": f"{enterprise_id}/{group_id}",
+        "label": row["l2_label"] or group_id,
+        "subaccent_hex": row["subaccent_hex"],
+        "hero_motif": row["hero_motif"],
+    }
+
+
+# --- Top-level resolver ---------------------------------------------------
+
+
+class ThemeResolver:
+    """Compose the 3-tier theme JSON for the current host.
+
+    Held as a class so the test surface can patch ``_resolve_enterprise``
+    or ``_resolve_l2`` independently. The instance is otherwise stateless;
+    ``app.state.store`` is passed in via ``resolve()``.
+    """
+
+    async def resolve(self, store: SqliteStore) -> dict[str, Any]:
+        """Return the merged theme dict.
+
+        Shape mirrors Decision 30's example block exactly so the FE
+        TypeScript types can stay in lockstep with the spec.
+        """
+        return {
+            "platform": {
+                "name": PLATFORM_NAME,
+                "version": PLATFORM_VERSION,
+                "tokens": dict(PLATFORM_TOKENS),
+            },
+            "enterprise": _resolve_enterprise(),
+            "l2": await _resolve_l2(store),
+        }
+
+
+__all__ = [
+    "PLATFORM_NAME",
+    "PLATFORM_TOKENS",
+    "PLATFORM_VERSION",
+    "ThemeResolver",
+]

--- a/server/backend/src/cq_server/theme.py
+++ b/server/backend/src/cq_server/theme.py
@@ -27,10 +27,37 @@ the resolver does at most one SQLite read per call which is cheap.
 
 from __future__ import annotations
 
+import logging
+import re
 from typing import Any
 
 from . import aigrp
 from .store._sqlite import SqliteStore
+
+logger = logging.getLogger(__name__)
+
+# Strict 6-digit hex shape — the only thing we accept on the read path,
+# defense-in-depth even though the AS-5 write path will validate too
+# (8l-reviewer MEDIUM 1 on PR #219).
+_HEX_RE = re.compile(r"^#[0-9a-fA-F]{6}$")
+
+
+def _safe_hex(value: Any) -> str | None:
+    """Return ``value`` if it's a well-formed 6-digit hex, else ``None``.
+
+    Defense in depth: the AS-5 admin write path validates on insert and
+    migration 0020 carries a CHECK constraint. This function ensures a
+    malformed value (e.g. injected via direct DB access or a future
+    schema bug) cannot reach the React ``setProperty`` call where it
+    might land in unexpected CSS contexts.
+    """
+    if not isinstance(value, str):
+        return None
+    if not _HEX_RE.match(value):
+        logger.warning("rejected malformed hex from theme storage: %r", value)
+        return None
+    return value
+
 
 # --- Platform constants ---------------------------------------------------
 #
@@ -103,7 +130,7 @@ async def _resolve_l2(store: SqliteStore) -> dict[str, Any]:
     return {
         "id": f"{enterprise_id}/{group_id}",
         "label": row["l2_label"] or group_id,
-        "subaccent_hex": row["subaccent_hex"],
+        "subaccent_hex": _safe_hex(row["subaccent_hex"]),
         "hero_motif": row["hero_motif"],
     }
 

--- a/server/backend/src/cq_server/theme_routes.py
+++ b/server/backend/src/cq_server/theme_routes.py
@@ -1,0 +1,53 @@
+"""FastAPI router for ``GET /api/v1/theme`` (FO-1d, Decision 30).
+
+Anonymous endpoint — the L2 login screen needs the Enterprise + L2
+brand BEFORE auth so the user lands on a chrome that already looks
+right (Decision 30 §"Why same login screen for user and admin"). Same
+reason the platform-mark "Powered by 8th-Layer.ai" is rendered without
+auth: brand identity is a first-impression contract.
+
+Cache-Control: ``public, max-age=300`` — clients revalidate every 5
+minutes. Matches the cadence we expect from the Theming admin form
+(AS-5) re-publishing changes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, Response
+
+from .deps import get_store
+from .store._sqlite import SqliteStore
+from .theme import ThemeResolver
+
+router = APIRouter(tags=["theme"])
+
+_resolver = ThemeResolver()
+
+
+@router.get("/theme")
+async def get_theme(
+    response: Response,
+    store: SqliteStore = Depends(get_store),
+) -> dict[str, Any]:
+    """Return the resolved 3-tier theme JSON for the current host.
+
+    Shape per Decision 30:
+
+    ```json
+    {
+      "platform": {"name": ..., "version": ..., "tokens": {...}},
+      "enterprise": {"id": ..., "display_name": ..., "logo_url": ...,
+                      "accent_hex": ..., "dark_mode_only": ...},
+      "l2": {"id": ..., "label": ..., "subaccent_hex": ...,
+              "hero_motif": ...}
+    }
+    ```
+
+    The FE applies ``--brand-primary`` (from ``enterprise.accent_hex``,
+    falling back to platform cyan) and ``--brand-secondary`` (from
+    ``l2.subaccent_hex``, falling back to ``enterprise.accent_hex``).
+    """
+    response.headers["Cache-Control"] = "public, max-age=300"
+    return await _resolver.resolve(store)

--- a/server/backend/tests/test_default_enterprise_backfill.py
+++ b/server/backend/tests/test_default_enterprise_backfill.py
@@ -409,4 +409,4 @@ class TestIdempotencyAndChain:
         """
         # Bumped to 0016_xgroup_consent (Phase 1.0b — Decision 28).
         # Chains after 0015_phase_1_0c_aigrp_peers_pair_secret_ref.
-        assert HEAD_REVISION == "0019_invites"
+        assert HEAD_REVISION == "0020_l2_brand"

--- a/server/backend/tests/test_migration_0011_activity_log.py
+++ b/server/backend/tests/test_migration_0011_activity_log.py
@@ -479,7 +479,7 @@ class TestHeadRevisionAndHistory:
         # 0014 (#124 crosstalk tables), 0013 (#121 finding 3), 0012
         # (#103), 0011 (#108 Stage 1). Each new migration MUST move
         # this constant.
-        assert HEAD_REVISION == "0019_invites"
+        assert HEAD_REVISION == "0020_l2_brand"
 
     @pytest.mark.parametrize("invalid_dir", [None])
     def test_alembic_history_includes_0011(self, invalid_dir: object) -> None:

--- a/server/backend/tests/test_migration_0015_aigrp_peers_pair_secret_ref.py
+++ b/server/backend/tests/test_migration_0015_aigrp_peers_pair_secret_ref.py
@@ -271,7 +271,7 @@ class TestHeadRevisionAndHistory:
     def test_head_revision_constant_was_bumped(self) -> None:
         from cq_server.migrations import HEAD_REVISION
 
-        assert HEAD_REVISION == "0019_invites"
+        assert HEAD_REVISION == "0020_l2_brand"
 
     def test_alembic_history_includes_0015(self) -> None:
         repo_root = Path(__file__).resolve().parents[1]

--- a/server/backend/tests/test_theme.py
+++ b/server/backend/tests/test_theme.py
@@ -1,0 +1,114 @@
+"""Tests for FO-1d ``GET /api/v1/theme`` (Decision 30).
+
+Covers the resolver's three return shapes:
+
+* No L2 overrides — platform defaults + Enterprise stub + L2 derived
+  from the env-pinned ``CQ_GROUP``.
+* L2 row present — overrides surface in the response.
+* Cache-Control header is set to ``public, max-age=300``.
+
+The endpoint is anonymous; tests do NOT attach an Authorization header.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from cq_server.app import _get_store, app
+
+
+@pytest.fixture
+def client(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "theme.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    monkeypatch.setenv("CQ_ENTERPRISE", "8th-layer-corp")
+    monkeypatch.setenv("CQ_GROUP", "engineering")
+    with TestClient(app) as c:
+        yield c
+
+
+def test_theme_returns_platform_defaults_when_no_l2_overrides(
+    client: TestClient,
+) -> None:
+    """A fresh DB has no ``l2_brand`` row; resolver falls back to env defaults."""
+    resp = client.get("/api/v1/theme")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    # Platform tier — always platform-fixed, never overridable.
+    assert body["platform"]["name"] == "8th-Layer.ai"
+    assert "tokens" in body["platform"]
+    assert body["platform"]["tokens"]["cyan"] == "#5bd0ff"
+
+    # Enterprise tier — V1 stub from CQ_ENTERPRISE env.
+    assert body["enterprise"]["id"] == "8th-layer-corp"
+    assert body["enterprise"]["display_name"] == "8th-layer-corp"
+    assert body["enterprise"]["logo_url"] is None
+    assert body["enterprise"]["accent_hex"] is None
+
+    # L2 tier — fallback to env-pinned CQ_GROUP, no overrides.
+    assert body["l2"]["id"] == "8th-layer-corp/engineering"
+    assert body["l2"]["label"] == "engineering"
+    assert body["l2"]["subaccent_hex"] is None
+    assert body["l2"]["hero_motif"] is None
+
+
+def test_theme_returns_l2_overrides_when_brand_row_present(
+    client: TestClient,
+) -> None:
+    """Inserting a row into ``l2_brand`` surfaces in the response."""
+    store = _get_store()
+    with store._engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO l2_brand (id, l2_label, subaccent_hex, hero_motif, "
+                "updated_at, updated_by) VALUES "
+                "(1, :label, :accent, :motif, :ts, NULL)"
+            ),
+            {
+                "label": "Engineering Org",
+                "accent": "#a685ff",
+                "motif": "gradient.cyan-violet",
+                "ts": "2026-05-10T00:00:00+00:00",
+            },
+        )
+
+    resp = client.get("/api/v1/theme")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["l2"]["label"] == "Engineering Org"
+    assert body["l2"]["subaccent_hex"] == "#a685ff"
+    assert body["l2"]["hero_motif"] == "gradient.cyan-violet"
+
+
+def test_theme_emits_cache_control_header(client: TestClient) -> None:
+    """``Cache-Control: public, max-age=300`` lets browsers revalidate every 5 minutes."""
+    resp = client.get("/api/v1/theme")
+    assert resp.status_code == 200
+    assert resp.headers["cache-control"] == "public, max-age=300"
+
+
+def test_theme_endpoint_is_anonymous(client: TestClient) -> None:
+    """No auth header required — login screen calls this BEFORE auth."""
+    # Explicitly do not attach any Authorization header.
+    resp = client.get("/api/v1/theme")
+    assert resp.status_code == 200
+
+
+def test_theme_visible_at_root_prefix_too(client: TestClient) -> None:
+    """app mounts ``api_router`` at both / and /api/v1; theme reachable at both."""
+    resp_root = client.get("/theme")
+    resp_api = client.get("/api/v1/theme")
+    assert resp_root.status_code == 200
+    assert resp_api.status_code == 200
+    assert resp_root.json() == resp_api.json()

--- a/server/frontend/src/App.tsx
+++ b/server/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { DashboardPage } from "./pages/DashboardPage"
 import { LoginPage } from "./pages/LoginPage"
 import { NetworkPage } from "./pages/NetworkPage"
 import { ReviewPage } from "./pages/ReviewPage"
+import { ThemeProvider } from "./theme"
 
 function AppRoutes() {
   const { isAuthenticated } = useAuth()
@@ -38,9 +39,11 @@ function AppRoutes() {
 export default function App() {
   return (
     <BrowserRouter>
-      <AuthProvider>
-        <AppRoutes />
-      </AuthProvider>
+      <ThemeProvider>
+        <AuthProvider>
+          <AppRoutes />
+        </AuthProvider>
+      </ThemeProvider>
     </BrowserRouter>
   )
 }

--- a/server/frontend/src/api.test.ts
+++ b/server/frontend/src/api.test.ts
@@ -1,27 +1,62 @@
-import { beforeEach, describe, expect, it } from "vitest"
-import { getToken, setToken } from "./api"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { api } from "./api"
 
-const STORAGE_KEY = "cq_auth_token"
+const LEGACY_TOKEN_KEY = "cq_auth_token"
 
-describe("token persistence", () => {
+describe("api auth substrate (FO-1d, post-#199)", () => {
   beforeEach(() => {
-    window.localStorage.clear()
-    setToken(null)
+    localStorage.clear()
   })
 
-  it("persists token to localStorage on setToken", () => {
-    setToken("test-jwt-token")
-    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("test-jwt-token")
+  afterEach(() => {
+    vi.restoreAllMocks()
   })
 
-  it("restores token from localStorage on getToken", () => {
-    window.localStorage.setItem(STORAGE_KEY, "stored-token")
-    expect(getToken()).toBe("stored-token")
+  it("does NOT export setToken / getToken — those are FO-1c-superseded", async () => {
+    // The bearer-in-localStorage path was the XSS leak FO-1c was meant to
+    // close. FO-1d completes the migration: the JS auth surface is the
+    // cq_session HttpOnly cookie. There is no legitimate reason to expose
+    // a getToken/setToken in this module.
+    const mod = await import("./api")
+    expect("setToken" in mod).toBe(false)
+    expect("getToken" in mod).toBe(false)
   })
 
-  it("clears localStorage when token is set to null", () => {
-    window.localStorage.setItem(STORAGE_KEY, "stored-token")
-    setToken(null)
-    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull()
+  it("clears legacy localStorage bearer on module load", async () => {
+    // Simulate a stale token left by a pre-FO-1d session.
+    localStorage.setItem(LEGACY_TOKEN_KEY, "stale-token-from-old-release")
+    // Re-import to retrigger the one-shot cleanup.
+    vi.resetModules()
+    await import("./api")
+    expect(localStorage.getItem(LEGACY_TOKEN_KEY)).toBeNull()
+  })
+
+  it("does NOT attach Authorization header from localStorage", async () => {
+    // Even if something writes to localStorage (a third-party lib, a
+    // future-bug, an XSS injection), no Authorization header should be
+    // attached by the request() wrapper.
+    localStorage.setItem(LEGACY_TOKEN_KEY, "tampered-token")
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ username: "alice", created_at: "x" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    )
+    await api.me()
+    const callArgs = fetchMock.mock.calls[0]
+    const headers = (callArgs[1]?.headers as Record<string, string>) ?? {}
+    expect(headers.Authorization).toBeUndefined()
+  })
+
+  it("attaches credentials: 'include' so the cq_session cookie travels", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ username: "alice", created_at: "x" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    )
+    await api.me()
+    const callArgs = fetchMock.mock.calls[0]
+    expect(callArgs[1]?.credentials).toBe("include")
   })
 })

--- a/server/frontend/src/api.ts
+++ b/server/frontend/src/api.ts
@@ -50,11 +50,19 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
     "Content-Type": "application/json",
     ...(options.headers as Record<string, string>),
   }
+  // FO-1d (#199): when a bearer token is set (e.g. legacy API-key path)
+  // we still attach Authorization. New cookie-bound sessions (FO-1c)
+  // ride on `credentials: "include"` instead — the cq_session cookie
+  // travels with the fetch automatically.
   const currentToken = getToken()
   if (currentToken) {
     headers.Authorization = `Bearer ${currentToken}`
   }
-  const resp = await fetch(`${API_BASE}${path}`, { ...options, headers })
+  const resp = await fetch(`${API_BASE}${path}`, {
+    ...options,
+    headers,
+    credentials: "include",
+  })
   if (!resp.ok) {
     if (resp.status === 401 && onUnauthorized) {
       onUnauthorized()

--- a/server/frontend/src/api.ts
+++ b/server/frontend/src/api.ts
@@ -9,24 +9,17 @@ import type {
 } from "./types"
 
 const API_BASE = "/api/v1"
-const TOKEN_KEY = "cq_auth_token"
+const LEGACY_TOKEN_KEY = "cq_auth_token"
 
-let token: string | null = null
-
-export function setToken(t: string | null) {
-  token = t
-  if (t) {
-    localStorage.setItem(TOKEN_KEY, t)
-  } else {
-    localStorage.removeItem(TOKEN_KEY)
-  }
-}
-
-export function getToken(): string | null {
-  if (!token) {
-    token = localStorage.getItem(TOKEN_KEY)
-  }
-  return token
+/**
+ * One-shot cleanup of pre-FO-1d localStorage bearer (#199, 8l-reviewer HIGH).
+ * Run once at module load so any stale token left by an older session is
+ * cleared. From FO-1d forward the `cq_session` HttpOnly cookie is the only
+ * auth substrate for human users; agent api-keys (`cqa.v1.*`) are sent via
+ * the dedicated CLI and never touch the browser.
+ */
+if (typeof localStorage !== "undefined") {
+  localStorage.removeItem(LEGACY_TOKEN_KEY)
 }
 
 class ApiError extends Error {
@@ -50,14 +43,10 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
     "Content-Type": "application/json",
     ...(options.headers as Record<string, string>),
   }
-  // FO-1d (#199): when a bearer token is set (e.g. legacy API-key path)
-  // we still attach Authorization. New cookie-bound sessions (FO-1c)
-  // ride on `credentials: "include"` instead — the cq_session cookie
-  // travels with the fetch automatically.
-  const currentToken = getToken()
-  if (currentToken) {
-    headers.Authorization = `Bearer ${currentToken}`
-  }
+  // FO-1d (#199): cookie-only auth. The `cq_session` HttpOnly cookie set by
+  // FO-1c travels automatically via `credentials: "include"`. Bearer tokens
+  // in localStorage were the XSS-leak vector FO-1c was meant to close, so
+  // we no longer attach an Authorization header from JS-reachable storage.
   const resp = await fetch(`${API_BASE}${path}`, {
     ...options,
     headers,

--- a/server/frontend/src/auth.test.tsx
+++ b/server/frontend/src/auth.test.tsx
@@ -1,37 +1,43 @@
 import { render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { setToken } from "./api"
 import { AuthProvider, useAuth } from "./auth"
-
-const TOKEN_KEY = "cq_auth_token"
 
 const originalFetch = globalThis.fetch
 
-function mockFetch(response: object, status = 200) {
-  globalThis.fetch = vi.fn().mockResolvedValue({
-    ok: status >= 200 && status < 300,
+interface MockResponse {
+  ok: boolean
+  status: number
+  json: () => Promise<object>
+}
+
+function mockFetch(response: object, status = 200): MockResponse {
+  const ok = status >= 200 && status < 300
+  const r: MockResponse = {
+    ok,
     status,
     json: () => Promise.resolve(response),
-  })
+  }
+  globalThis.fetch = vi.fn().mockResolvedValue(r)
+  return r
 }
 
 function AuthStatus() {
-  const { isAuthenticated, username, loading } = useAuth()
+  const { isAuthenticated, username, loading, role } = useAuth()
   return (
     <div>
       <span data-testid="status">
         {isAuthenticated ? "authenticated" : "unauthenticated"}
       </span>
       <span data-testid="username">{username ?? ""}</span>
+      <span data-testid="role">{role ?? ""}</span>
       <span data-testid="loading">{String(loading)}</span>
     </div>
   )
 }
 
-describe("AuthProvider session restore", () => {
+describe("AuthProvider — cookie-bound session (FO-1c + FO-1d)", () => {
   beforeEach(() => {
     localStorage.clear()
-    setToken(null)
   })
 
   afterEach(() => {
@@ -39,9 +45,8 @@ describe("AuthProvider session restore", () => {
     vi.restoreAllMocks()
   })
 
-  it("restores session from localStorage on mount", async () => {
-    localStorage.setItem(TOKEN_KEY, "valid-jwt")
-    mockFetch({ username: "alice", created_at: "2024-01-01" })
+  it("restores session from /auth/me cookie on mount", async () => {
+    mockFetch({ username: "alice", role: "user", created_at: "2024-01-01" })
 
     render(
       <AuthProvider>
@@ -53,11 +58,16 @@ describe("AuthProvider session restore", () => {
       expect(screen.getByTestId("status")).toHaveTextContent("authenticated")
     })
     expect(screen.getByTestId("username")).toHaveTextContent("alice")
+    expect(screen.getByTestId("role")).toHaveTextContent("user")
+    // /auth/me must be called with credentials so the HttpOnly cookie travels.
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "/api/v1/auth/me",
+      expect.objectContaining({ credentials: "include" }),
+    )
   })
 
-  it("clears invalid token from localStorage on mount", async () => {
-    localStorage.setItem(TOKEN_KEY, "expired-jwt")
-    mockFetch({ detail: "Invalid or expired token" }, 401)
+  it("treats 401 from /auth/me as unauthenticated (no cookie or expired)", async () => {
+    mockFetch({ detail: "Missing or invalid session cookie" }, 401)
 
     render(
       <AuthProvider>
@@ -66,31 +76,15 @@ describe("AuthProvider session restore", () => {
     )
 
     await waitFor(() => {
-      expect(localStorage.getItem(TOKEN_KEY)).toBeNull()
+      expect(screen.getByTestId("loading")).toHaveTextContent("false")
     })
     expect(screen.getByTestId("status")).toHaveTextContent("unauthenticated")
   })
 
-  it("does nothing when no token in localStorage", () => {
-    const fetchSpy = vi.fn()
-    globalThis.fetch = fetchSpy
-
-    render(
-      <AuthProvider>
-        <AuthStatus />
-      </AuthProvider>,
-    )
-
-    expect(screen.getByTestId("status")).toHaveTextContent("unauthenticated")
-    expect(fetchSpy).not.toHaveBeenCalled()
-  })
-
-  it("reports loading while session restore is in-flight", async () => {
-    localStorage.setItem(TOKEN_KEY, "valid-jwt")
-
-    let resolveFetch!: (value: Response) => void
+  it("reports loading while /auth/me is in-flight", async () => {
+    let resolveFetch!: (value: MockResponse) => void
     globalThis.fetch = vi.fn().mockReturnValue(
-      new Promise<Response>((resolve) => {
+      new Promise<MockResponse>((resolve) => {
         resolveFetch = resolve
       }),
     )
@@ -101,34 +95,23 @@ describe("AuthProvider session restore", () => {
       </AuthProvider>,
     )
 
-    // While /auth/me is pending, loading should be true.
     expect(screen.getByTestId("loading")).toHaveTextContent("true")
     expect(screen.getByTestId("status")).toHaveTextContent("unauthenticated")
 
-    // Resolve the fetch.
     resolveFetch({
       ok: true,
       status: 200,
       json: () =>
-        Promise.resolve({ username: "alice", created_at: "2024-01-01" }),
-    } as Response)
+        Promise.resolve({
+          username: "alice",
+          role: "user",
+          created_at: "2024-01-01",
+        }),
+    })
 
     await waitFor(() => {
       expect(screen.getByTestId("loading")).toHaveTextContent("false")
     })
     expect(screen.getByTestId("status")).toHaveTextContent("authenticated")
-  })
-
-  it("is not loading when no stored token exists", () => {
-    const fetchSpy = vi.fn()
-    globalThis.fetch = fetchSpy
-
-    render(
-      <AuthProvider>
-        <AuthStatus />
-      </AuthProvider>,
-    )
-
-    expect(screen.getByTestId("loading")).toHaveTextContent("false")
   })
 })

--- a/server/frontend/src/auth.tsx
+++ b/server/frontend/src/auth.tsx
@@ -1,3 +1,23 @@
+/**
+ * Authentication state for the L2 admin shell (FO-1c + FO-1d).
+ *
+ * Login state is determined by calling `/auth/me` with `credentials:
+ * "include"` so the cq_session cookie (HttpOnly, set by the server on
+ * login) is the source of truth. The legacy bearer-token-in-localStorage
+ * path is retired here — JS no longer holds the JWT, which closes the
+ * XSS-leak vector that motivated FO-1c.
+ *
+ * Two login methods:
+ *   - login(username, password) — legacy fallback; calls POST /auth/login.
+ *     The server responds 200 + sets the cookie; we discard the token in
+ *     the body and treat the cookie as authoritative.
+ *   - loginWithPasskey(username) — FO-1a passkey ceremony via
+ *     ./webauthn.passkeyLogin; same cookie disposition on success.
+ *
+ * useAuth exposes both plus { username, role, isAuthenticated, loading,
+ * logout }.
+ */
+
 import {
   createContext,
   type ReactNode,
@@ -6,54 +26,106 @@ import {
   useEffect,
   useState,
 } from "react"
-import { api, getToken, setOnUnauthorized, setToken } from "./api"
+import { api, setToken } from "./api"
+import { passkeyLogin } from "./webauthn"
+
+interface MeResponse {
+  username: string
+  role?: string
+}
 
 interface AuthState {
   username: string | null
+  role: string | null
   isAuthenticated: boolean
   loading: boolean
   login: (username: string, password: string) => Promise<void>
+  loginWithPasskey: (username: string) => Promise<void>
   logout: () => void
 }
 
 const AuthContext = createContext<AuthState | null>(null)
 
+async function fetchMe(): Promise<MeResponse | null> {
+  // /auth/me uses cookie credentials per FO-1c. 401 → not logged in;
+  // anything else (network error, 5xx) → null with the caller deciding.
+  try {
+    const resp = await fetch("/api/v1/auth/me", {
+      credentials: "include",
+    })
+    if (!resp.ok) return null
+    return await resp.json()
+  } catch {
+    return null
+  }
+}
+
+async function callLogout(): Promise<void> {
+  // Best-effort POST to clear the cookie server-side. Server may not
+  // expose a logout route in V1 — we still clear local state below.
+  try {
+    await fetch("/api/v1/auth/logout", {
+      method: "POST",
+      credentials: "include",
+    })
+  } catch {
+    // ignore
+  }
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [username, setUsername] = useState<string | null>(null)
-  const [loading, setLoading] = useState(() => !!getToken())
+  const [role, setRole] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
 
-  const login = useCallback(async (user: string, pass: string) => {
-    const resp = await api.login(user, pass)
-    setToken(resp.token)
-    setUsername(resp.username)
+  const refresh = useCallback(async () => {
+    const me = await fetchMe()
+    if (me) {
+      setUsername(me.username)
+      setRole(me.role ?? null)
+    } else {
+      setUsername(null)
+      setRole(null)
+    }
   }, [])
+
+  const login = useCallback(
+    async (user: string, pass: string) => {
+      // Legacy password login. The server sets the cookie on success;
+      // we read /auth/me to learn role + canonicalize username.
+      await api.login(user, pass)
+      await refresh()
+    },
+    [refresh],
+  )
+
+  const loginWithPasskey = useCallback(
+    async (user: string) => {
+      await passkeyLogin(user)
+      await refresh()
+    },
+    [refresh],
+  )
 
   const logout = useCallback(() => {
-    setToken(null)
     setUsername(null)
+    setRole(null)
+    // Clear any stray bearer state from the legacy localStorage path.
+    setToken(null)
+    void callLogout()
   }, [])
 
-  // Register 401 handler so any API call that gets 401 triggers logout.
+  // On mount, attempt to read the cookie-bound session.
   useEffect(() => {
-    setOnUnauthorized(logout)
-    return () => setOnUnauthorized(() => {})
-  }, [logout])
-
-  // Restore session from a persisted token on mount.
-  useEffect(() => {
-    const stored = getToken()
-    if (!stored) return
     let cancelled = false
-    api
-      .me()
-      .then(
-        (resp) => {
-          if (!cancelled) setUsername(resp.username)
-        },
-        () => {
-          if (!cancelled) setToken(null)
-        },
-      )
+    fetchMe()
+      .then((me) => {
+        if (cancelled) return
+        if (me) {
+          setUsername(me.username)
+          setRole(me.role ?? null)
+        }
+      })
       .finally(() => {
         if (!cancelled) setLoading(false)
       })
@@ -64,14 +136,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   return (
     <AuthContext.Provider
-      value={{ username, isAuthenticated: !!username, loading, login, logout }}
+      value={{
+        username,
+        role,
+        isAuthenticated: !!username,
+        loading,
+        login,
+        loginWithPasskey,
+        logout,
+      }}
     >
       {children}
     </AuthContext.Provider>
   )
 }
 
-// eslint-disable-next-line react-refresh/only-export-components -- Standard React context pattern: provider + hook exported together.
+// eslint-disable-next-line react-refresh/only-export-components -- standard React context pattern.
 export function useAuth(): AuthState {
   const ctx = useContext(AuthContext)
   if (!ctx) throw new Error("useAuth must be used within AuthProvider")

--- a/server/frontend/src/auth.tsx
+++ b/server/frontend/src/auth.tsx
@@ -26,7 +26,7 @@ import {
   useEffect,
   useState,
 } from "react"
-import { api, setToken } from "./api"
+import { api } from "./api"
 import { passkeyLogin } from "./webauthn"
 
 interface MeResponse {
@@ -110,8 +110,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const logout = useCallback(() => {
     setUsername(null)
     setRole(null)
-    // Clear any stray bearer state from the legacy localStorage path.
-    setToken(null)
     void callLogout()
   }, [])
 

--- a/server/frontend/src/components/FilteredListModal.tsx
+++ b/server/frontend/src/components/FilteredListModal.tsx
@@ -134,7 +134,7 @@ export function FilteredListModal({ filter, onClose, onSelectUnit }: Props) {
               >
                 ∅
               </span>
-              <span className="eyebrow text-[var(--cyan)]">
+              <span className="eyebrow text-[var(--brand-primary)]">
                 No knowledge units found
               </span>
             </div>
@@ -146,7 +146,7 @@ export function FilteredListModal({ filter, onClose, onSelectUnit }: Props) {
                 <button
                   type="button"
                   key={item.knowledge_unit.id}
-                  className="w-full text-left p-3 rounded-lg border border-[var(--rule)] bg-[var(--surface)] hover:border-[var(--cyan)] hover:bg-[var(--surface-hover)] transition-colors"
+                  className="w-full text-left p-3 rounded-lg border border-[var(--rule)] bg-[var(--surface)] hover:border-[var(--brand-primary)] hover:bg-[var(--surface-hover)] transition-colors"
                   onClick={() => onSelectUnit(item.knowledge_unit.id)}
                 >
                   <div className="flex items-center gap-2 mb-1">

--- a/server/frontend/src/components/KnowledgeUnitModal.tsx
+++ b/server/frontend/src/components/KnowledgeUnitModal.tsx
@@ -136,8 +136,10 @@ export function KnowledgeUnitModal({ unitId, onClose }: Props) {
               {item.knowledge_unit.insight.detail}
             </p>
 
-            <div className="border-l-2 rounded-r-lg px-4 py-3 bg-[color-mix(in_srgb,var(--cyan)_8%,transparent)] border-[var(--cyan)]">
-              <span className="eyebrow text-[var(--cyan)]">Action</span>
+            <div className="border-l-2 rounded-r-lg px-4 py-3 bg-[color-mix(in_srgb,var(--brand-primary)_8%,transparent)] border-[var(--brand-primary)]">
+              <span className="eyebrow text-[var(--brand-primary)]">
+                Action
+              </span>
               <p className="text-[var(--ink)] text-sm mt-1.5 leading-relaxed">
                 {item.knowledge_unit.insight.action}
               </p>

--- a/server/frontend/src/components/Layout.tsx
+++ b/server/frontend/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react"
 import { Link, Outlet, useLocation } from "react-router"
 import { api } from "../api"
 import { useAuth } from "../auth"
+import { PoweredBy8thLayer } from "./PoweredBy8thLayer"
 import { Wordmark } from "./Wordmark"
 
 export function Layout() {
@@ -83,6 +84,7 @@ export function Layout() {
       >
         <Outlet context={{ setPendingCount }} />
       </main>
+      <PoweredBy8thLayer />
     </div>
   )
 }

--- a/server/frontend/src/components/Layout.tsx
+++ b/server/frontend/src/components/Layout.tsx
@@ -43,7 +43,7 @@ export function Layout() {
           </span>
         )}
         {active && (
-          <span className="absolute -bottom-px left-0 right-0 h-px bg-gradient-to-r from-transparent via-[var(--cyan)] to-transparent" />
+          <span className="absolute -bottom-px left-0 right-0 h-px bg-gradient-to-r from-transparent via-[var(--brand-primary)] to-transparent" />
         )}
       </Link>
     )

--- a/server/frontend/src/components/PoweredBy8thLayer.tsx
+++ b/server/frontend/src/components/PoweredBy8thLayer.tsx
@@ -1,0 +1,27 @@
+/**
+ * "Powered by 8th-Layer.ai" co-branding badge (FO-1d, Decision 30).
+ *
+ * Visible on every page in the L2 admin shell. Decision 30
+ * §"co-branding rule" makes this badge non-overridable — it links to
+ * the platform marketing site and uses platform tokens directly so a
+ * customer brand override cannot suppress it.
+ *
+ * V1 ships this as a small text link in the layout footer; later tiers
+ * (FO-7 white-label) may relax the visibility rule but the V1 default
+ * is "always present, always dim, always platform-coloured."
+ */
+
+export function PoweredBy8thLayer() {
+  return (
+    <footer className="mt-12 mb-8 px-4 text-center">
+      <a
+        href="https://8th-layer.ai"
+        target="_blank"
+        rel="noreferrer noopener"
+        className="font-mono-brand text-[10px] uppercase tracking-[0.22em] text-[var(--ink-faint)] hover:text-[var(--ink-mute)] transition-colors"
+      >
+        Powered by 8th-Layer.ai
+      </a>
+    </footer>
+  )
+}

--- a/server/frontend/src/components/ReviewCard.tsx
+++ b/server/frontend/src/components/ReviewCard.tsx
@@ -27,7 +27,7 @@ const CARD_STYLES: Record<string, string> = {
 
 const ACTION_BOX_STYLES: Record<string, string> = {
   neutral:
-    "bg-[color-mix(in_srgb,var(--cyan)_8%,transparent)] border-[var(--cyan)] text-[var(--cyan)]",
+    "bg-[color-mix(in_srgb,var(--brand-primary)_8%,transparent)] border-[var(--brand-primary)] text-[var(--brand-primary)]",
   approve:
     "bg-[color-mix(in_srgb,var(--emerald)_10%,transparent)] border-[var(--emerald)] text-[var(--emerald)]",
   reject:

--- a/server/frontend/src/components/Wordmark.tsx
+++ b/server/frontend/src/components/Wordmark.tsx
@@ -1,11 +1,21 @@
 /**
- * Placeholder 8th-Layer.ai wordmark.
+ * Three-tier brand wordmark (FO-1d, Decision 30).
  *
- * The final logo is still in concepting (see crosstalk-enterprise/docs/brand/
- * logo-concepts-2026-05-08.md). Until then we ship a typographic mark in
- * Fraunces — the "8" sits in the display face, "L" in mono — as a visually
- * distinctive, license-free placeholder. Fully replaceable when an SVG lands.
+ * Renders horizontally as `<Enterprise> · <L2-label> · 8th-Layer.ai`. The
+ * Enterprise display name takes the primary visual weight (Fraunces);
+ * the L2 label sits as a secondary mono-tagged segment; the platform
+ * mark is rendered small + dim as the always-visible co-branding badge.
+ *
+ * Pre-theme-load fallback: if the theme context hasn't resolved yet (or
+ * the API call failed), we render the platform-only mark — preserves
+ * the original placeholder visuals so the topbar never goes blank.
+ *
+ * The 8th-Layer mark itself uses platform tokens (`--ink`, `--ink-dim`)
+ * directly — it's the platform identity and never re-tints under
+ * customer brand overrides.
  */
+
+import { useTheme } from "../theme"
 
 interface Props {
   size?: "sm" | "md" | "lg"
@@ -13,13 +23,21 @@ interface Props {
 }
 
 const SIZES = {
-  sm: { mark: "text-base", word: "text-xs" },
-  md: { mark: "text-2xl", word: "text-sm" },
-  lg: { mark: "text-5xl", word: "text-base" },
+  sm: { mark: "text-base", word: "text-xs", enterprise: "text-sm" },
+  md: { mark: "text-2xl", word: "text-sm", enterprise: "text-lg" },
+  lg: { mark: "text-5xl", word: "text-base", enterprise: "text-2xl" },
 } as const
 
-export function Wordmark({ size = "md", variant = "full" }: Props) {
-  const s = SIZES[size]
+function PlatformMark({
+  size,
+  variant = "full",
+  dim = false,
+}: {
+  size: Props["size"]
+  variant?: Props["variant"]
+  dim?: boolean
+}) {
+  const s = SIZES[size ?? "md"]
   return (
     <span
       role="img"
@@ -28,7 +46,7 @@ export function Wordmark({ size = "md", variant = "full" }: Props) {
     >
       <span
         aria-hidden="true"
-        className={`font-display ${s.mark} text-[var(--ink)] leading-none`}
+        className={`font-display ${s.mark} ${dim ? "text-[var(--ink-dim)]" : "text-[var(--ink)]"} leading-none`}
         style={{
           fontVariantNumeric: "tabular-nums",
           fontWeight: 200,
@@ -39,10 +57,61 @@ export function Wordmark({ size = "md", variant = "full" }: Props) {
       </span>
       <span
         aria-hidden="true"
-        className={`font-mono-brand ${s.word} text-[var(--ink-dim)] uppercase tracking-[0.22em]`}
+        className={`font-mono-brand ${s.word} ${dim ? "text-[var(--ink-faint)]" : "text-[var(--ink-dim)]"} uppercase tracking-[0.22em]`}
       >
         {variant === "compact" ? "L8" : "8TH·LAYER"}
       </span>
+    </span>
+  )
+}
+
+export function Wordmark({ size = "md", variant = "full" }: Props) {
+  const { theme } = useTheme()
+  const s = SIZES[size]
+
+  // Theme not yet loaded (or failed) → fall back to the platform-only
+  // mark. Keeps the placeholder identity visible during the brief
+  // window before /api/v1/theme resolves.
+  if (!theme) {
+    return <PlatformMark size={size} variant={variant} />
+  }
+
+  const enterprise = theme.enterprise.display_name
+  const l2 = theme.l2.label
+
+  return (
+    <span
+      role="img"
+      aria-label={`${enterprise} · ${l2} · 8th-Layer.ai`}
+      className="inline-flex items-center gap-3 select-none"
+    >
+      {/* Tier 2 — Enterprise display name (primary). Fraunces, full ink. */}
+      <span
+        className={`font-display ${s.enterprise} text-[var(--ink)] leading-none`}
+        style={{ fontWeight: 300, letterSpacing: "-0.01em" }}
+      >
+        {enterprise}
+      </span>
+      {/* Tier 3 — L2 label (secondary). Mono, dim, tracked uppercase. */}
+      <span
+        aria-hidden="true"
+        className="font-mono-brand text-[10px] text-[var(--ink-faint)]"
+      >
+        ·
+      </span>
+      <span
+        className={`font-mono-brand ${s.word} text-[var(--ink-mute)] uppercase tracking-[0.18em]`}
+      >
+        {l2}
+      </span>
+      {/* Tier 1 — platform co-branding mark. Always present, always dim. */}
+      <span
+        aria-hidden="true"
+        className="font-mono-brand text-[10px] text-[var(--ink-faint)]"
+      >
+        ·
+      </span>
+      <PlatformMark size="sm" variant="compact" dim />
     </span>
   )
 }

--- a/server/frontend/src/index.css
+++ b/server/frontend/src/index.css
@@ -8,6 +8,23 @@
  *
  * License-wise this is a derivative of the mainline cq frontend (Apache-2.0).
  * See ../../../NOTICE and FORK_DELTA.md.
+ *
+ * ── Brand indirection (FO-1d, Decision 30) ──────────────────────────────
+ * Two layers of tokens:
+ *
+ *   PLATFORM tokens (--cyan, --violet, --gold, ...)  — the 8th-Layer.ai
+ *     palette. Stable; only changed when the platform brand itself changes.
+ *
+ *   BRAND tokens (--brand-primary, --brand-secondary) — DEFAULT to the
+ *     platform cyan/violet but can be overridden at runtime by the
+ *     ThemeProvider (which reads /api/v1/theme and sets the property on
+ *     :root). Components that represent BRAND surfaces (CTA buttons,
+ *     focus rings, hover accents) reference --brand-primary so per-
+ *     Enterprise / per-L2 overrides take effect without a recompile.
+ *
+ * Components that encode the 8th-Layer mark itself (Wordmark glyph base
+ * color, AAISN topology mark) keep referencing platform tokens directly
+ * — the platform mark is co-branded, not customer-rebrandable.
  */
 
 @import "tailwindcss";
@@ -32,6 +49,11 @@
   --emerald: #10b981;
   --gold: #fcd34d;
   --rose: #ff5c7c;
+
+  /* Brand indirection — default to platform palette; overridable at
+     runtime via ThemeProvider for per-Enterprise / per-L2 chrome. */
+  --brand-primary: var(--cyan);
+  --brand-secondary: var(--violet);
 
   --surface: rgba(255, 255, 255, 0.025);
   --surface-raised: rgba(255, 255, 255, 0.04);
@@ -70,6 +92,12 @@
   --gold: #f59e0b;
   --rose: #dc2626;
 
+  /* Brand indirection — mainline-cq stays platform-fixed (Decision 30
+     §"upstream-compatible fallback"); ThemeProvider only overrides
+     these under data-theme="8th-layer". */
+  --brand-primary: var(--cyan);
+  --brand-secondary: var(--violet);
+
   --surface: #ffffff;
   --surface-raised: #ffffff;
   --surface-hover: #f3f4f6;
@@ -97,6 +125,8 @@
   --emerald: #10b981;
   --gold: #fcd34d;
   --rose: #ff5c7c;
+  --brand-primary: var(--cyan);
+  --brand-secondary: var(--violet);
   --surface: rgba(255, 255, 255, 0.025);
   --surface-raised: rgba(255, 255, 255, 0.04);
   --surface-hover: rgba(255, 255, 255, 0.06);
@@ -180,8 +210,9 @@ body {
     border-color 150ms ease,
     box-shadow 150ms ease;
   &:focus {
-    border-color: var(--cyan);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--cyan) 25%, transparent);
+    border-color: var(--brand-primary);
+    box-shadow: 0 0 0 3px
+      color-mix(in srgb, var(--brand-primary) 25%, transparent);
   }
 }
 

--- a/server/frontend/src/network/useTopologyPoll.ts
+++ b/server/frontend/src/network/useTopologyPoll.ts
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from "react"
-import { getToken } from "../api"
 import { topologyFixture } from "./fixtures/topology.fixture"
 import type { TopologyResponse } from "./types"
 
@@ -21,14 +20,12 @@ export interface UseTopologyPollOptions {
 const DEFAULT_INTERVAL_MS = 5000
 
 async function defaultFetcher(): Promise<TopologyResponse> {
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-  }
-  const token = getToken()
-  if (token) {
-    headers.Authorization = `Bearer ${token}`
-  }
-  const resp = await fetch("/api/v1/network/topology", { headers })
+  // FO-1d (#199, 8l-reviewer HIGH): cookie-only auth. The cq_session cookie
+  // travels via `credentials: "include"` — no Authorization header from JS.
+  const resp = await fetch("/api/v1/network/topology", {
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+  })
   if (!resp.ok) {
     throw new Error(`HTTP ${resp.status}`)
   }

--- a/server/frontend/src/pages/ApiKeysPage.tsx
+++ b/server/frontend/src/pages/ApiKeysPage.tsx
@@ -192,10 +192,12 @@ export function ApiKeysPage() {
     setCopied(true)
   }
 
-  // Brand button styles. A primary cyan-tinted CTA, a destructive rose CTA,
-  // and a subtle ghost button that maps to the dark surface tokens.
+  // Brand button styles. A primary brand-tinted CTA, a destructive rose CTA,
+  // and a subtle ghost button that maps to the dark surface tokens. The
+  // primary CTA references --brand-primary so per-Enterprise theme
+  // overrides re-tint without code changes (Decision 30).
   const primaryBtn =
-    "rounded-md bg-[color-mix(in_srgb,var(--cyan)_18%,transparent)] border border-[color-mix(in_srgb,var(--cyan)_45%,transparent)] px-4 py-2 font-mono-brand text-[11px] uppercase tracking-[0.2em] text-[var(--cyan)] hover:bg-[color-mix(in_srgb,var(--cyan)_28%,transparent)] disabled:opacity-50 transition-all"
+    "rounded-md bg-[color-mix(in_srgb,var(--brand-primary)_18%,transparent)] border border-[color-mix(in_srgb,var(--brand-primary)_45%,transparent)] px-4 py-2 font-mono-brand text-[11px] uppercase tracking-[0.2em] text-[var(--brand-primary)] hover:bg-[color-mix(in_srgb,var(--brand-primary)_28%,transparent)] disabled:opacity-50 transition-all"
   const destructiveBtn =
     "rounded-md bg-[color-mix(in_srgb,var(--rose)_18%,transparent)] border border-[color-mix(in_srgb,var(--rose)_45%,transparent)] px-4 py-2 font-mono-brand text-[11px] uppercase tracking-[0.2em] text-[var(--rose)] hover:bg-[color-mix(in_srgb,var(--rose)_28%,transparent)] disabled:opacity-50 transition-all"
   const ghostBtn =
@@ -319,7 +321,7 @@ export function ApiKeysPage() {
                 aria-pressed={filter === value}
                 className={`px-3 py-1.5 font-mono-brand text-[11px] uppercase tracking-[0.16em] transition-colors ${
                   filter === value
-                    ? "bg-[color-mix(in_srgb,var(--cyan)_22%,transparent)] text-[var(--cyan)]"
+                    ? "bg-[color-mix(in_srgb,var(--brand-primary)_22%,transparent)] text-[var(--brand-primary)]"
                     : "text-[var(--ink-dim)] hover:bg-[var(--surface-hover)]"
                 }`}
               >
@@ -346,7 +348,9 @@ export function ApiKeysPage() {
             >
               ∅
             </span>
-            <span className="eyebrow text-[var(--cyan)]">No API keys yet</span>
+            <span className="eyebrow text-[var(--brand-primary)]">
+              No API keys yet
+            </span>
             <span className="text-sm text-[var(--ink-mute)]">
               Mint one above to give an agent access.
             </span>
@@ -516,7 +520,7 @@ export function ApiKeysPage() {
               Copy this token now. It will not be shown again.
             </p>
             <div className="mt-4 flex items-center gap-2 rounded-lg bg-[var(--bg-via)] border border-[var(--rule-strong)] p-3">
-              <code className="flex-1 break-all font-mono-brand text-sm text-[var(--cyan)]">
+              <code className="flex-1 break-all font-mono-brand text-sm text-[var(--brand-primary)]">
                 {createdKey.token}
               </code>
               <button type="button" onClick={copyToken} className={primaryBtn}>
@@ -528,7 +532,7 @@ export function ApiKeysPage() {
                 type="checkbox"
                 checked={acknowledged}
                 onChange={(e) => setAcknowledged(e.target.checked)}
-                className="accent-[var(--cyan)]"
+                className="accent-[var(--brand-primary)]"
               />
               I have copied this token and saved it securely.
             </label>

--- a/server/frontend/src/pages/DashboardPage.tsx
+++ b/server/frontend/src/pages/DashboardPage.tsx
@@ -44,7 +44,7 @@ function EmptyGlyph({ label }: { label: string }) {
       >
         ∅
       </span>
-      <span className="eyebrow text-[var(--cyan)]">{label}</span>
+      <span className="eyebrow text-[var(--brand-primary)]">{label}</span>
     </div>
   )
 }
@@ -173,7 +173,7 @@ export function DashboardPage() {
                           </span>
                           <div className="flex-1 h-1 bg-[var(--rule)] rounded-full overflow-hidden">
                             <div
-                              className="h-full bg-gradient-to-r from-[var(--violet)] to-[var(--cyan)] rounded-full"
+                              className="h-full bg-gradient-to-r from-[var(--brand-secondary)] to-[var(--brand-primary)] rounded-full"
                               style={{ width: `${(count / maxCount) * 100}%` }}
                             />
                           </div>

--- a/server/frontend/src/pages/LoginPage.tsx
+++ b/server/frontend/src/pages/LoginPage.tsx
@@ -63,7 +63,7 @@ export function LoginPage() {
           <button
             type="submit"
             disabled={loading}
-            className="w-full rounded-md bg-[color-mix(in_srgb,var(--cyan)_18%,transparent)] border border-[color-mix(in_srgb,var(--cyan)_45%,transparent)] py-2.5 font-mono-brand text-[11px] uppercase tracking-[0.22em] text-[var(--cyan)] hover:bg-[color-mix(in_srgb,var(--cyan)_28%,transparent)] disabled:opacity-50 transition-all"
+            className="w-full rounded-md bg-[color-mix(in_srgb,var(--brand-primary)_18%,transparent)] border border-[color-mix(in_srgb,var(--brand-primary)_45%,transparent)] py-2.5 font-mono-brand text-[11px] uppercase tracking-[0.22em] text-[var(--brand-primary)] hover:bg-[color-mix(in_srgb,var(--brand-primary)_28%,transparent)] disabled:opacity-50 transition-all"
           >
             {loading ? "Signing in…" : "Sign in"}
           </button>

--- a/server/frontend/src/pages/LoginPage.tsx
+++ b/server/frontend/src/pages/LoginPage.tsx
@@ -1,77 +1,175 @@
+/**
+ * LoginPage — passkey-first login UI for the L2 admin shell (FO-1d, #199).
+ *
+ * Two paths in the same screen (Decision 30 §"Auth UI surfaces"):
+ *
+ *   1. Primary CTA — "Sign in with passkey" — calls
+ *      /api/v1/auth/passkey/login/begin + WebAuthn ceremony +
+ *      /api/v1/auth/passkey/login/finish via the auth context's
+ *      `loginWithPasskey`.
+ *   2. Secondary fallback — username + password legacy form.
+ *
+ * Cookie-bound session (FO-1c): both paths set the cq_session cookie
+ * server-side; the browser keeps it; this page never stores a JWT in
+ * localStorage. After success we read user.role from /auth/me (via
+ * useAuth's restore) and redirect: enterprise_admin / l2_admin → /admin,
+ * everyone else → /.
+ *
+ * The screen consumes the theme context so the Enterprise + L2 brand
+ * land before auth — Decision 30's "first-impression contract".
+ */
+
 import { type FormEvent, useState } from "react"
+import { useNavigate } from "react-router"
 import { useAuth } from "../auth"
+import { PoweredBy8thLayer } from "../components/PoweredBy8thLayer"
 import { Wordmark } from "../components/Wordmark"
+import { useTheme } from "../theme"
 
 export function LoginPage() {
-  const { login } = useAuth()
+  const { login, loginWithPasskey } = useAuth()
+  const { theme } = useTheme()
+  const navigate = useNavigate()
   const [username, setUsername] = useState("")
   const [password, setPassword] = useState("")
   const [error, setError] = useState<string | null>(null)
-  const [loading, setLoading] = useState(false)
+  const [passkeyLoading, setPasskeyLoading] = useState(false)
+  const [passwordLoading, setPasswordLoading] = useState(false)
 
-  async function handleSubmit(e: FormEvent) {
-    e.preventDefault()
+  function landingForRole(role: string | null): string {
+    if (role === "enterprise_admin" || role === "l2_admin") return "/admin"
+    return "/"
+  }
+
+  async function handlePasskey() {
+    if (!username) {
+      setError("Enter your username to use a passkey.")
+      return
+    }
     setError(null)
-    setLoading(true)
+    setPasskeyLoading(true)
     try {
-      await login(username, password)
-    } catch {
-      setError("Invalid credentials")
+      await loginWithPasskey(username)
+      // useAuth.refresh() has already run; consult /auth/me result via
+      // a fresh GET to read role for routing. Using fetch directly
+      // avoids racing the AuthProvider's useEffect.
+      const meResp = await fetch("/api/v1/auth/me", { credentials: "include" })
+      const me = meResp.ok ? await meResp.json() : null
+      navigate(landingForRole(me?.role ?? null))
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Passkey sign-in failed. Try password instead.",
+      )
     } finally {
-      setLoading(false)
+      setPasskeyLoading(false)
     }
   }
 
+  async function handlePassword(e: FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setPasswordLoading(true)
+    try {
+      await login(username, password)
+      const meResp = await fetch("/api/v1/auth/me", { credentials: "include" })
+      const me = meResp.ok ? await meResp.json() : null
+      navigate(landingForRole(me?.role ?? null))
+    } catch {
+      setError("Invalid credentials")
+    } finally {
+      setPasswordLoading(false)
+    }
+  }
+
+  const enterpriseName = theme?.enterprise.display_name
+  const l2Label = theme?.l2.label
+
   return (
-    <div className="min-h-screen flex items-center justify-center px-4">
-      <div className="w-full max-w-sm">
-        <div className="flex flex-col items-center gap-6 mb-8">
+    <div className="min-h-screen flex flex-col items-center justify-between px-4 py-10">
+      <div className="w-full max-w-sm flex-1 flex flex-col justify-center">
+        <div className="flex flex-col items-center gap-4 mb-8">
           <Wordmark size="lg" />
-          <p className="eyebrow">Layer 8 · Admin Console</p>
+          {(enterpriseName || l2Label) && (
+            <p className="eyebrow text-center">
+              {enterpriseName ?? "—"}
+              {l2Label ? ` · ${l2Label}` : ""}
+            </p>
+          )}
         </div>
-        <form
-          onSubmit={handleSubmit}
-          className="brand-surface-raised p-7 backdrop-blur-sm shadow-[0_24px_60px_-24px_rgba(0,0,0,0.6)]"
-        >
+
+        <div className="brand-surface-raised p-7 backdrop-blur-sm shadow-[0_24px_60px_-24px_rgba(0,0,0,0.6)]">
           {error && (
             <p className="mb-4 rounded-md border border-[color-mix(in_srgb,var(--rose)_40%,transparent)] bg-[color-mix(in_srgb,var(--rose)_8%,transparent)] px-3 py-2 text-center text-sm text-[var(--rose)]">
               {error}
             </p>
           )}
+
+          {/* Username — shared between passkey and password paths. */}
           <label className="block mb-4">
             <span className="eyebrow block mb-1.5">Username</span>
             <input
               type="text"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
-              autoComplete="username"
+              autoComplete="username webauthn"
               className="brand-input w-full"
               required
             />
           </label>
-          <label className="block mb-7">
-            <span className="eyebrow block mb-1.5">Password</span>
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              autoComplete="current-password"
-              className="brand-input w-full"
-              required
-            />
-          </label>
+
+          {/* Primary CTA — passkey. Always rendered first per Decision 30. */}
           <button
-            type="submit"
-            disabled={loading}
-            className="w-full rounded-md bg-[color-mix(in_srgb,var(--brand-primary)_18%,transparent)] border border-[color-mix(in_srgb,var(--brand-primary)_45%,transparent)] py-2.5 font-mono-brand text-[11px] uppercase tracking-[0.22em] text-[var(--brand-primary)] hover:bg-[color-mix(in_srgb,var(--brand-primary)_28%,transparent)] disabled:opacity-50 transition-all"
+            type="button"
+            onClick={handlePasskey}
+            disabled={passkeyLoading || passwordLoading || !username}
+            className="w-full rounded-md bg-[color-mix(in_srgb,var(--brand-primary)_22%,transparent)] border border-[color-mix(in_srgb,var(--brand-primary)_55%,transparent)] py-2.5 font-mono-brand text-[11px] uppercase tracking-[0.22em] text-[var(--brand-primary)] hover:bg-[color-mix(in_srgb,var(--brand-primary)_32%,transparent)] disabled:opacity-50 transition-all"
           >
-            {loading ? "Signing in…" : "Sign in"}
+            {passkeyLoading ? "Awaiting passkey…" : "Sign in with passkey"}
           </button>
-        </form>
-        <p className="mt-6 text-center font-mono-brand text-[10px] uppercase tracking-[0.2em] text-[var(--ink-faint)]">
-          8th-layer.ai · semantic knowledge layer
-        </p>
+
+          {/* OR separator */}
+          <div className="my-5 flex items-center gap-3">
+            <span className="flex-1 h-px bg-[var(--rule)]" />
+            <span className="font-mono-brand text-[10px] uppercase tracking-[0.22em] text-[var(--ink-faint)]">
+              or
+            </span>
+            <span className="flex-1 h-px bg-[var(--rule)]" />
+          </div>
+
+          {/* Legacy password fallback. */}
+          <form onSubmit={handlePassword}>
+            <label className="block mb-4">
+              <span className="eyebrow block mb-1.5">Password</span>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                autoComplete="current-password"
+                className="brand-input w-full"
+              />
+            </label>
+            <button
+              type="submit"
+              disabled={
+                passwordLoading || passkeyLoading || !username || !password
+              }
+              className="w-full rounded-md border border-[var(--rule-strong)] bg-[var(--surface)] py-2 font-mono-brand text-[11px] uppercase tracking-[0.22em] text-[var(--ink-dim)] hover:bg-[var(--surface-hover)] disabled:opacity-50 transition-all"
+            >
+              {passwordLoading ? "Signing in…" : "Sign in with password"}
+            </button>
+          </form>
+
+          <p className="mt-6 text-center text-xs text-[var(--ink-mute)] leading-relaxed">
+            Don't have an account?
+            <br />
+            Ask your admin for an invite.
+          </p>
+        </div>
       </div>
+
+      <PoweredBy8thLayer />
     </div>
   )
 }

--- a/server/frontend/src/pages/ReviewPage.tsx
+++ b/server/frontend/src/pages/ReviewPage.tsx
@@ -152,7 +152,7 @@ export function ReviewPage() {
   if (loading) {
     return (
       <div className="flex justify-center mt-16">
-        <div className="h-8 w-8 animate-spin rounded-full border-2 border-[var(--cyan)] border-t-transparent" />
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-[var(--brand-primary)] border-t-transparent" />
       </div>
     )
   }
@@ -162,7 +162,7 @@ export function ReviewPage() {
     const hasSkipped = skippedIds.current.size > 0
     return (
       <div className="max-w-xl mx-auto brand-surface-raised p-10 text-center mt-8 backdrop-blur-sm">
-        <div className="text-5xl mb-3 text-[var(--cyan)] font-display font-light">
+        <div className="text-5xl mb-3 text-[var(--brand-primary)] font-display font-light">
           {hasSkipped ? "\u21b7" : "\u2713"}
         </div>
         <p className="eyebrow mb-2">Review queue</p>
@@ -198,14 +198,14 @@ export function ReviewPage() {
               skippedIds.current.clear()
               fetchNext()
             }}
-            className="inline-block mt-5 font-mono-brand text-[11px] uppercase tracking-[0.2em] text-[var(--cyan)] hover:text-[var(--ink)] transition-colors"
+            className="inline-block mt-5 font-mono-brand text-[11px] uppercase tracking-[0.2em] text-[var(--brand-primary)] hover:text-[var(--ink)] transition-colors"
           >
             Review skipped items
           </button>
         )}
         <Link
           to="/dashboard"
-          className="inline-block mt-5 font-mono-brand text-[11px] uppercase tracking-[0.2em] text-[var(--cyan)] hover:text-[var(--ink)] ml-4 transition-colors"
+          className="inline-block mt-5 font-mono-brand text-[11px] uppercase tracking-[0.2em] text-[var(--brand-primary)] hover:text-[var(--ink)] ml-4 transition-colors"
         >
           View dashboard \u2192
         </Link>

--- a/server/frontend/src/theme/ThemeProvider.test.tsx
+++ b/server/frontend/src/theme/ThemeProvider.test.tsx
@@ -94,6 +94,38 @@ describe("ThemeProvider", () => {
     ).toBe("#0088ff")
   })
 
+  it("rejects malformed hex values (FO-1d 8l-reviewer MEDIUM 1)", async () => {
+    document.documentElement.setAttribute("data-theme", "8th-layer")
+    const malformed = {
+      ...OVERRIDE_FIXTURE,
+      enterprise: {
+        ...OVERRIDE_FIXTURE.enterprise,
+        accent_hex: "red; background: url(http://attacker)",
+      },
+      l2: {
+        ...OVERRIDE_FIXTURE.l2,
+        subaccent_hex: "not-a-hex",
+      },
+    }
+    const fetcher = vi.fn().mockResolvedValue(malformed)
+    render(
+      <ThemeProvider fetcher={fetcher}>
+        <ThemeReadout />
+      </ThemeProvider>,
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId("loading").textContent).toBe("false")
+    })
+    // Both --brand-primary and --brand-secondary should remain unset
+    // (CSS file defaults) because the values failed the hex regex.
+    expect(
+      document.documentElement.style.getPropertyValue("--brand-primary"),
+    ).toBe("")
+    expect(
+      document.documentElement.style.getPropertyValue("--brand-secondary"),
+    ).toBe("")
+  })
+
   it("does NOT touch CSS overrides under data-theme=mainline-cq", async () => {
     document.documentElement.setAttribute("data-theme", "mainline-cq")
     const fetcher = vi.fn().mockResolvedValue(OVERRIDE_FIXTURE)

--- a/server/frontend/src/theme/ThemeProvider.test.tsx
+++ b/server/frontend/src/theme/ThemeProvider.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { ThemeProvider, useTheme } from "./ThemeProvider"
+import type { ResolvedTheme } from "./types"
+
+const PLATFORM_FIXTURE: ResolvedTheme = {
+  platform: {
+    name: "8th-Layer.ai",
+    version: "1.0.0",
+    tokens: { cyan: "#5bd0ff", violet: "#a685ff" },
+  },
+  enterprise: {
+    id: "8th-layer-corp",
+    display_name: "8th-layer-corp",
+    logo_url: null,
+    accent_hex: null,
+    dark_mode_only: true,
+  },
+  l2: {
+    id: "8th-layer-corp/engineering",
+    label: "engineering",
+    subaccent_hex: null,
+    hero_motif: null,
+  },
+}
+
+const OVERRIDE_FIXTURE: ResolvedTheme = {
+  ...PLATFORM_FIXTURE,
+  enterprise: {
+    ...PLATFORM_FIXTURE.enterprise,
+    accent_hex: "#ff8800",
+  },
+  l2: {
+    ...PLATFORM_FIXTURE.l2,
+    subaccent_hex: "#0088ff",
+  },
+}
+
+function ThemeReadout() {
+  const { theme, loading, error } = useTheme()
+  return (
+    <div>
+      <span data-testid="loading">{String(loading)}</span>
+      <span data-testid="error">{error ? error.message : ""}</span>
+      <span data-testid="enterprise">
+        {theme ? theme.enterprise.id : "no-theme"}
+      </span>
+    </div>
+  )
+}
+
+describe("ThemeProvider", () => {
+  beforeEach(() => {
+    document.documentElement.setAttribute("data-theme", "8th-layer")
+    document.documentElement.style.removeProperty("--brand-primary")
+    document.documentElement.style.removeProperty("--brand-secondary")
+  })
+
+  afterEach(() => {
+    document.documentElement.removeAttribute("data-theme")
+  })
+
+  it("fetches the theme on mount and exposes it via context", async () => {
+    const fetcher = vi.fn().mockResolvedValue(PLATFORM_FIXTURE)
+    render(
+      <ThemeProvider fetcher={fetcher}>
+        <ThemeReadout />
+      </ThemeProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading").textContent).toBe("false")
+    })
+    expect(fetcher).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId("enterprise").textContent).toBe("8th-layer-corp")
+  })
+
+  it("applies brand override CSS custom properties when set", async () => {
+    const fetcher = vi.fn().mockResolvedValue(OVERRIDE_FIXTURE)
+    render(
+      <ThemeProvider fetcher={fetcher}>
+        <ThemeReadout />
+      </ThemeProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading").textContent).toBe("false")
+    })
+    expect(
+      document.documentElement.style.getPropertyValue("--brand-primary"),
+    ).toBe("#ff8800")
+    expect(
+      document.documentElement.style.getPropertyValue("--brand-secondary"),
+    ).toBe("#0088ff")
+  })
+
+  it("does NOT touch CSS overrides under data-theme=mainline-cq", async () => {
+    document.documentElement.setAttribute("data-theme", "mainline-cq")
+    const fetcher = vi.fn().mockResolvedValue(OVERRIDE_FIXTURE)
+    render(
+      <ThemeProvider fetcher={fetcher}>
+        <ThemeReadout />
+      </ThemeProvider>,
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId("loading").textContent).toBe("false")
+    })
+    expect(
+      document.documentElement.style.getPropertyValue("--brand-primary"),
+    ).toBe("")
+  })
+
+  it("falls back gracefully on fetch failure", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const fetcher = vi.fn().mockRejectedValue(new Error("boom"))
+    render(
+      <ThemeProvider fetcher={fetcher}>
+        <ThemeReadout />
+      </ThemeProvider>,
+    )
+    await waitFor(() => {
+      expect(screen.getByTestId("loading").textContent).toBe("false")
+    })
+    expect(screen.getByTestId("error").textContent).toBe("boom")
+    expect(screen.getByTestId("enterprise").textContent).toBe("no-theme")
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it("uses initialTheme when supplied (test seam, no fetch)", () => {
+    const fetcher = vi.fn()
+    render(
+      <ThemeProvider initialTheme={PLATFORM_FIXTURE} fetcher={fetcher}>
+        <ThemeReadout />
+      </ThemeProvider>,
+    )
+    expect(fetcher).not.toHaveBeenCalled()
+    expect(screen.getByTestId("loading").textContent).toBe("false")
+    expect(screen.getByTestId("enterprise").textContent).toBe("8th-layer-corp")
+  })
+})

--- a/server/frontend/src/theme/ThemeProvider.tsx
+++ b/server/frontend/src/theme/ThemeProvider.tsx
@@ -35,6 +35,16 @@ interface ThemeState {
 
 const ThemeContext = createContext<ThemeState | null>(null)
 
+// Strict 6-digit hex shape — defense in depth. The backend resolver +
+// migration 0020 CHECK constraint also validate (8l-reviewer MEDIUM 1
+// on PR #219). Anything that fails this check stays at the CSS default.
+const HEX_RE = /^#[0-9a-fA-F]{6}$/
+
+function safeHex(value: unknown): string | null {
+  if (typeof value !== "string") return null
+  return HEX_RE.test(value) ? value : null
+}
+
 /**
  * Apply the resolved theme's brand overrides as CSS custom properties on
  * `document.documentElement`. Only run under `data-theme="8th-layer"` per
@@ -48,15 +58,17 @@ function applyBrandOverrides(theme: ResolvedTheme): void {
   // customer-specific brand overrides.
   if (root.getAttribute("data-theme") !== "8th-layer") return
 
-  if (theme.enterprise.accent_hex) {
-    root.style.setProperty("--brand-primary", theme.enterprise.accent_hex)
+  const enterpriseAccent = safeHex(theme.enterprise.accent_hex)
+  const l2Subaccent = safeHex(theme.l2.subaccent_hex)
+
+  if (enterpriseAccent) {
+    root.style.setProperty("--brand-primary", enterpriseAccent)
   }
   // Sub-accent precedence: explicit L2 sub-accent wins; otherwise the
   // Enterprise accent gets used as the secondary too (matches Decision
   // 30's CSS example: `--brand-secondary: var(--l2-subaccent,
   // --enterprise-accent)`).
-  const secondary =
-    theme.l2.subaccent_hex || theme.enterprise.accent_hex || null
+  const secondary = l2Subaccent || enterpriseAccent
   if (secondary) {
     root.style.setProperty("--brand-secondary", secondary)
   }

--- a/server/frontend/src/theme/ThemeProvider.tsx
+++ b/server/frontend/src/theme/ThemeProvider.tsx
@@ -1,0 +1,134 @@
+/**
+ * ThemeProvider — fetches `/api/v1/theme` once on mount, exposes the resolved
+ * 3-tier theme via context, and applies the brand override CSS custom
+ * properties on `:root` (Decision 30).
+ *
+ * The CSS-token indirection (`--brand-primary`, `--brand-secondary`) defaults
+ * to the platform palette in `index.css`. When the API call returns:
+ *
+ *   --brand-primary  ← enterprise.accent_hex   (else: platform.cyan default)
+ *   --brand-secondary ← l2.subaccent_hex       (else: enterprise accent or
+ *                                                 platform.violet default)
+ *
+ * On API failure the FE keeps the CSS-defined defaults — no flash, no error
+ * dialog. `console.warn` records the failure for debugging.
+ *
+ * The provider also exposes a `loading` flag so consumers (Wordmark, Layout)
+ * can opt to render a placeholder vs the platform-only fallback while the
+ * fetch is in flight.
+ */
+
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from "react"
+import type { ResolvedTheme } from "./types"
+
+interface ThemeState {
+  theme: ResolvedTheme | null
+  loading: boolean
+  error: Error | null
+}
+
+const ThemeContext = createContext<ThemeState | null>(null)
+
+/**
+ * Apply the resolved theme's brand overrides as CSS custom properties on
+ * `document.documentElement`. Only run under `data-theme="8th-layer"` per
+ * the upstream-compatibility rule (mainline-cq stays platform-fixed; see
+ * issue 199 spec refinement note).
+ */
+function applyBrandOverrides(theme: ResolvedTheme): void {
+  const root = document.documentElement
+  // Defensive: only override under the 8th-layer data-theme. mainline-cq
+  // is a license-friendly upstream-compatible mode and must not carry
+  // customer-specific brand overrides.
+  if (root.getAttribute("data-theme") !== "8th-layer") return
+
+  if (theme.enterprise.accent_hex) {
+    root.style.setProperty("--brand-primary", theme.enterprise.accent_hex)
+  }
+  // Sub-accent precedence: explicit L2 sub-accent wins; otherwise the
+  // Enterprise accent gets used as the secondary too (matches Decision
+  // 30's CSS example: `--brand-secondary: var(--l2-subaccent,
+  // --enterprise-accent)`).
+  const secondary =
+    theme.l2.subaccent_hex || theme.enterprise.accent_hex || null
+  if (secondary) {
+    root.style.setProperty("--brand-secondary", secondary)
+  }
+}
+
+/**
+ * Test seam — exposed so unit tests can inject a fixture without hitting
+ * `fetch`. Not exported from the package index.
+ */
+export interface ThemeProviderProps {
+  children: ReactNode
+  initialTheme?: ResolvedTheme
+  fetcher?: () => Promise<ResolvedTheme>
+}
+
+async function defaultFetcher(): Promise<ResolvedTheme> {
+  const resp = await fetch("/api/v1/theme", { credentials: "include" })
+  if (!resp.ok) {
+    throw new Error(`theme fetch failed: HTTP ${resp.status}`)
+  }
+  return resp.json()
+}
+
+export function ThemeProvider({
+  children,
+  initialTheme,
+  fetcher = defaultFetcher,
+}: ThemeProviderProps) {
+  const [theme, setTheme] = useState<ResolvedTheme | null>(initialTheme ?? null)
+  const [loading, setLoading] = useState<boolean>(!initialTheme)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    if (initialTheme) {
+      applyBrandOverrides(initialTheme)
+      return
+    }
+    let cancelled = false
+    fetcher()
+      .then((resolved) => {
+        if (cancelled) return
+        setTheme(resolved)
+        applyBrandOverrides(resolved)
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        const e = err instanceof Error ? err : new Error(String(err))
+        setError(e)
+        // Soft-fail: keep CSS defaults, log for debugging. The shell stays
+        // usable on the platform palette.
+        console.warn("[ThemeProvider] falling back to CSS defaults:", e)
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [fetcher, initialTheme])
+
+  return (
+    <ThemeContext.Provider value={{ theme, loading, error }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+// eslint-disable-next-line react-refresh/only-export-components -- standard React context pattern.
+export function useTheme(): ThemeState {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) {
+    throw new Error("useTheme must be used within ThemeProvider")
+  }
+  return ctx
+}

--- a/server/frontend/src/theme/index.ts
+++ b/server/frontend/src/theme/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Theme module entrypoint — re-exports the public surface (FO-1d).
+ */
+
+export { ThemeProvider, useTheme } from "./ThemeProvider"
+export type {
+  EnterpriseTheme,
+  L2Theme,
+  PlatformTheme,
+  ResolvedTheme,
+} from "./types"

--- a/server/frontend/src/theme/types.ts
+++ b/server/frontend/src/theme/types.ts
@@ -1,0 +1,33 @@
+/**
+ * Type contract for the JSON returned by `GET /api/v1/theme`.
+ *
+ * Mirrors `cq_server.theme.ThemeResolver.resolve()`. Keys are required;
+ * value-level nullability matches the backend contract (Decision 30).
+ */
+
+export interface PlatformTheme {
+  name: string
+  version: string
+  tokens: Record<string, string>
+}
+
+export interface EnterpriseTheme {
+  id: string
+  display_name: string
+  logo_url: string | null
+  accent_hex: string | null
+  dark_mode_only: boolean
+}
+
+export interface L2Theme {
+  id: string
+  label: string
+  subaccent_hex: string | null
+  hero_motif: string | null
+}
+
+export interface ResolvedTheme {
+  platform: PlatformTheme
+  enterprise: EnterpriseTheme
+  l2: L2Theme
+}

--- a/server/frontend/src/webauthn.ts
+++ b/server/frontend/src/webauthn.ts
@@ -1,0 +1,130 @@
+/**
+ * Tiny WebAuthn helpers (FO-1d).
+ *
+ * The full @simplewebauthn/browser package is overkill for our needs — we
+ * only call navigator.credentials.create() / .get() once each, and the
+ * server hands us already-shaped PublicKeyCredentialOptions. The tricky
+ * bits are the base64url ↔ ArrayBuffer round-trips on the wire, which
+ * this module handles in ~50 LOC.
+ *
+ * Why not @simplewebauthn/browser: dropping a peer dep keeps the lock
+ * file shallow and avoids version-skew with the backend's py_webauthn
+ * helper module. We control the wire shape both sides.
+ */
+
+// --- base64url ↔ ArrayBuffer ---------------------------------------------
+
+export function base64urlToBytes(b64u: string): Uint8Array<ArrayBuffer> {
+  const padded = b64u + "=".repeat((4 - (b64u.length % 4)) % 4)
+  const b64 = padded.replace(/-/g, "+").replace(/_/g, "/")
+  const bin = atob(b64)
+  // Use a fresh ArrayBuffer (not ArrayBufferLike — DOM types want
+  // BufferSource = ArrayBufferView<ArrayBuffer>, not the wider
+  // SharedArrayBuffer-allowing alias). Otherwise tsc 5.9 rejects.
+  const buf = new ArrayBuffer(bin.length)
+  const out = new Uint8Array(buf)
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i)
+  return out
+}
+
+export function bytesToBase64url(buf: ArrayBuffer | Uint8Array): string {
+  const bytes = buf instanceof Uint8Array ? buf : new Uint8Array(buf)
+  let bin = ""
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i])
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+}
+
+// --- option-shape converters ---------------------------------------------
+
+interface ServerCredentialDescriptor {
+  type: string
+  id: string
+  transports?: string[]
+}
+
+interface ServerLoginOptions {
+  challenge: string
+  rpId?: string
+  timeout?: number
+  allowCredentials?: ServerCredentialDescriptor[]
+  userVerification?: UserVerificationRequirement
+}
+
+function decodeAllow(
+  list: ServerCredentialDescriptor[] | undefined,
+): PublicKeyCredentialDescriptor[] | undefined {
+  if (!list) return undefined
+  return list.map((c) => ({
+    type: "public-key",
+    id: base64urlToBytes(c.id),
+    transports: c.transports as AuthenticatorTransport[] | undefined,
+  }))
+}
+
+// --- assertion (login) ---------------------------------------------------
+
+export async function passkeyLogin(
+  username: string,
+): Promise<{ token: string; username: string; sign_count: number }> {
+  // 1. Begin — server hands us assertion options.
+  const beginResp = await fetch("/api/v1/auth/passkey/login/begin", {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username }),
+  })
+  if (!beginResp.ok) {
+    const body = await beginResp.json().catch(() => ({}))
+    throw new Error(
+      body.detail || `passkey/login/begin failed: ${beginResp.status}`,
+    )
+  }
+  const opts: ServerLoginOptions = await beginResp.json()
+
+  // 2. Convert wire shape → browser API shape.
+  const publicKey: PublicKeyCredentialRequestOptions = {
+    challenge: base64urlToBytes(opts.challenge),
+    rpId: opts.rpId,
+    timeout: opts.timeout,
+    allowCredentials: decodeAllow(opts.allowCredentials),
+    userVerification: opts.userVerification,
+  }
+
+  // 3. Browser ceremony.
+  const cred = (await navigator.credentials.get({
+    publicKey,
+  })) as PublicKeyCredential | null
+  if (!cred) throw new Error("passkey ceremony was cancelled")
+
+  const assertion = cred.response as AuthenticatorAssertionResponse
+
+  // 4. Finish — encode the assertion + send.
+  const credentialJson = {
+    id: cred.id,
+    rawId: bytesToBase64url(cred.rawId),
+    type: cred.type,
+    response: {
+      clientDataJSON: bytesToBase64url(assertion.clientDataJSON),
+      authenticatorData: bytesToBase64url(assertion.authenticatorData),
+      signature: bytesToBase64url(assertion.signature),
+      userHandle: assertion.userHandle
+        ? bytesToBase64url(assertion.userHandle)
+        : null,
+    },
+    clientExtensionResults: cred.getClientExtensionResults(),
+  }
+
+  const finishResp = await fetch("/api/v1/auth/passkey/login/finish", {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, credential: credentialJson }),
+  })
+  if (!finishResp.ok) {
+    const body = await finishResp.json().catch(() => ({}))
+    throw new Error(
+      body.detail || `passkey/login/finish failed: ${finishResp.status}`,
+    )
+  }
+  return finishResp.json()
+}


### PR DESCRIPTION
## Summary

Frontend + theme endpoint for **FO-1d** (#199) — closes the last open phase of FO-1 (#191). The backend substrate from FO-1a (#205) / FO-1b (#207) / FO-1c (#213) is now humanly usable: a non-admin invitee can claim → enroll → log out → passkey login → land in the user shell.

Decision 30 (OneZero1ai/8th-layer-core#58) drives the per-L2 branding chrome. Six logical commits for review tractability:

### 1d.1 — Brand-indirection refactor (CSS only)
Adds \`--brand-primary\` / \`--brand-secondary\` CSS custom properties on top of the existing \`--cyan\` / \`--violet\` platform palette. 24 \`var(--cyan)\` references mechanically swept: CTA buttons, focus rings, active-tab underlines, and progress-bar gradients now reference the brand tokens; data-viz hex literals + the \`::selection\` background + the Wordmark glyph stay platform-fixed (data semantics + non-overridable mark). Both \`data-theme=\"8th-layer\"\` and \`data-theme=\"mainline-cq\"\` define the brand tokens with platform defaults — mainline-cq stays upstream-compatible per issue 199's spec refinement note.

### 1d.2 — Backend \`/api/v1/theme\` + \`l2_brand\` table
- Alembic \`0020_l2_brand\` — single-row table (CHECK id=1). HEAD_REVISION bumped; three tripwire tests follow.
- \`cq_server.theme.ThemeResolver\` — composes platform constants + Enterprise stub (V1 derives display_name from \`CQ_ENTERPRISE\` env, null logo + null accent) + L2 reads from the new table.
- \`cq_server.theme_routes\` — anonymous \`GET /theme\` with \`Cache-Control: public, max-age=300\` so the login screen can render brand chrome BEFORE auth.
- 5 tests in \`tests/test_theme.py\`.

### 1d.3 — \`useTheme\` hook + \`ThemeProvider\`
Fetches \`/api/v1/theme\` on mount, exposes the resolved theme via React context, and applies brand-override CSS custom properties on \`:root\` (only under \`data-theme=\"8th-layer\"\`). Soft-fails to CSS defaults on API errors. App.tsx wraps in \`<ThemeProvider>\`. 5 vitest cases.

### 1d.4 — Wordmark 3-tier render
Renders \`<Enterprise> · <L2 label> · 8th-Layer.ai\`. Pre-load fallback shows the platform-only mark so the topbar never goes blank.

### 1d.5 — \`PoweredBy8thLayer\` footer
New non-overridable platform attribution badge. Uses platform tokens directly (not brand) per the co-branding rule. Wired into \`Layout\`; LoginPage shows the same footer.

### 1d.6 — LoginPage passkey-first + cookie-bound auth
- \`webauthn.ts\` — hand-rolled WebAuthn helper (~50 LOC), no \`@simplewebauthn/browser\` dep.
- \`auth.tsx\` — useAuth now consumes the cq_session cookie via \`/auth/me\` with \`credentials: \"include\"\`. Drops localStorage bearer-token path entirely. Adds \`loginWithPasskey(username)\` alongside legacy \`login(username, password)\`.
- \`api.ts\` — every fetch sets \`credentials: \"include\"\`.
- \`pages/LoginPage.tsx\` — Decision 30 layout: Wordmark + brand eyebrow on top, primary \"Sign in with passkey\" CTA, OR separator, password fallback, footer. Both paths read role from \`/auth/me\` after success and route enterprise_admin / l2_admin → \`/admin\`, else \`/\`.

## Cross-links

- Issue: #199
- Parent epic: OneZero1ai/8th-layer-core#57
- FO-1a (#205), FO-1b (#207), FO-1c (#213) substrate — all merged.
- Decision 30 (OneZero1ai/8th-layer-core#58) — spec source-of-truth.

**FO-1 (#191) is now end-to-end complete with this PR.**

## Test plan

- [x] \`npm run build\` — clean (TS + Vite)
- [x] \`npx biome check .\` — clean
- [x] \`npx vitest run\` — 26 tests pass (5 new theme tests, 3 rewritten auth tests)
- [x] \`pytest tests/test_theme.py\` — 5/5 pass
- [x] Full \`pytest tests/\` — 831 pass, 5 skipped
- [x] \`ruff check\` + \`ruff format --check\` — clean
- [x] \`/openapi.json\` exposes \`/theme\` and \`/api/v1/theme\`
- [ ] Manual smoke \`npm run dev\`
- [ ] Manual E2E — invite claim → enroll passkey → logout → passkey login

🤖 Generated with [Claude Code](https://claude.com/claude-code)