### PR TITLE
test(server): fix 7 stale test failures surfaced by the CI migration

### DIFF
--- a/server/backend/tests/test_default_enterprise_backfill.py
+++ b/server/backend/tests/test_default_enterprise_backfill.py
@@ -407,6 +407,6 @@ class TestIdempotencyAndChain:
         ``run_migrations`` silently misses the new revision on stamped
         DBs. Pin the constant so the chain head is the source of truth.
         """
-        # Bumped to 0016_xgroup_consent (Phase 1.0b — Decision 28).
-        # Chains after 0015_phase_1_0c_aigrp_peers_pair_secret_ref.
-        assert HEAD_REVISION == "0023_persona_assignment_audit"
+        # The current chain head. Update this whenever a new migration
+        # lands — this test failing IS the reminder to bump HEAD_REVISION.
+        assert HEAD_REVISION == "0024_user_tour_state"

--- a/server/backend/tests/test_migration_0011_activity_log.py
+++ b/server/backend/tests/test_migration_0011_activity_log.py
@@ -473,13 +473,9 @@ class TestHeadRevisionAndHistory:
         is the source of truth for ops scripts and stamp logic."""
         from cq_server.migrations import HEAD_REVISION
 
-        # Bumped by 0016_xgroup_consent (Phase 1.0b — Decision 28
-        # intra-Enterprise xgroup_consent + AIGRP key protocols).
-        # Earlier bumps: 0015 (Phase 1.0c — Decision 27/28 audit gap),
-        # 0014 (#124 crosstalk tables), 0013 (#121 finding 3), 0012
-        # (#103), 0011 (#108 Stage 1). Each new migration MUST move
-        # this constant.
-        assert HEAD_REVISION == "0023_persona_assignment_audit"
+        # The current chain head. Each new migration MUST move this
+        # constant; this test failing is the reminder.
+        assert HEAD_REVISION == "0024_user_tour_state"
 
     @pytest.mark.parametrize("invalid_dir", [None])
     def test_alembic_history_includes_0011(self, invalid_dir: object) -> None:

--- a/server/backend/tests/test_migration_0015_aigrp_peers_pair_secret_ref.py
+++ b/server/backend/tests/test_migration_0015_aigrp_peers_pair_secret_ref.py
@@ -271,7 +271,7 @@ class TestHeadRevisionAndHistory:
     def test_head_revision_constant_was_bumped(self) -> None:
         from cq_server.migrations import HEAD_REVISION
 
-        assert HEAD_REVISION == "0023_persona_assignment_audit"
+        assert HEAD_REVISION == "0024_user_tour_state"
 
     def test_alembic_history_includes_0015(self) -> None:
         repo_root = Path(__file__).resolve().parents[1]

--- a/server/backend/tests/test_queries.py
+++ b/server/backend/tests/test_queries.py
@@ -590,19 +590,20 @@ class TestUserHelpers:
         with engine.begin() as conn:
             conn.execute(
                 q.INSERT_USER,
-                {"username": "bob", "password_hash": "hashed", "created_at": created_at},  # pragma: allowlist secret
+                {"username": "bob", "password_hash": "hashed", "role": "user", "created_at": created_at},  # pragma: allowlist secret
             )
         user_via_store = store.sync.get_user("bob")
         assert user_via_store is not None
         with engine.connect() as conn:
             row = conn.execute(q.SELECT_USER_BY_USERNAME, {"username": "bob"}).fetchone()
         assert row is not None
+        # SELECT_USER_BY_USERNAME column order: id, username, password_hash, role, created_at
         assert {
             "id": row[0],
             "username": row[1],
             "password_hash": row[2],
-            "created_at": row[3],
-            "role": "user",
+            "role": row[3],
+            "created_at": row[4],
             "enterprise_id": "default-enterprise",
             "group_id": "default-group",
         } == user_via_store
@@ -610,7 +611,7 @@ class TestUserHelpers:
     async def test_insert_user_duplicate_username_raises(self, db: tuple[SqliteStore, Engine]) -> None:
         """Pins the UNIQUE constraint on users.username."""
         _, engine = db
-        row = {"username": "duplicate", "password_hash": "h", "created_at": datetime.now(UTC).isoformat()}
+        row = {"username": "duplicate", "password_hash": "h", "role": "user", "created_at": datetime.now(UTC).isoformat()}
         with engine.begin() as conn:
             conn.execute(q.INSERT_USER, row)
         with pytest.raises(IntegrityError), engine.begin() as conn:

--- a/server/backend/tests/test_review.py
+++ b/server/backend/tests/test_review.py
@@ -270,6 +270,11 @@ class TestGetUnit:
 
     def test_get_requires_auth(self, client: TestClient) -> None:
         unit = _propose(client)
+        # _propose logs in, which persists the cq_session cookie in the
+        # TestClient jar; since cookie auth landed, that cookie would
+        # authenticate this request. Clear it to exercise the genuine
+        # unauthenticated path.
+        client.cookies.clear()
         resp = client.get(f"/review/{unit['id']}")
         assert resp.status_code == 401
 


### PR DESCRIPTION
The new `8th-layer-agent-ci` CodeBuild gate (#168) made `main`'s already-red server test suite visible. All 7 failures were **stale tests, not product bugs** — the features shipped correctly; their tests weren't updated.

- **HEAD_REVISION pins (3 files)** — `test_default_enterprise_backfill`, `test_migration_0011_activity_log`, `test_migration_0015_*` each hardcode `assert HEAD_REVISION == "0023_persona_assignment_audit"`. Migration `0024_user_tour_state` (founder tour, #254) correctly bumped the `HEAD_REVISION` constant; the test pins didn't follow. Bumped to `0024`, de-staled the comments.
- **`test_queries` TestUserHelpers (2)** — the raw `INSERT_USER` param dicts omitted `role` (the column the role-propagation fix #252/#253 added), and the `SELECT_USER_BY_USERNAME` row indices still assumed the pre-`role` column order. Added `role` to the dicts; fixed `row[3]`/`row[4]` indexing.
- **`test_review::test_get_requires_auth` (1)** — `_propose()` logs in, persisting the `cq_session` cookie in the TestClient jar. Since cookie auth landed, that cookie authenticates the "no header" request → 200. Clear the jar so the test exercises the genuine unauthenticated path → 401.

Test-only changes; no production code touched. Full server suite verified: **858 passed, 5 skipped, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)