### PR TITLE
fix(consults): log proof when a cross-Enterprise forward fires (8th-layer#36)

### DIFF
--- a/server/backend/src/cq_server/consults.py
+++ b/server/backend/src/cq_server/consults.py
@@ -249,6 +249,15 @@ def _forward_request(target: dict[str, Any], payload: dict[str, Any]) -> None:
                 r.text[:200],
             )
             raise HTTPException(status_code=502, detail="peer unreachable")
+        # agent#36 — positive proof the cross-Enterprise forward fired.
+        # Without this, a missing peer reply is indistinguishable from a
+        # forward that never left this L2; the source-side log disambiguates.
+        logger.info(
+            "consults forward-request: peer=%s thread=%s status=%s — cross-Enterprise forward delivered",
+            target["l2_id"],
+            payload.get("thread_id", "?"),
+            r.status_code,
+        )
     except httpx.RequestError as e:
         logger.warning(
             "consults forward-request: peer=%s transport_error=%r",
@@ -285,6 +294,13 @@ def _forward_message(target: dict[str, Any], payload: dict[str, Any]) -> None:
                 r.text[:200],
             )
             raise HTTPException(status_code=502, detail="peer unreachable")
+        # agent#36 — positive proof the cross-Enterprise forward fired.
+        logger.info(
+            "consults forward-message: peer=%s thread=%s status=%s — cross-Enterprise forward delivered",
+            target["l2_id"],
+            payload.get("thread_id", "?"),
+            r.status_code,
+        )
     except httpx.RequestError as e:
         logger.warning(
             "consults forward-message: peer=%s transport_error=%r",
@@ -393,6 +409,17 @@ def _x_enterprise_forward_request(
                     f"on x-enterprise-forward-request: {r.text[:200]}"
                 ),
             )
+        # agent#36 — positive proof the cross-Enterprise forward fired.
+        # A missing peer reply downstream is then attributable to the peer
+        # side (no auto-reply handler, slow cron), not a forward that never
+        # left this L2.
+        logger.info(
+            "consults x-enterprise-forward-request: peer=%s thread=%s status=%s "
+            "— cross-Enterprise forward delivered",
+            target_endpoint["l2_id"],
+            payload.get("thread_id", "?"),
+            r.status_code,
+        )
     except httpx.RequestError as e:
         raise HTTPException(
             status_code=502,


### PR DESCRIPTION
Addresses **8th-layer#36** (the instrumentation half — operator picked option 2).

## Problem
The L2-to-L2 consult forward path logged **only on failure**. A successful forward was silent — so when a peer reply never arrived (Carmen's setup-skill smoke test, no reply after 90s), there was no source-side evidence to tell a *dropped forward* from a *slow/absent peer-side auto-responder*.

## Change
Add an `INFO` log on the **success** branch of all three forward paths in `consults.py` — `_forward_request`, `_forward_message`, `_x_enterprise_forward_request` — recording peer `l2_id`, `thread_id`, and peer status. The cross-Enterprise path (`_x_enterprise_forward_request`) is the one #36's reproducer actually exercises.

Now a missing peer reply is attributable: if `consults x-enterprise-forward-request: ... forward delivered` is in the source L2 log, the forward fired and the gap is peer-side.

Pairs with the setup-skill doc fix (8th-layer-directory PR, same issue) which demotes the peer auto-reply from a smoke-test gate to a bonus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)