### PR TITLE
fix(server): clear ruff drift breaking main's Server CI Lint

### DIFF
--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -44,11 +44,11 @@ from .quality import check_propose_quality
 from .reflect import router as reflect_router
 from .reputation_routes import router as reputation_router
 from .review import router as review_router
-from .tour_routes import router as tour_router
 from .scoring import apply_confirmation, apply_flag
 from .store import normalize_domains
 from .store._sqlite import SqliteStore
 from .theme_routes import router as theme_router
+from .tour_routes import router as tour_router
 
 _STATIC_DIR = Path(__file__).parent / "static"
 

--- a/server/backend/src/cq_server/consults.py
+++ b/server/backend/src/cq_server/consults.py
@@ -414,8 +414,7 @@ def _x_enterprise_forward_request(
         # side (no auto-reply handler, slow cron), not a forward that never
         # left this L2.
         logger.info(
-            "consults x-enterprise-forward-request: peer=%s thread=%s status=%s "
-            "— cross-Enterprise forward delivered",
+            "consults x-enterprise-forward-request: peer=%s thread=%s status=%s — cross-Enterprise forward delivered",
             target_endpoint["l2_id"],
             payload.get("thread_id", "?"),
             r.status_code,

--- a/server/backend/src/cq_server/tour_routes.py
+++ b/server/backend/src/cq_server/tour_routes.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import json
 import logging
 from datetime import UTC, datetime
-from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel


### PR DESCRIPTION
main's **Server CI / Lint** job has been red since ~2026-05-13 — surfaced repeatedly while reviewing the PR backlog today (every open PR's CI looked failed because of it, masking real signal).

Root cause: ruff drift in `server/backend/src/cq_server/`. Three trivial, behaviour-free fixes:

- `app.py` — import sort (`tour_router` moved into alphabetical order) [ruff I001]
- `tour_routes.py` — drop unused `from typing import Any` [ruff F401]
- `consults.py` — un-wrap an over-wrapped log string (format drift from #261)

After this, `ruff check src/` → "All checks passed!" and `ruff format --check src/` → "53 files already formatted". No logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)