### PR TITLE
fix(auth): /auth/me + admin routes accept cq_session cookie (closes login 401)

### DIFF
--- a/server/backend/src/cq_server/auth.py
+++ b/server/backend/src/cq_server/auth.py
@@ -457,13 +457,35 @@ class _CallerIdentity:
 
 
 async def _resolve_caller(request: Request, store: SqliteStore) -> _CallerIdentity:
-    """Authenticate the caller via either bearer-token shape and return identity.
+    """Authenticate the caller via cookie, bearer JWT, or API key.
 
-    Tokens prefixed with ``cqa.v1.`` are decoded as API keys; everything
-    else is verified as a JWT. 401 on either path's failure.
+    Resolution order:
+
+    1. ``Authorization: Bearer <token>`` header when present — covers
+       both the legacy JWT shape and ``cqa.v1.*`` API keys minted via
+       ``POST /auth/api-keys``. Explicit beats implicit: if a caller
+       sets the header, honor it.
+    2. ``cq_session`` cookie (FO-1d browsers; minted by ``/auth/login``
+       + ``/invites/{token}/claim``). This is the only credential the
+       React admin shell can carry — post-FO-1d it strips the
+       Authorization header. See ``web_session.read_session_from_cookie``.
+
+    Why the cookie fallback: pre-fix, ``/auth/me`` and every other
+    route fronted by ``get_current_user`` only checked the header.
+    The browser sets the HttpOnly cookie on login, then on every
+    subsequent request the cookie travels but the React fetch
+    wrapper does NOT add an Authorization header — so the server
+    saw no credential and 401'd, even with a perfectly valid session.
+    401 on every path's failure.
     """
     header = request.headers.get("Authorization")
     if not header or not header.startswith("Bearer "):
+        # FO-1d: no Authorization header? Try the cq_session cookie before 401.
+        from .web_session import read_session_from_cookie
+
+        session = read_session_from_cookie(request)
+        if session is not None:
+            return _CallerIdentity(username=session.username, auth_kind="jwt")
         raise HTTPException(status_code=401, detail="Missing or invalid authorization header")
     token = header.removeprefix("Bearer ")
     if token.startswith(f"{TOKEN_NAMESPACE}.{TOKEN_VERSION}."):

--- a/server/backend/tests/test_app.py
+++ b/server/backend/tests/test_app.py
@@ -705,7 +705,10 @@ class TestApiKeyEnforcement:
         unit_id = propose_resp.json()["id"]
         _approve_unit(enforced_client, unit_id)
 
-        # Without key both are rejected.
+        # Without key both are rejected. Clear the cq_session cookie the
+        # seed login left on the TestClient — real API-key callers never
+        # carry a browser cookie, and the cookie alone would authenticate.
+        enforced_client.cookies.clear()
         assert enforced_client.post(f"/confirm/{unit_id}").status_code == 401
         assert enforced_client.post(f"/flag/{unit_id}", json={"reason": "stale"}).status_code == 401
 

--- a/server/backend/tests/test_auth.py
+++ b/server/backend/tests/test_auth.py
@@ -125,6 +125,21 @@ class TestAuthMe:
         resp = client.get("/auth/me", headers={"Authorization": "Bearer invalid"})
         assert resp.status_code == 401
 
+    def test_me_with_cookie_only(self, client: TestClient) -> None:
+        # FO-1d browsers strip the Authorization header — they send only the
+        # cq_session HttpOnly cookie. /auth/me must accept that path.
+        _seed_user(client)
+        login = client.post("/auth/login", json={"username": "peter", "password": self.test_password})
+        assert login.status_code == 200
+        assert "cq_session" in login.cookies
+        # TestClient persists cookies across requests by default — call /me
+        # with NO Authorization header to prove the cookie alone suffices.
+        resp = client.get("/auth/me")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["username"] == "peter"
+        assert body["auth_kind"] == "jwt"
+
     def test_me_with_api_key(self, api_key_client: TestClient) -> None:
         # Mint an API key via JWT, then call /me with the API key bearer.
         jwt_token = _login(api_key_client)


### PR DESCRIPTION
Post-FO-1d the React admin shell carries only the cq_session HttpOnly cookie (no Authorization header). _resolve_caller in auth.py only inspected the Authorization header — so /auth/me and every route fronted by get_current_user 401'd even with a valid cookie set by /auth/login. Root cause of the smoke-test login loop: POST /auth/login returns 200 + Set-Cookie cq_session, but GET /auth/me 401s because the server never read the cookie, React shows login screen on repeat. Fix: one fallback in _resolve_caller — when no Authorization: Bearer header is present, decode cq_session via web_session.read_session_from_cookie before 401'ing. Header still wins when both present, so API-key callers are unaffected. Tests: added test_me_with_cookie_only; patched test_confirm_and_flag_require_api_key to clear TestClient cookie jar. 137 related tests pass.