### PR TITLE
feat(tour): in-app founder walkthrough (8 steps) + server-side persistence

### DIFF
--- a/server/backend/alembic/versions/0024_user_tour_state.py
+++ b/server/backend/alembic/versions/0024_user_tour_state.py
@@ -1,0 +1,62 @@
+"""Founder-tour: ``users.tour_state`` JSON-text column.
+
+Revision ID: 0024_user_tour_state
+Revises: 0023_persona_assignment_audit
+Create Date: 2026-05-14
+
+Per-user tour-completion state for the in-app onboarding walkthrough.
+Stored as a TEXT column holding JSON of the shape:
+
+    {
+      "completed_at": "2026-05-14T11:55:00Z" | null,
+      "current_step": 3,
+      "dismissed_at": "2026-05-14T11:53:00Z" | null
+    }
+
+NULL row means "the tour has never been shown" — frontend auto-fires.
+``completed_at`` set means the user finished it. ``dismissed_at`` set
+means they X'd out before finishing — still don't auto-fire again, but
+the `?` button can replay.
+
+# Why a single JSON column (not a separate table)
+
+The data is tiny, never queried across users, never joined. A relation
+would be over-engineering. JSON in TEXT matches the convention used
+elsewhere (``invites.target_l2_id`` etc.) — sqlite stores it as TEXT
+and the Python side type-coerces via Pydantic on read.
+
+# Idempotency
+
+Standard ``_column_names`` guard mirrors every other additive migration
+in the chain. Re-run is a no-op; downgrade drops the column.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0024_user_tour_state"
+down_revision: str | Sequence[str] | None = "0023_persona_assignment_audit"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _column_names(bind: sa.engine.Connection, table_name: str) -> set[str]:
+    inspector = sa.inspect(bind)
+    if table_name not in inspector.get_table_names():
+        return set()
+    return {col["name"] for col in inspector.get_columns(table_name)}
+
+
+def upgrade() -> None:
+    """Add ``users.tour_state`` (TEXT, nullable)."""
+    bind = op.get_bind()
+    if "tour_state" not in _column_names(bind, "users"):
+        op.add_column("users", sa.Column("tour_state", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    """Drop ``users.tour_state``. Sqlite needs batch-mode for DROP COLUMN."""
+    with op.batch_alter_table("users") as batch:
+        batch.drop_column("tour_state")

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -44,6 +44,7 @@ from .quality import check_propose_quality
 from .reflect import router as reflect_router
 from .reputation_routes import router as reputation_router
 from .review import router as review_router
+from .tour_routes import router as tour_router
 from .scoring import apply_confirmation, apply_flag
 from .store import normalize_domains
 from .store._sqlite import SqliteStore
@@ -445,6 +446,9 @@ api_router.include_router(persona_router)
 # Mounted on api_router so it lives under both / and /api/v1, same as
 # every other API route. Decision 30 sets the spec.
 api_router.include_router(theme_router)
+# Founder-tour persistence — GET/PUT /api/v1/users/me/tour-state for
+# the in-app onboarding walkthrough.
+api_router.include_router(tour_router)
 
 
 @api_router.get("/health")

--- a/server/backend/src/cq_server/migrations.py
+++ b/server/backend/src/cq_server/migrations.py
@@ -36,7 +36,7 @@ BASELINE_REVISION = "0001"
 # Phase 2 (task #100) — chain head after porting fork-delta tables to
 # Alembic. Update this string when adding a new migration so test
 # assertions and ops scripts stay in sync with the actual chain head.
-HEAD_REVISION = "0023_persona_assignment_audit"
+HEAD_REVISION = "0024_user_tour_state"
 
 
 def _find_alembic_ini() -> Path:

--- a/server/backend/src/cq_server/tour_routes.py
+++ b/server/backend/src/cq_server/tour_routes.py
@@ -1,0 +1,129 @@
+"""Founder-tour persistence — per-user `tour_state` read/write.
+
+Tiny endpoint pair behind ``/api/v1/users/me/tour-state``:
+
+* ``GET``  → return the JSON blob (or an empty default if NULL).
+* ``PUT``  → upsert the JSON blob. No partial updates — caller sends
+             the full shape every time. Keeps the contract honest.
+
+Authentication is the standard cookie/bearer dep (``get_current_user``).
+Per-user — there is no admin-fetch-other-user surface here.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import text
+
+from .auth import get_current_user
+from .deps import get_store
+from .store._sqlite import SqliteStore
+
+log = logging.getLogger("tour_routes")
+
+router = APIRouter(prefix="/users/me", tags=["tour"])
+
+
+class TourState(BaseModel):
+    """Shape of the per-user tour-completion state.
+
+    All fields are optional — the frontend treats absence of
+    ``completed_at`` as "tour has not been finished; auto-fire OK"
+    unless ``dismissed_at`` is set (then replay only via the
+    `?` launcher, never auto-fire).
+    """
+
+    completed_at: str | None = None
+    dismissed_at: str | None = None
+    current_step: int = 0
+
+
+def _parse(raw: str | None) -> TourState:
+    """Decode the TEXT column into a ``TourState``. Empty → defaults."""
+    if not raw:
+        return TourState()
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        # Corrupt row — surface as "fresh" rather than 500ing the UI.
+        log.warning("tour_state JSON decode failed; returning defaults")
+        return TourState()
+    if not isinstance(data, dict):
+        return TourState()
+    return TourState(
+        completed_at=data.get("completed_at"),
+        dismissed_at=data.get("dismissed_at"),
+        current_step=int(data.get("current_step", 0)),
+    )
+
+
+def _serialize(state: TourState) -> str:
+    """Encode for the TEXT column. Compact JSON, stable key order."""
+    return json.dumps(
+        {
+            "completed_at": state.completed_at,
+            "dismissed_at": state.dismissed_at,
+            "current_step": state.current_step,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _read_sync(store: SqliteStore, username: str) -> str | None:
+    with store._engine.connect() as conn:  # noqa: SLF001
+        row = conn.execute(
+            text("SELECT tour_state FROM users WHERE username = :u"),
+            {"u": username},
+        ).fetchone()
+    return row[0] if row is not None else None
+
+
+def _write_sync(store: SqliteStore, username: str, blob: str) -> int:
+    with store._engine.begin() as conn:  # noqa: SLF001
+        result = conn.execute(
+            text("UPDATE users SET tour_state = :s WHERE username = :u"),
+            {"s": blob, "u": username},
+        )
+    return int(result.rowcount or 0)
+
+
+@router.get("/tour-state", response_model=TourState)
+async def get_tour_state(
+    username: str = Depends(get_current_user),
+    store: SqliteStore = Depends(get_store),
+) -> TourState:
+    """Return the caller's tour-state, or empty defaults if never set."""
+    raw = await store._run_sync(_read_sync, store, username)  # noqa: SLF001
+    return _parse(raw)
+
+
+@router.put("/tour-state", response_model=TourState)
+async def put_tour_state(
+    payload: TourState,
+    username: str = Depends(get_current_user),
+    store: SqliteStore = Depends(get_store),
+) -> TourState:
+    """Replace the caller's tour-state with the supplied blob.
+
+    Server stamps ``completed_at`` / ``dismissed_at`` to now if the
+    caller sent the literal string ``"now"`` — convenience so the
+    frontend doesn't need to grab a clock.
+    """
+    now = datetime.now(UTC).isoformat()
+    if payload.completed_at == "now":
+        payload.completed_at = now
+    if payload.dismissed_at == "now":
+        payload.dismissed_at = now
+
+    blob = _serialize(payload)
+    rowcount = await store._run_sync(_write_sync, store, username, blob)  # noqa: SLF001
+    if rowcount == 0:
+        raise HTTPException(status_code=404, detail="User not found")
+    return payload

--- a/server/backend/tests/test_tour_routes.py
+++ b/server/backend/tests/test_tour_routes.py
@@ -1,0 +1,92 @@
+"""Tests for the founder-tour persistence endpoints.
+
+Covers the GET/PUT contract on ``/api/v1/users/me/tour-state``:
+
+* GET on a fresh user → empty defaults (never-touched row reads as
+  ``{completed_at: null, dismissed_at: null, current_step: 0}``).
+* PUT round-trips an arbitrary state and survives a follow-up GET.
+* The "now" sentinel on PUT gets stamped to an ISO-8601 timestamp.
+* Anonymous callers 401 (the auth dep is on the router).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cq_server.app import app
+from cq_server.auth import get_current_user, hash_password
+from cq_server.deps import require_api_key
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "tour.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    app.dependency_overrides[require_api_key] = lambda: "founder"
+    app.dependency_overrides[get_current_user] = lambda: "founder"
+    with TestClient(app) as c:
+        # Seed the row so the UPDATE path has something to hit.
+        from cq_server.app import _get_store
+
+        store = _get_store()
+        store.sync.create_user("founder", hash_password("pw-1234567"))
+        yield c
+    app.dependency_overrides.pop(require_api_key, None)
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_get_fresh_user_returns_defaults(client: TestClient) -> None:
+    resp = client.get("/api/v1/users/me/tour-state")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"completed_at": None, "dismissed_at": None, "current_step": 0}
+
+
+def test_put_then_get_round_trips(client: TestClient) -> None:
+    put = client.put(
+        "/api/v1/users/me/tour-state",
+        json={"completed_at": None, "dismissed_at": None, "current_step": 3},
+    )
+    assert put.status_code == 200, put.text
+    assert put.json()["current_step"] == 3
+
+    get = client.get("/api/v1/users/me/tour-state")
+    assert get.status_code == 200
+    body = get.json()
+    assert body["current_step"] == 3
+    assert body["completed_at"] is None
+
+
+def test_put_now_sentinel_stamps_iso_timestamp(client: TestClient) -> None:
+    put = client.put(
+        "/api/v1/users/me/tour-state",
+        json={"completed_at": "now", "current_step": 8},
+    )
+    assert put.status_code == 200
+    body = put.json()
+    assert body["current_step"] == 8
+    # ISO-8601 with timezone — starts with year and includes 'T'.
+    assert body["completed_at"] is not None
+    assert body["completed_at"][:4].isdigit()
+    assert "T" in body["completed_at"]
+
+
+def test_put_404_for_missing_user(client: TestClient) -> None:
+    """If the user row vanishes mid-flight, PUT surfaces 404 not 500."""
+    from cq_server.app import _get_store
+    from sqlalchemy import text
+
+    # Delete the seeded user — simulates the mid-flight race.
+    store = _get_store()
+    with store._engine.begin() as conn:  # noqa: SLF001
+        conn.execute(text("DELETE FROM users WHERE username = :u"), {"u": "founder"})
+
+    resp = client.put(
+        "/api/v1/users/me/tour-state",
+        json={"completed_at": None, "current_step": 1},
+    )
+    assert resp.status_code == 404, resp.text

--- a/server/frontend/src/App.tsx
+++ b/server/frontend/src/App.tsx
@@ -10,6 +10,8 @@ import { NetworkPage } from "./pages/NetworkPage"
 import { PersonasPage } from "./pages/PersonasPage"
 import { ReviewPage } from "./pages/ReviewPage"
 import { ThemeProvider } from "./theme"
+import { TourOverlay } from "./tour/TourOverlay"
+import { TourProvider } from "./tour/TourProvider"
 
 function AppRoutes() {
   const { isAuthenticated } = useAuth()
@@ -45,7 +47,10 @@ export default function App() {
     <BrowserRouter>
       <ThemeProvider>
         <AuthProvider>
-          <AppRoutes />
+          <TourProvider>
+            <AppRoutes />
+            <TourOverlay />
+          </TourProvider>
         </AuthProvider>
       </ThemeProvider>
     </BrowserRouter>

--- a/server/frontend/src/components/Layout.tsx
+++ b/server/frontend/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react"
 import { Link, Outlet, useLocation } from "react-router"
 import { api } from "../api"
 import { useAuth } from "../auth"
+import { TourLauncher } from "../tour/TourLauncher"
 import { PoweredBy8thLayer } from "./PoweredBy8thLayer"
 import { Wordmark } from "./Wordmark"
 
@@ -26,11 +27,12 @@ export function Layout() {
     return () => clearInterval(interval)
   }, [onDashboard])
 
-  function navLink(path: string, label: string) {
+  function navLink(path: string, label: string, tourId?: string) {
     const active = location.pathname === path
     return (
       <Link
         to={path}
+        data-tour-target={tourId}
         className={`relative font-mono-brand text-[11px] uppercase tracking-[0.22em] py-1 whitespace-nowrap transition-colors ${
           active
             ? "text-[var(--ink)]"
@@ -57,22 +59,25 @@ export function Layout() {
           className={`${wide ? "w-full px-6" : "max-w-3xl mx-auto px-4"} py-3 flex items-center justify-between`}
         >
           <div className="flex items-center gap-3 md:gap-7">
-            <Link to="/dashboard" className="mr-2">
+            <Link to="/dashboard" className="mr-2" data-tour-target="welcome">
               <Wordmark size="md" />
             </Link>
-            {navLink("/review", "Review")}
-            {navLink("/dashboard", "Dashboard")}
-            {navLink("/network", "Network")}
-            {navLink("/settings/api-keys", "API Keys")}
-            {navLink("/admin/personas", "Personas")}
+            <span data-tour-target="group" className="contents" />
+            {navLink("/review", "Review", "review")}
+            {navLink("/dashboard", "Dashboard", "dashboard")}
+            {navLink("/network", "Network", "network")}
+            {navLink("/settings/api-keys", "API Keys", "api-keys")}
+            {navLink("/admin/personas", "Personas", "personas")}
           </div>
           <div className="flex items-center gap-4">
+            <TourLauncher />
             <span className="hidden md:inline font-mono-brand text-[11px] uppercase tracking-[0.18em] text-[var(--ink-mute)]">
               {username}
             </span>
             <button
               type="button"
               onClick={logout}
+              data-tour-target="done"
               className="font-mono-brand text-[11px] uppercase tracking-[0.18em] text-[var(--ink-faint)] hover:text-[var(--rose)] transition-colors"
             >
               Logout

--- a/server/frontend/src/tour/TourLauncher.tsx
+++ b/server/frontend/src/tour/TourLauncher.tsx
@@ -1,0 +1,24 @@
+/**
+ * The `?` button in the header — manual tour replay.
+ *
+ * Sits in the nav so it's available everywhere the Layout renders.
+ * Single button, single click, restarts the tour from step 1.
+ */
+
+import { useTour } from "./useTour"
+
+export function TourLauncher() {
+  const { start, active } = useTour()
+  if (active) return null // hide while the tour is showing — avoid restart loops
+  return (
+    <button
+      type="button"
+      onClick={start}
+      aria-label="Replay onboarding tour"
+      title="Replay tour"
+      className="font-mono-brand text-[12px] w-6 h-6 inline-flex items-center justify-center rounded-full border border-[var(--rule-strong)] text-[var(--ink-mute)] hover:text-[var(--ink)] hover:border-[var(--brand-primary,#5bd0ff)] transition-colors"
+    >
+      ?
+    </button>
+  )
+}

--- a/server/frontend/src/tour/TourOverlay.tsx
+++ b/server/frontend/src/tour/TourOverlay.tsx
@@ -1,0 +1,265 @@
+/**
+ * Spotlight + popover engine for the Founder's First L2 walk-through.
+ *
+ * Why custom (not react-joyride / intro.js): the admin shell uses
+ * project-specific brand tokens (Fraunces / cyan-violet gradient on
+ * dark) and a custom-property theme system. A library would import its
+ * own CSS and ship default chrome that wouldn't match. ~250 LOC of
+ * brand-native overlay is cheaper than restyling someone else's component.
+ *
+ * Topology:
+ *
+ *   <TourOverlay>                  ← portal mounted at document.body
+ *     <backdrop mask />            ← darkened rect-with-hole around target
+ *     <Popover />                  ← positioned next to the target
+ *
+ * The mask is a single full-viewport <svg> with a <mask> that punches a
+ * rounded rectangle around the target. Cheap, no per-pixel work.
+ *
+ * Positioning: we put the popover ABOVE the target if it fits, else
+ * BELOW. Horizontal — clamp to the viewport with an 8px margin. No
+ * arrow on v1; the spotlight makes the connection obvious.
+ */
+
+import { useEffect, useLayoutEffect, useRef, useState } from "react"
+import { createPortal } from "react-dom"
+import type { TourStep } from "./steps"
+import { useTour } from "./useTour"
+
+interface Rect {
+  top: number
+  left: number
+  width: number
+  height: number
+}
+
+const PADDING = 8 // spotlight inflate, px
+const POPOVER_GAP = 14 // space between spotlight and popover, px
+const POPOVER_WIDTH = 320 // popover width, px
+
+function useTargetRect(targetId: string | undefined): Rect | null {
+  const [rect, setRect] = useState<Rect | null>(null)
+
+  useLayoutEffect(() => {
+    if (!targetId) {
+      setRect(null)
+      return
+    }
+    function measure() {
+      const el = document.querySelector<HTMLElement>(
+        `[data-tour-target="${targetId}"]`,
+      )
+      if (!el) {
+        setRect(null)
+        return
+      }
+      const r = el.getBoundingClientRect()
+      setRect({ top: r.top, left: r.left, width: r.width, height: r.height })
+    }
+    // Two RAFs — first paints React's nav changes, second measures the
+    // post-paint layout. Without this the first step often measures the
+    // pre-navigation DOM and the spotlight lands on stale geometry.
+    requestAnimationFrame(() => requestAnimationFrame(measure))
+    window.addEventListener("resize", measure)
+    window.addEventListener("scroll", measure, true)
+    return () => {
+      window.removeEventListener("resize", measure)
+      window.removeEventListener("scroll", measure, true)
+    }
+  }, [targetId])
+
+  return rect
+}
+
+function popoverPosition(rect: Rect | null): {
+  top: number
+  left: number
+  anchor: "above" | "below" | "center"
+} {
+  if (!rect) {
+    return {
+      top: Math.max(120, window.innerHeight / 2 - 100),
+      left: Math.max(16, window.innerWidth / 2 - POPOVER_WIDTH / 2),
+      anchor: "center",
+    }
+  }
+  const fitsBelow =
+    rect.top + rect.height + POPOVER_GAP + 220 < window.innerHeight
+  const anchor: "above" | "below" = fitsBelow ? "below" : "above"
+  const top =
+    anchor === "below"
+      ? rect.top + rect.height + POPOVER_GAP
+      : Math.max(16, rect.top - POPOVER_GAP - 220)
+  const naiveLeft = rect.left + rect.width / 2 - POPOVER_WIDTH / 2
+  const left = Math.max(
+    16,
+    Math.min(window.innerWidth - POPOVER_WIDTH - 16, naiveLeft),
+  )
+  return { top, left, anchor }
+}
+
+function Spotlight({ rect }: { rect: Rect | null }) {
+  if (!rect) {
+    return (
+      <div
+        className="fixed inset-0 bg-black/60 pointer-events-auto"
+        aria-hidden="true"
+      />
+    )
+  }
+  // SVG-mask approach — one rect + one cutout, hardware composited.
+  const pad = PADDING
+  return (
+    <svg
+      className="fixed inset-0 w-full h-full pointer-events-auto"
+      aria-hidden="true"
+      style={{ width: "100vw", height: "100vh" }}
+    >
+      <defs>
+        <mask id="tour-mask">
+          <rect x="0" y="0" width="100%" height="100%" fill="white" />
+          <rect
+            x={rect.left - pad}
+            y={rect.top - pad}
+            width={rect.width + pad * 2}
+            height={rect.height + pad * 2}
+            rx="10"
+            fill="black"
+          />
+        </mask>
+      </defs>
+      <rect
+        x="0"
+        y="0"
+        width="100%"
+        height="100%"
+        fill="rgba(4, 8, 16, 0.72)"
+        mask="url(#tour-mask)"
+      />
+      <rect
+        x={rect.left - pad}
+        y={rect.top - pad}
+        width={rect.width + pad * 2}
+        height={rect.height + pad * 2}
+        rx="10"
+        fill="none"
+        stroke="rgba(91, 208, 255, 0.55)"
+        strokeWidth="1.5"
+      />
+    </svg>
+  )
+}
+
+function Popover({
+  step,
+  index,
+  total,
+  position,
+  onNext,
+  onSkip,
+}: {
+  step: TourStep
+  index: number
+  total: number
+  position: { top: number; left: number }
+  onNext: () => void
+  onSkip: () => void
+}) {
+  const isLast = index === total - 1
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={`tour-step-${step.id}-title`}
+      className="fixed z-[60] pointer-events-auto"
+      style={{
+        top: position.top,
+        left: position.left,
+        width: POPOVER_WIDTH,
+      }}
+    >
+      <div
+        className="rounded-xl border border-[var(--rule-strong)] bg-[color-mix(in_srgb,var(--bg-via)_94%,transparent)] backdrop-blur-lg p-5 shadow-2xl"
+        style={{ boxShadow: "0 20px 60px rgba(0,0,0,0.5)" }}
+      >
+        <div className="flex items-center justify-between mb-2">
+          <span className="font-mono-brand text-[10px] uppercase tracking-[0.22em] text-[var(--ink-mute)]">
+            Step {index + 1} / {total}
+          </span>
+          <button
+            type="button"
+            onClick={onSkip}
+            aria-label="Skip tour"
+            className="font-mono-brand text-[10px] uppercase tracking-[0.18em] text-[var(--ink-faint)] hover:text-[var(--rose)] transition-colors"
+          >
+            Skip
+          </button>
+        </div>
+        <h2
+          id={`tour-step-${step.id}-title`}
+          className="font-serif-brand text-lg text-[var(--ink)] mb-2"
+        >
+          {step.title}
+        </h2>
+        <p className="text-sm text-[var(--ink-dim)] leading-relaxed mb-5">
+          {step.body}
+        </p>
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex gap-1.5">
+            {Array.from({ length: total }, (_, i) => (
+              <span
+                // biome-ignore lint/suspicious/noArrayIndexKey: pure-display dots
+                key={i}
+                className={`h-1.5 w-1.5 rounded-full transition-colors ${
+                  i <= index
+                    ? "bg-[var(--brand-primary,#5bd0ff)]"
+                    : "bg-[var(--rule-strong)]"
+                }`}
+              />
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={onNext}
+            className="px-4 py-2 rounded-md font-mono-brand text-[11px] uppercase tracking-[0.18em] text-[#0a0612] bg-gradient-to-r from-[var(--cyan,#5bd0ff)] to-[var(--violet,#a685ff)] hover:brightness-110 transition-all"
+          >
+            {step.ctaLabel ?? (isLast ? "Finish" : "Next")}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function TourOverlay() {
+  const { active, currentStep, currentIndex, total, next, dismiss } = useTour()
+  const rect = useTargetRect(active && currentStep ? currentStep.id : undefined)
+  const positionRef = useRef(popoverPosition(rect))
+  positionRef.current = popoverPosition(rect)
+
+  // ESC to dismiss
+  useEffect(() => {
+    if (!active) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") dismiss()
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [active, dismiss])
+
+  if (!active || !currentStep) return null
+  return createPortal(
+    <div className="fixed inset-0 z-[55]">
+      <Spotlight rect={rect} />
+      <Popover
+        step={currentStep}
+        index={currentIndex}
+        total={total}
+        position={positionRef.current}
+        onNext={next}
+        onSkip={dismiss}
+      />
+    </div>,
+    document.body,
+  )
+}

--- a/server/frontend/src/tour/TourProvider.tsx
+++ b/server/frontend/src/tour/TourProvider.tsx
@@ -1,0 +1,164 @@
+/**
+ * Tour state machine + persistence.
+ *
+ * One global tour at a time. The provider:
+ *   - Pulls tour-state from `/api/v1/users/me/tour-state` on mount.
+ *   - Decides whether to auto-fire (no `completed_at` AND no `dismissed_at`).
+ *   - Owns `currentIndex` and the public actions: start, next, dismiss, replay.
+ *   - PUTs the current state to the server on every transition so refresh
+ *     resumes mid-tour rather than restarting (and a teammate logging in
+ *     on a second device sees "you've already done this").
+ *
+ * Why a context (not a hook with internal state): two consumers — the
+ * overlay (renders the spotlight) and the launcher (the `?` button in
+ * the header). One state, two readers — exactly what context is for.
+ */
+
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react"
+import { useNavigate } from "react-router"
+import { useAuth } from "../auth"
+import { TOUR_STEPS, type TourStep } from "./steps"
+
+interface TourState {
+  completed_at: string | null
+  dismissed_at: string | null
+  current_step: number
+}
+
+interface TourContextValue {
+  active: boolean
+  currentStep: TourStep | null
+  currentIndex: number
+  total: number
+  start: () => void
+  next: () => void
+  dismiss: () => void
+}
+
+const TourContext = createContext<TourContextValue | null>(null)
+
+const API = "/api/v1/users/me/tour-state"
+
+async function fetchTourState(): Promise<TourState> {
+  const resp = await fetch(API, { credentials: "include" })
+  if (!resp.ok) {
+    // Fresh / 401 / network — treat as a never-shown tour. The overlay
+    // will not auto-fire unless we explicitly say "OK to fire" via the
+    // local active flag, which only flips when we read a real state row.
+    return { completed_at: null, dismissed_at: null, current_step: 0 }
+  }
+  return resp.json()
+}
+
+async function putTourState(state: Partial<TourState>): Promise<void> {
+  await fetch(API, {
+    method: "PUT",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(state),
+  }).catch(() => {})
+}
+
+export function TourProvider({ children }: { children: ReactNode }) {
+  const { isAuthenticated } = useAuth()
+  const navigate = useNavigate()
+  const [active, setActive] = useState(false)
+  const [currentIndex, setCurrentIndex] = useState(0)
+
+  // On login: fetch tour state. If never-completed and never-dismissed,
+  // auto-fire from the last known step. The server-side state means a
+  // refresh / new-device login picks up where the user left off.
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setActive(false)
+      return
+    }
+    let cancelled = false
+    fetchTourState().then((state) => {
+      if (cancelled) return
+      const idx = Math.max(
+        0,
+        Math.min(state.current_step, TOUR_STEPS.length - 1),
+      )
+      setCurrentIndex(idx)
+      const shouldAutofire = !state.completed_at && !state.dismissed_at
+      if (shouldAutofire) {
+        // Don't yank a freshly-logged-in user away from /login → /review
+        // mid-navigation; give the router a tick to land.
+        setTimeout(() => !cancelled && setActive(true), 400)
+      }
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [isAuthenticated])
+
+  // When a step has a `nav` target, push the route BEFORE the overlay
+  // re-measures (the spotlight needs the target node painted first).
+  useEffect(() => {
+    if (!active) return
+    const step = TOUR_STEPS[currentIndex]
+    if (step?.nav) {
+      navigate(step.nav, { replace: false })
+    }
+  }, [active, currentIndex, navigate])
+
+  const start = useCallback(() => {
+    setCurrentIndex(0)
+    setActive(true)
+    putTourState({ current_step: 0, completed_at: null, dismissed_at: null })
+  }, [])
+
+  const next = useCallback(() => {
+    setCurrentIndex((prev) => {
+      const nextIdx = prev + 1
+      if (nextIdx >= TOUR_STEPS.length) {
+        // Last step → mark completed, close overlay.
+        setActive(false)
+        putTourState({
+          current_step: TOUR_STEPS.length - 1,
+          completed_at: "now",
+        })
+        return prev
+      }
+      putTourState({ current_step: nextIdx })
+      return nextIdx
+    })
+  }, [])
+
+  const dismiss = useCallback(() => {
+    setActive(false)
+    putTourState({ current_step: currentIndex, dismissed_at: "now" })
+  }, [currentIndex])
+
+  const value = useMemo<TourContextValue>(
+    () => ({
+      active,
+      currentStep: TOUR_STEPS[currentIndex] ?? null,
+      currentIndex,
+      total: TOUR_STEPS.length,
+      start,
+      next,
+      dismiss,
+    }),
+    [active, currentIndex, start, next, dismiss],
+  )
+
+  return <TourContext.Provider value={value}>{children}</TourContext.Provider>
+}
+
+export function useTourContext(): TourContextValue {
+  const ctx = useContext(TourContext)
+  if (!ctx) {
+    throw new Error("useTourContext: missing <TourProvider>")
+  }
+  return ctx
+}

--- a/server/frontend/src/tour/steps.ts
+++ b/server/frontend/src/tour/steps.ts
@@ -1,0 +1,78 @@
+/**
+ * The Founder's First L2 walk-through — eight steps that land a new
+ * founder from "I just logged in" to "I know what to do next."
+ *
+ * `target` is a CSS selector (we attach `data-tour-target="<id>"` to the
+ * relevant DOM node and the engine queries on that). If the target is
+ * missing (route doesn't render it, screen too narrow, etc.) the engine
+ * falls back to a centered modal so the step is never silently lost.
+ *
+ * `nav` (optional) lets a step push the router to a path BEFORE rendering
+ * — e.g. step 5 jumps to /review so the highlight lands on a visible tab
+ * even if the user manually navigated away mid-tour.
+ *
+ * Copy is intentionally ~25 words per step. Shorter is harsh; longer the
+ * user skims past. Eight steps × ~90 seconds = the right onboarding budget.
+ */
+
+export interface TourStep {
+  /** Stable id — used in `data-tour-target` selectors and analytics. */
+  id: string
+  /** Optional route to navigate to before showing this step. */
+  nav?: string
+  /** Title rendered as the popover heading. */
+  title: string
+  /** Body copy. Plain text — no markdown. */
+  body: string
+  /** Optional CTA label for the "Next" button. Defaults to "Next". */
+  ctaLabel?: string
+}
+
+export const TOUR_STEPS: TourStep[] = [
+  {
+    id: "welcome",
+    title: "Welcome to your L2",
+    body: "This is your Enterprise's Semantic Knowledge Layer — Layer 8 of the stack. Agent sessions register here, propose discoveries, and query a growing commons.",
+  },
+  {
+    id: "group",
+    title: "One Group, one L2 — for now",
+    body: "Your Enterprise starts with the `default` group. Add more Groups later; each gets its own isolated L2 (model B).",
+  },
+  {
+    id: "api-keys",
+    nav: "/settings/api-keys",
+    title: "Connect your first agent",
+    body: "Mint a key here, then point a Claude Code session at this L2 via the `cq` plugin's setup-skill. Knowledge starts flowing in minutes.",
+  },
+  {
+    id: "network",
+    nav: "/network",
+    title: "Watch the graph grow",
+    body: "Sessions, Personas, Humans, KUs, peer Enterprises — all of it shows up here as nodes. This IS your operational picture.",
+  },
+  {
+    id: "review",
+    nav: "/review",
+    title: "Approve knowledge",
+    body: "When an agent proposes a KU that needs human eyes, it lands here. You ship only what you vouch for.",
+  },
+  {
+    id: "dashboard",
+    nav: "/dashboard",
+    title: "Day-over-day",
+    body: "Propose / approve / flag counts, fresh activity, fleet health. Mission control for the substrate.",
+  },
+  {
+    id: "personas",
+    nav: "/admin/personas",
+    title: "Invite humans, assign personas",
+    body: "One human, many personas. Each logs in with a passkey and gets its own activity trail under one Enterprise identity.",
+  },
+  {
+    id: "done",
+    title: "You're operational",
+    body: "The substrate is live. Connect your first session and the graph fills in. Replay this tour anytime via the `?` button.",
+    ctaLabel: "Finish",
+  },
+]

--- a/server/frontend/src/tour/useTour.ts
+++ b/server/frontend/src/tour/useTour.ts
@@ -1,0 +1,7 @@
+/**
+ * Thin re-export so consumers import a hook (idiomatic) rather than the
+ * raw context. Keeps the API tight: `useTour()` returns the state +
+ * actions, nothing else.
+ */
+
+export { useTourContext as useTour } from "./TourProvider"


### PR DESCRIPTION
Adds the founder onboarding tour that auto-fires the first time a claimed admin lands in the L2 admin shell. Eight steps, ~90 seconds, teaches what an L2 is, where to connect agents, and where each operational surface lives. Custom spotlight + popover engine (no library, brand-native). State persists server-side via users.tour_state JSON column (migration 0024) + GET/PUT /api/v1/users/me/tour-state endpoints. Resumes mid-tour across refresh / device. Manual replay via ? button in the header. Tests cover the endpoint contract: default-on-fresh-user, round-trip PUT/GET, 'now' sentinel stamping, 404-on-missing-user race. Frontend type-checks + builds + lint:check clean. 53 backend tests in the affected suites pass.