### PR TITLE
feat(cq): self-host cq binary so propose_batch actually ships (#190)

### DIFF
--- a/FORK_DELTA.md
+++ b/FORK_DELTA.md
@@ -8,8 +8,10 @@ See [`docs/decisions/08-agent-side-fork.md`](https://github.com/OneZero1ai/8th-l
 
 ## What we add over upstream cq
 
-(planned — none merged yet as of fork creation)
+(see git history for what has merged; the list below is the intended delta)
 
+- **`propose_batch` MCP tool** — stores N knowledge units in one MCP round-trip. Additive to upstream's tool surface; the per-unit `propose` is unchanged. Lets `/cq:reflect` cap its tool-call echo at a single invocation regardless of candidate count.
+- **Self-hosted cq binary** — the fork carries Go-side additions (e.g. `propose_batch`) that upstream's published binary does not, so the plugin fetches the binary from an 8th-Layer-owned CloudFront release host rather than upstream GitHub releases. See `plugins/cq/scripts/cq_binary.py`.
 - **AIGRP client-side routing** — Agent Intelligence Graph Routing Protocol. The forked agent maintains a routing table fed by gossip + tenant directory, makes routing decisions client-side, executes peer-to-peer within trust boundaries, defers cross-trust-boundary execution to the tenant Remote for consent enforcement.
 - **DID-KMS bridge** — derives a DID from a KMS-signed Persona public key (`did:web:` proxy V1; `did:keri:` V2+). Populates `provenance.proposer_did` on every Knowledge Unit.
 - **Multi-tenancy hooks** — agent honors tenant + enterprise + team scope from the JWT context (mapped from `CQ_API_KEY`); routing-table entries scope-filtered.

--- a/cli/RELEASING.md
+++ b/cli/RELEASING.md
@@ -1,0 +1,66 @@
+# Releasing the cq binary
+
+The 8th-Layer fork ships its own `cq` binary because it carries Go-side
+additions (e.g. the `propose_batch` MCP tool) that upstream's published
+binary does not. The plugin (`plugins/cq/scripts/cq_binary.py`) fetches
+the binary over unauthenticated HTTPS from a CloudFront distribution in
+front of a private S3 bucket.
+
+There is no CI release pipeline yet — releases are cut manually with the
+steps below. Automating this is tracked as a follow-up.
+
+## Hosting
+
+- S3 bucket: `8l-cli-releases-124074140789-us-east-1` (account `124074140789`,
+  profile `8th-layer-app`, private, OAC-only).
+- CloudFront: distribution `E2KE74D3FCXBSX`, domain `dyejnuj2nvzpy.cloudfront.net`.
+- Asset layout: `cli/v{version}/cq_{OS}_{arch}.{tar.gz|zip}`
+  where `OS` ∈ {`Darwin`, `Linux`, `Windows`} and `arch` ∈ {`x86_64`, `arm64`}.
+
+## Cut a release
+
+From `cli/`, pick the new `VER` (must be ≥ the `cli_min_version` you will
+set in `plugins/cq/scripts/bootstrap.json`):
+
+```sh
+VER=0.9.0
+SHA=$(git rev-parse --short HEAD)
+DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+VP=github.com/mozilla-ai/cq/cli/internal/version
+LD="-s -w -X $VP.version=$VER -X $VP.commit=$SHA -X $VP.date=$DATE"
+OUT=/tmp/cq-release; rm -rf $OUT; mkdir -p $OUT
+
+# version MUST be injected via ldflags — `cq --version` is parsed by
+# cq_binary.py; a "dev" version fails the min-version check and re-downloads
+# on every launch.
+
+for t in "Darwin arm64 darwin arm64" "Darwin x86_64 darwin amd64" \
+         "Linux x86_64 linux amd64" "Linux arm64 linux arm64"; do
+  set -- $t
+  d=$(mktemp -d)
+  GOOS=$3 GOARCH=$4 go build -ldflags "$LD" -o "$d/cq" .
+  tar -C "$d" -czf "$OUT/cq_$1_$2.tar.gz" cq
+done
+for t in "x86_64 amd64" "arm64 arm64"; do
+  set -- $t
+  d=$(mktemp -d)
+  GOOS=windows GOARCH=$2 go build -ldflags "$LD" -o "$d/cq.exe" .
+  (cd "$d" && zip -q "$OUT/cq_Windows_$1.zip" cq.exe)
+done
+```
+
+Note: run the loops in `bash`, not `zsh` — `zsh` does not word-split
+`$t` and the `set --` trick silently degrades to native-only builds.
+
+Upload and bump the gate:
+
+```sh
+B=8l-cli-releases-124074140789-us-east-1
+for f in $OUT/*.tar.gz; do aws s3 cp "$f" "s3://$B/cli/v$VER/$(basename $f)" \
+  --profile 8th-layer-app --content-type application/gzip; done
+for f in $OUT/*.zip; do aws s3 cp "$f" "s3://$B/cli/v$VER/$(basename $f)" \
+  --profile 8th-layer-app --content-type application/zip; done
+```
+
+Then set `cli_min_version` in `plugins/cq/scripts/bootstrap.json` to `$VER`
+and bump the plugin version in `plugins/cq/.claude-plugin/plugin.json`.

--- a/plugins/cq/.claude-plugin/plugin.json
+++ b/plugins/cq/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "8l-cq",
-  "version": "0.9.0+8l-dev",
+  "version": "0.10.0+8l-dev",
   "description": "8th-Layer.ai agent — Apache-2.0 fork of Mozilla.AI's cq plugin (https://github.com/mozilla-ai/cq) adding enterprise execution: AIGRP intra-Enterprise routing, DSN intent resolution, L3 live consults, multi-tenant scope, directory + reputation log primitives. Speaks the cq protocol natively (MCP server is still named 'cq' for protocol compatibility); pair with an 8th-Layer.ai tenant Remote for the enterprise feature set. v0.9 adds the crosstalk MCP server (l2-only mode) for inter-agent messaging through the tenant L2 — productized from the prototype that originated in claude-mux.",
   "homepage": "https://8th-layer.ai",
   "author": {

--- a/plugins/cq/scripts/bootstrap.json
+++ b/plugins/cq/scripts/bootstrap.json
@@ -1,3 +1,3 @@
 {
-  "cli_min_version": "0.5.0"
+  "cli_min_version": "0.9.0"
 }

--- a/plugins/cq/scripts/cq_binary.py
+++ b/plugins/cq/scripts/cq_binary.py
@@ -3,7 +3,11 @@
 Stdlib-only module consumed by both `bootstrap.py` (when Claude launches
 the MCP server) and the multi-host installer (`cq_install.binary`). It
 owns the rules for where the binary is cached, how its version is
-verified, and how it is fetched from GitHub releases when absent.
+verified, and how it is fetched from the 8th-Layer release host when
+absent. The 8th-Layer fork ships its own cq binary (it carries the
+`propose_batch` MCP tool, which upstream does not), so release assets
+are served from an 8th-Layer-owned CloudFront distribution rather than
+upstream GitHub releases.
 
 This module is run in two different environments: under whatever Python
 Claude provides, and under the installer's uv-managed venv. It must
@@ -24,7 +28,10 @@ import urllib.request
 import zipfile
 from pathlib import Path
 
-REPO = "mozilla-ai/cq"
+# Release host for the 8th-Layer fork's cq binary. Assets live at
+# {CQ_RELEASE_BASE_URL}/cli/v{version}/cq_{OS}_{arch}.{ext}. CloudFront in
+# front of a private S3 bucket (OAC); unauthenticated HTTPS GET.
+CQ_RELEASE_BASE_URL = "https://dyejnuj2nvzpy.cloudfront.net"
 
 
 def cq_binary_name() -> str:
@@ -61,7 +68,7 @@ def default_data_home() -> Path:
 
 
 def download(version: str, system: str, bin_dir: Path, binary: Path) -> None:
-    """Fetch the cq binary from GitHub releases for the current platform."""
+    """Fetch the cq binary from the 8th-Layer release host for this platform."""
     machine = platform.machine()
     arch_map: dict[str, str] = {
         "AMD64": "x86_64",
@@ -81,13 +88,8 @@ def download(version: str, system: str, bin_dir: Path, binary: Path) -> None:
         print(f"Error: unsupported OS: {system}", file=sys.stderr)
         sys.exit(1)
 
-    tag = f"cli/v{version}"
-    asset_base = f"cq_{os_name}_{arch}"
-
-    if system == "Windows":
-        url = f"https://github.com/{REPO}/releases/download/{tag}/{asset_base}.zip"
-    else:
-        url = f"https://github.com/{REPO}/releases/download/{tag}/{asset_base}.tar.gz"
+    ext = "zip" if system == "Windows" else "tar.gz"
+    url = f"{CQ_RELEASE_BASE_URL}/cli/v{version}/cq_{os_name}_{arch}.{ext}"
 
     print(f"cq: downloading v{version} for {os_name}/{arch}...", file=sys.stderr)
 

--- a/plugins/cq/tests/test_cq_binary.py
+++ b/plugins/cq/tests/test_cq_binary.py
@@ -288,7 +288,7 @@ def test_download_constructs_correct_url_for_aarch64_on_linux(cq_binary, monkeyp
     with contextlib.suppress(TypeError):
         cq_binary.download("0.2.2", "Linux", bin_dir, binary)
 
-    assert captured_url == "https://github.com/mozilla-ai/cq/releases/download/cli/v0.2.2/cq_Linux_arm64.tar.gz"
+    assert captured_url == f"{cq_binary.CQ_RELEASE_BASE_URL}/cli/v0.2.2/cq_Linux_arm64.tar.gz"
 
 
 def test_download_constructs_correct_url_for_arm64_on_windows(cq_binary, monkeypatch, tmp_path):
@@ -311,4 +311,4 @@ def test_download_constructs_correct_url_for_arm64_on_windows(cq_binary, monkeyp
     with contextlib.suppress(TypeError):
         cq_binary.download("0.2.2", "Windows", bin_dir, binary)
 
-    assert captured_url == "https://github.com/mozilla-ai/cq/releases/download/cli/v0.2.2/cq_Windows_arm64.zip"
+    assert captured_url == f"{cq_binary.CQ_RELEASE_BASE_URL}/cli/v0.2.2/cq_Windows_arm64.zip"


### PR DESCRIPTION
PR #206 merged propose_batch + the /cq:reflect skill switch, but the fix never reached a running session: cq_binary.py downloads the cq binary from upstream mozilla-ai/cq GitHub releases, which has no propose_batch — so the merged Go code was dead and reflect still emitted a verbose per-KU propose echo.

This PR ships the fork's own cq binary from an 8th-Layer CloudFront release host (private S3 + OAC). cq_binary.py download() now points at CQ_RELEASE_BASE_URL; cli_min_version 0.5.0 -> 0.9.0; plugin 0.9.0 -> 0.10.0. Release steps in cli/RELEASING.md.

Infra: S3 8l-cli-releases-124074140789-us-east-1 (private, OAC), CloudFront E2KE74D3FCXBSX (dyejnuj2nvzpy.cloudfront.net). cq v0.9.0 binaries for Darwin/Linux/Windows x x86_64/arm64 uploaded under cli/v0.9.0/.

Verified: cli builds clean, propose_batch Go tests pass, cq_binary.py 30 tests pass, CloudFront serves all 6 assets (200), downloaded binary runs cq v0.9.0 and its MCP tools/list includes propose_batch.

After merge: republish plugin to 8th-layer-marketplace (0.10.0), verify reflect prints <=10 lines, close #190.