### PR TITLE
feat(cq-server): first-boot password-admin bootstrap from SSM (agent#165)

### DIFF
--- a/deploy/aws/marketplace-l2.yaml
+++ b/deploy/aws/marketplace-l2.yaml
@@ -79,6 +79,13 @@ Parameters:
   AdminPasswordSsmParam:
     Type: String
     Default: ""
+    # Empty (disabled) or a leading-slash SSM parameter name. The
+    # leading slash is required: the exec-role policy builds the ARN as
+    # ":parameter${AdminPasswordSsmParam}", which is only well-formed
+    # when the name starts with "/". Reject a bad value at stack-create
+    # rather than failing opaquely at task start.
+    AllowedPattern: "^(/.*)?$"
+    ConstraintDescription: Must be empty or an SSM parameter name beginning with "/".
     Description: |
       Optional. Name of a pre-existing SSM SecureString parameter
       holding the initial admin password (e.g.

--- a/deploy/aws/marketplace-l2.yaml
+++ b/deploy/aws/marketplace-l2.yaml
@@ -76,6 +76,24 @@ Parameters:
       role. Carried in the stack for documentation/audit only — it is
       NOT used at runtime by any resource in this template.
 
+  AdminPasswordSsmParam:
+    Type: String
+    Default: ""
+    Description: |
+      Optional. Name of a pre-existing SSM SecureString parameter
+      holding the initial admin password (e.g.
+      "/8th-layer/<slug>/admin-password"). When set, cq-server seeds a
+      password-login `admin` user on first boot (agent#165) so an
+      operator can log in and mint an agent API key. Leave empty for the
+      marketplace self-service path — the founder gets in via the
+      CQ_INITIAL_ADMIN_EMAIL magic-link instead. The parameter must
+      exist before stack creation. An `alias/aws/ssm`-encrypted
+      parameter works as-is; a customer-managed-CMK-encrypted parameter
+      additionally needs a key grant for the task execution role.
+
+Conditions:
+  HasAdminPasswordParam: !Not [!Equals [!Ref AdminPasswordSsmParam, ""]]
+
 Resources:
   # =====================================================================
   # SECRETS — auto-generated, stored in Secrets Manager, mounted to the
@@ -296,6 +314,21 @@ Resources:
                   - !Ref JwtSecret
                   - !Ref ApiKeyPepper
                   - !Ref AigrpPeerKey
+        # agent#165 — only present when AdminPasswordSsmParam is set.
+        # Lets ECS resolve the CQ_INITIAL_ADMIN_PASSWORD SecureString at
+        # task start. ssm:GetParameters with WithDecryption suffices for
+        # an alias/aws/ssm-encrypted parameter; a customer CMK needs a
+        # separate key grant (called out on the parameter's Description).
+        - !If
+          - HasAdminPasswordParam
+          - PolicyName: AdminPasswordSsmRead
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: Allow
+                  Action: [ssm:GetParameters]
+                  Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${AdminPasswordSsmParam}"
+          - !Ref "AWS::NoValue"
 
   TaskRole:
     Type: AWS::IAM::Role
@@ -401,10 +434,24 @@ Resources:
             - { Name: CQ_DIRECTORY_PULL_INTERVAL_SEC, Value: "60" }
             - { Name: CQ_AIGRP_IS_FIRST_DEPLOY, Value: "true" }
             - { Name: CQ_AIGRP_SEED_PEER_URL, Value: "" }
+            # Plain (non-secret) — the SSM path is logged at first-boot
+            # bootstrap so operators can see where the seed came from.
+            # The password itself is mounted via Secrets below.
+            - !If
+              - HasAdminPasswordParam
+              - { Name: CQ_INITIAL_ADMIN_PASSWORD_SSM_PATH, Value: !Ref AdminPasswordSsmParam }
+              - !Ref "AWS::NoValue"
           Secrets:
             - { Name: CQ_JWT_SECRET,      ValueFrom: !Ref JwtSecret }
             - { Name: CQ_API_KEY_PEPPER,  ValueFrom: !Ref ApiKeyPepper }
             - { Name: CQ_AIGRP_PEER_KEY,  ValueFrom: !Ref AigrpPeerKey }
+            # agent#165 — first-boot password-admin seed. Only wired when
+            # AdminPasswordSsmParam is set; ECS resolves the SSM
+            # SecureString at task start into CQ_INITIAL_ADMIN_PASSWORD.
+            - !If
+              - HasAdminPasswordParam
+              - { Name: CQ_INITIAL_ADMIN_PASSWORD, ValueFrom: !Ref AdminPasswordSsmParam }
+              - !Ref "AWS::NoValue"
           # Container-level health check uses python (urllib) rather than
           # curl because the cq-server image (Python slim base) doesn't
           # ship curl/wget. The image already declares the same probe in

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -345,7 +345,10 @@ async def lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
     # passed via the CFN template. Mint a pending invite for that email
     # so the founder can claim → register passkey → land in admin UI.
     # Idempotent: skipped when any non-system user already exists.
-    from .bootstrap_admin import bootstrap_first_admin_if_needed
+    from .bootstrap_admin import (
+        bootstrap_first_admin_if_needed,
+        bootstrap_password_admin_if_needed,
+    )
 
     try:
         await bootstrap_first_admin_if_needed(_store)
@@ -354,6 +357,20 @@ async def lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
 
         _logging.getLogger("bootstrap_admin").exception(
             "bootstrap_first_admin_if_needed raised; continuing without first-admin invite"
+        )
+
+    # agent#165 — operator onboarding path. On a first boot with
+    # CQ_INITIAL_ADMIN_PASSWORD set (SSM-backed via the task def
+    # secrets: block), seed a password-login admin so the operator can
+    # log in + mint an agent API key. Idempotent: no-op once any user
+    # exists. Complementary to the email-invite path above.
+    try:
+        await bootstrap_password_admin_if_needed(_store)
+    except Exception:  # noqa: BLE001
+        import logging as _logging
+
+        _logging.getLogger("bootstrap_admin").exception(
+            "bootstrap_password_admin_if_needed raised; continuing without password admin"
         )
 
     # Provisioning crash recovery moved to 8th-layer-directory per

--- a/server/backend/src/cq_server/bootstrap_admin.py
+++ b/server/backend/src/cq_server/bootstrap_admin.py
@@ -131,15 +131,18 @@ async def bootstrap_password_admin_if_needed(store: SqliteStore) -> None:
     replaces the manual ``aws ecs execute-command`` + ``seed-users.py``
     dance that blocked smoke-check #5 during the TeamDW standup.
 
-    Distinct from :func:`bootstrap_first_admin_if_needed` (the founder
-    path, ``CQ_INITIAL_ADMIN_EMAIL`` → magic-link invite → passkey). The
-    two are complementary; an L2 may set either, both, or neither.
+    Alternative to :func:`bootstrap_first_admin_if_needed` (the founder
+    path, ``CQ_INITIAL_ADMIN_EMAIL`` → magic-link invite → passkey) — an
+    L2 should set one or the other. If both are set the email path wins
+    (it runs first; this function detects its ``_bootstrap_system``
+    marker row and defers), so an L2 never gets two admin principals.
 
-    Idempotency: skipped when any non-system user already exists OR when
-    ``CQ_INITIAL_ADMIN_PASSWORD`` is unset. The empty-users check means
-    that once any admin exists — including one rotated by a later manual
-    edit — re-deploying with the env still set is a no-op forever, so a
-    password rotation can never re-seed over a live admin.
+    Idempotency: skipped when ``CQ_INITIAL_ADMIN_PASSWORD`` is unset,
+    when any real (non-system) user already exists, OR when the email
+    path's ``_bootstrap_system`` row is present. Once a real admin
+    exists — including one rotated by a later manual edit — re-deploying
+    with the env still set is a no-op, so a password rotation can never
+    re-seed over a live admin.
 
     Never raises — boot must not fail because of a bootstrap hiccup.
     """
@@ -154,6 +157,21 @@ async def bootstrap_password_admin_if_needed(store: SqliteStore) -> None:
         if await _users_exist(store):
             log.debug("bootstrap_password_admin: skipped — users already present")
             return
+        # Mutual exclusion with the email/magic-link path. If
+        # bootstrap_first_admin_if_needed already ran it left the
+        # _bootstrap_system row behind (and a pending founder invite) —
+        # _users_exist excludes that row, so without this guard the
+        # password path would *also* seed an admin, leaving the L2 with
+        # two independent admin principals on one tenancy. The two
+        # bootstraps are alternatives, not complements: the email path
+        # ran first (app.py lifespan order), so it wins; defer to it.
+        if await _system_row_exists(store):
+            log.warning(
+                "[BOOTSTRAP_ADMIN] password-admin bootstrap skipped — the email "
+                "first-admin bootstrap already claimed this L2. Set only one of "
+                "CQ_INITIAL_ADMIN_EMAIL / CQ_INITIAL_ADMIN_PASSWORD."
+            )
+            return
     except Exception:  # noqa: BLE001
         log.exception("bootstrap_password_admin: user-count probe failed; skipping")
         return
@@ -161,10 +179,22 @@ async def bootstrap_password_admin_if_needed(store: SqliteStore) -> None:
     # Pin the admin to the L2's own tenancy. A user left on the
     # 'default-enterprise'/'default-group' server_default cannot transact
     # on the real tenancy — cross-Enterprise consults 403 with a
-    # forwarder mismatch (see scripts/seed-users.py). Only pin when both
-    # are set; otherwise fall back to the column defaults.
-    enterprise_id = os.environ.get("CQ_ENTERPRISE", "").strip() or None
-    group_id = os.environ.get("CQ_GROUP", "").strip() or None
+    # forwarder mismatch (see scripts/seed-users.py). Pin only when BOTH
+    # are set; a partial config falls back to defaults — warn so the
+    # operator notices the half-wired tenancy rather than discovering it
+    # via empty tenancy-scoped reads later.
+    ent_raw = os.environ.get("CQ_ENTERPRISE", "").strip()
+    grp_raw = os.environ.get("CQ_GROUP", "").strip()
+    if bool(ent_raw) != bool(grp_raw):
+        log.warning(
+            "[BOOTSTRAP_ADMIN] only one of CQ_ENTERPRISE/CQ_GROUP is set "
+            "(enterprise=%r group=%r); seeding admin on the default tenancy. "
+            "Set both or neither.",
+            ent_raw,
+            grp_raw,
+        )
+    enterprise_id: str | None = ent_raw or None
+    group_id: str | None = grp_raw or None
     if enterprise_id is None or group_id is None:
         enterprise_id = group_id = None
 
@@ -206,6 +236,29 @@ async def _users_exist(store: SqliteStore) -> bool:
         with store._engine.connect() as conn:  # noqa: SLF001
             row = conn.execute(
                 text("SELECT COUNT(*) FROM users WHERE username != :sys"),
+                {"sys": _SYSTEM_USERNAME},
+            ).first()
+            return int(row[0]) if row else 0
+
+    import asyncio
+
+    count = await asyncio.get_event_loop().run_in_executor(None, _count)
+    return count > 0
+
+
+async def _system_row_exists(store: SqliteStore) -> bool:
+    """Return True iff the ``_bootstrap_system`` marker row exists.
+
+    Its presence means :func:`bootstrap_first_admin_if_needed` already
+    ran on this L2 — used by the password path to defer to the email
+    path when both are configured.
+    """
+    from sqlalchemy import text
+
+    def _count() -> int:
+        with store._engine.connect() as conn:  # noqa: SLF001
+            row = conn.execute(
+                text("SELECT COUNT(*) FROM users WHERE username = :sys"),
                 {"sys": _SYSTEM_USERNAME},
             ).first()
             return int(row[0]) if row else 0

--- a/server/backend/src/cq_server/bootstrap_admin.py
+++ b/server/backend/src/cq_server/bootstrap_admin.py
@@ -116,6 +116,84 @@ async def bootstrap_first_admin_if_needed(store: SqliteStore) -> None:
     )
 
 
+_DEFAULT_ADMIN_USERNAME = "admin"
+
+
+async def bootstrap_password_admin_if_needed(store: SqliteStore) -> None:
+    """Seed a password-login admin on first boot from an SSM-backed env.
+
+    The operator onboarding path (agent#165): an operator sets an SSM
+    parameter holding the initial admin password *before* deploying the
+    L2 stack; the task definition mounts it as ``CQ_INITIAL_ADMIN_PASSWORD``
+    via the ECS ``secrets:`` integration. On the very first boot — users
+    table empty — this seeds a real ``admin`` user with role=admin so the
+    operator can log in, mint an agent API key, and plant it. This
+    replaces the manual ``aws ecs execute-command`` + ``seed-users.py``
+    dance that blocked smoke-check #5 during the TeamDW standup.
+
+    Distinct from :func:`bootstrap_first_admin_if_needed` (the founder
+    path, ``CQ_INITIAL_ADMIN_EMAIL`` → magic-link invite → passkey). The
+    two are complementary; an L2 may set either, both, or neither.
+
+    Idempotency: skipped when any non-system user already exists OR when
+    ``CQ_INITIAL_ADMIN_PASSWORD`` is unset. The empty-users check means
+    that once any admin exists — including one rotated by a later manual
+    edit — re-deploying with the env still set is a no-op forever, so a
+    password rotation can never re-seed over a live admin.
+
+    Never raises — boot must not fail because of a bootstrap hiccup.
+    """
+    password = os.environ.get("CQ_INITIAL_ADMIN_PASSWORD", "")
+    if not password:
+        return
+    username = os.environ.get("CQ_INITIAL_ADMIN_USERNAME", "").strip() or _DEFAULT_ADMIN_USERNAME
+    # Informational only — the SSM path, never the password, is logged.
+    ssm_path = os.environ.get("CQ_INITIAL_ADMIN_PASSWORD_SSM_PATH", "").strip()
+
+    try:
+        if await _users_exist(store):
+            log.debug("bootstrap_password_admin: skipped — users already present")
+            return
+    except Exception:  # noqa: BLE001
+        log.exception("bootstrap_password_admin: user-count probe failed; skipping")
+        return
+
+    # Pin the admin to the L2's own tenancy. A user left on the
+    # 'default-enterprise'/'default-group' server_default cannot transact
+    # on the real tenancy — cross-Enterprise consults 403 with a
+    # forwarder mismatch (see scripts/seed-users.py). Only pin when both
+    # are set; otherwise fall back to the column defaults.
+    enterprise_id = os.environ.get("CQ_ENTERPRISE", "").strip() or None
+    group_id = os.environ.get("CQ_GROUP", "").strip() or None
+    if enterprise_id is None or group_id is None:
+        enterprise_id = group_id = None
+
+    from .auth import hash_password
+
+    try:
+        await store.create_user(
+            username=username,
+            password_hash=hash_password(password),
+            role="admin",
+            enterprise_id=enterprise_id,
+            group_id=group_id,
+        )
+    except Exception:  # noqa: BLE001
+        log.exception("bootstrap_password_admin: admin user creation failed; skipping")
+        return
+
+    # Bracketed sentinel — greppable in CloudWatch Logs Insights.
+    # The password is NEVER logged; only the SSM path it came from.
+    source = f"SSM {ssm_path}" if ssm_path else "CQ_INITIAL_ADMIN_PASSWORD env"
+    log.warning(
+        "[BOOTSTRAP_ADMIN] admin user '%s' (role=admin, enterprise=%s, group=%s) seeded from %s",
+        username,
+        enterprise_id or "default-enterprise",
+        group_id or "default-group",
+        source,
+    )
+
+
 async def _users_exist(store: SqliteStore) -> bool:
     """Return True iff at least one row in users (excluding the system row).
 

--- a/server/backend/src/cq_server/store/_queries.py
+++ b/server/backend/src/cq_server/store/_queries.py
@@ -229,6 +229,16 @@ INSERT_USER: TextClause = text(
     "VALUES (:username, :password_hash, :role, :created_at)"
 )
 
+# Like INSERT_USER but pins enterprise_id / group_id explicitly instead
+# of letting the column server_default ('default-enterprise' /
+# 'default-group') apply. Required for any user that must transact on a
+# real tenancy — a user left on the defaults breaks cross-Enterprise
+# consults (the forwarder-mismatch 403 described in scripts/seed-users.py).
+INSERT_USER_WITH_TENANCY: TextClause = text(
+    "INSERT INTO users (username, password_hash, role, created_at, enterprise_id, group_id) "
+    "VALUES (:username, :password_hash, :role, :created_at, :enterprise_id, :group_id)"
+)
+
 SELECT_USER_BY_USERNAME: TextClause = text(
     "SELECT id, username, password_hash, role, created_at FROM users WHERE username = :username"
 )

--- a/server/backend/src/cq_server/store/_sqlite.py
+++ b/server/backend/src/cq_server/store/_sqlite.py
@@ -191,8 +191,23 @@ class SqliteStore:
             expires_at=expires_at,
         )
 
-    async def create_user(self, username: str, password_hash: str, role: str = "user") -> None:
-        await self._run_sync(self._create_user_sync, username, password_hash, role)
+    async def create_user(
+        self,
+        username: str,
+        password_hash: str,
+        role: str = "user",
+        *,
+        enterprise_id: str | None = None,
+        group_id: str | None = None,
+    ) -> None:
+        await self._run_sync(
+            self._create_user_sync,
+            username,
+            password_hash,
+            role,
+            enterprise_id,
+            group_id,
+        )
 
     # --- WebAuthn / passkey credentials (FO-1a, #191) ---------------------
 
@@ -1580,21 +1595,34 @@ class SqliteStore:
             "revoked_at": None,
         }
 
-    def _create_user_sync(self, username: str, password_hash: str, role: str = "user") -> None:
-        from ._queries import INSERT_USER
+    def _create_user_sync(
+        self,
+        username: str,
+        password_hash: str,
+        role: str = "user",
+        enterprise_id: str | None = None,
+        group_id: str | None = None,
+    ) -> None:
+        from ._queries import INSERT_USER, INSERT_USER_WITH_TENANCY
 
         created_at = datetime.now(UTC).isoformat()
+        params: dict[str, str] = {
+            "username": username,
+            "password_hash": password_hash,
+            "role": role,
+            "created_at": created_at,
+        }
+        # Pin tenancy explicitly only when the caller supplies it;
+        # otherwise the column server_default applies (legacy behaviour).
+        if enterprise_id is not None and group_id is not None:
+            query = INSERT_USER_WITH_TENANCY
+            params["enterprise_id"] = enterprise_id
+            params["group_id"] = group_id
+        else:
+            query = INSERT_USER
         try:
             with self._engine.begin() as conn:
-                conn.execute(
-                    INSERT_USER,
-                    {
-                        "username": username,
-                        "password_hash": password_hash,
-                        "role": role,
-                        "created_at": created_at,
-                    },
-                )
+                conn.execute(query, params)
         except IntegrityError as e:
             if e.orig is not None:
                 raise e.orig from e

--- a/server/backend/tests/test_bootstrap_admin.py
+++ b/server/backend/tests/test_bootstrap_admin.py
@@ -20,7 +20,10 @@ import pytest
 from sqlalchemy import text
 
 from cq_server.auth import hash_password, verify_password
-from cq_server.bootstrap_admin import bootstrap_password_admin_if_needed
+from cq_server.bootstrap_admin import (
+    _SYSTEM_USERNAME,
+    bootstrap_password_admin_if_needed,
+)
 from cq_server.store import SqliteStore
 
 
@@ -90,6 +93,21 @@ async def test_idempotent_when_user_already_exists(
     assert _user_row(store, "admin") is None, "must not seed over an existing user base"
     founder = _user_row(store, "founder")
     assert founder is not None and verify_password("orig-pw", founder[0])
+
+
+async def test_defers_to_email_path_when_system_row_present(
+    store: SqliteStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Simulate bootstrap_first_admin_if_needed having already run: it
+    # leaves the _bootstrap_system marker row (and a pending invite) but
+    # no real user. The password path must NOT also seed an admin —
+    # otherwise the L2 ends up with two admin principals.
+    await store.create_user(_SYSTEM_USERNAME, hash_password("!disabled!"))
+    monkeypatch.setenv("CQ_INITIAL_ADMIN_PASSWORD", "would-be-second-admin")
+
+    await bootstrap_password_admin_if_needed(store)
+
+    assert _user_row(store, "admin") is None, "must defer to the email bootstrap path"
 
 
 async def test_honours_custom_username(

--- a/server/backend/tests/test_bootstrap_admin.py
+++ b/server/backend/tests/test_bootstrap_admin.py
@@ -1,0 +1,110 @@
+"""Tests for the password-login admin bootstrap (agent#165).
+
+Covers ``bootstrap_password_admin_if_needed``:
+
+* seeds an admin when CQ_INITIAL_ADMIN_PASSWORD is set and users empty
+* the seeded password actually verifies via the login hash check
+* tenancy (enterprise_id / group_id) is pinned from CQ_ENTERPRISE /
+  CQ_GROUP, not left on the column server_default
+* idempotent — a no-op once any non-system user exists
+* a no-op when CQ_INITIAL_ADMIN_PASSWORD is unset
+* honours CQ_INITIAL_ADMIN_USERNAME
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy import text
+
+from cq_server.auth import hash_password, verify_password
+from cq_server.bootstrap_admin import bootstrap_password_admin_if_needed
+from cq_server.store import SqliteStore
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> Iterator[SqliteStore]:
+    from cq_server.migrations import run_migrations
+
+    db = tmp_path / "bootstrap.db"
+    run_migrations(f"sqlite:///{db}")
+    s = SqliteStore(db_path=db)
+    yield s
+    s.close_sync()
+
+
+def _user_row(store: SqliteStore, username: str) -> tuple[str, str, str, str] | None:
+    """Return (password_hash, role, enterprise_id, group_id) or None."""
+    with store._engine.connect() as conn:  # noqa: SLF001
+        row = conn.execute(
+            text(
+                "SELECT password_hash, role, enterprise_id, group_id "
+                "FROM users WHERE username = :u"
+            ),
+            {"u": username},
+        ).fetchone()
+    return tuple(row) if row else None  # type: ignore[return-value]
+
+
+async def test_seeds_admin_when_password_set(
+    store: SqliteStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CQ_INITIAL_ADMIN_PASSWORD", "s3cret-bootstrap-pw")
+    monkeypatch.setenv("CQ_ENTERPRISE", "8th-layer-corp")
+    monkeypatch.setenv("CQ_GROUP", "engineering")
+    monkeypatch.delenv("CQ_INITIAL_ADMIN_USERNAME", raising=False)
+
+    await bootstrap_password_admin_if_needed(store)
+
+    row = _user_row(store, "admin")
+    assert row is not None, "admin user should have been seeded"
+    password_hash, role, enterprise_id, group_id = row
+    assert role == "admin"
+    assert verify_password("s3cret-bootstrap-pw", password_hash)
+    # Tenancy pinned to the L2's identity, not the default-* server_default.
+    assert enterprise_id == "8th-layer-corp"
+    assert group_id == "engineering"
+
+
+async def test_noop_when_password_unset(
+    store: SqliteStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("CQ_INITIAL_ADMIN_PASSWORD", raising=False)
+
+    await bootstrap_password_admin_if_needed(store)
+
+    assert _user_row(store, "admin") is None
+
+
+async def test_idempotent_when_user_already_exists(
+    store: SqliteStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A pre-existing operator-created user — bootstrap must not run.
+    await store.create_user("founder", hash_password("orig-pw"), role="admin")
+    monkeypatch.setenv("CQ_INITIAL_ADMIN_PASSWORD", "would-be-new-pw")
+
+    await bootstrap_password_admin_if_needed(store)
+
+    assert _user_row(store, "admin") is None, "must not seed over an existing user base"
+    founder = _user_row(store, "founder")
+    assert founder is not None and verify_password("orig-pw", founder[0])
+
+
+async def test_honours_custom_username(
+    store: SqliteStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CQ_INITIAL_ADMIN_PASSWORD", "pw-123456")
+    monkeypatch.setenv("CQ_INITIAL_ADMIN_USERNAME", "operator")
+    monkeypatch.delenv("CQ_ENTERPRISE", raising=False)
+    monkeypatch.delenv("CQ_GROUP", raising=False)
+
+    await bootstrap_password_admin_if_needed(store)
+
+    assert _user_row(store, "admin") is None
+    row = _user_row(store, "operator")
+    assert row is not None and row[1] == "admin"
+    # Tenancy env unset → fall back to the column server_default.
+    assert row[2] == "default-enterprise"
+    assert row[3] == "default-group"


### PR DESCRIPTION
## Summary

Fresh L2 stacks ship with an empty `users` table. Onboarding required
an operator to `aws ecs execute-command` into the task, run
`seed-users.py`, and stash the printed password by hand — the friction
the setup-skill audit flagged, and what blocked smoke-check #5 during
the TeamDW standup (no admin to log in as; minting needs login).

cq-server now self-seeds a **password-login admin** on first boot.

## What changed

- **`bootstrap_password_admin_if_needed`** (`bootstrap_admin.py`) — when
  `CQ_INITIAL_ADMIN_PASSWORD` is set and the users table is empty, seed
  an `admin` user with `role=admin`. Idempotent: once any non-system
  user exists it's a no-op forever, so re-deploying after a password
  rotation can never re-seed over a live admin. Wired into the lifespan
  next to the existing email-invite bootstrap (#218) — the two are
  complementary: **operator path** (password → login → mint API key)
  vs **founder path** (`CQ_INITIAL_ADMIN_EMAIL` → magic-link → passkey).
- **Tenancy pinning** — the admin is created with `enterprise_id` /
  `group_id` from `CQ_ENTERPRISE` / `CQ_GROUP`, not the
  `default-enterprise`/`default-group` server_default. A user left on
  the defaults can't transact on the real tenancy (cross-Enterprise
  consults 403 with a forwarder mismatch). `store.create_user` gains
  optional `enterprise_id`/`group_id` kwargs + `INSERT_USER_WITH_TENANCY`;
  legacy callers are unchanged (defaults still apply).
- **`marketplace-l2.yaml`** — optional `AdminPasswordSsmParam` parameter.
  When set, ECS resolves the SSM SecureString into
  `CQ_INITIAL_ADMIN_PASSWORD` via the task-def `secrets:` block; the task
  execution role gains a conditional `ssm:GetParameters` policy. Empty
  default → fully no-op (marketplace self-service keeps the magic-link).
- The bootstrap logs the **SSM path only, never the password**
  (`[BOOTSTRAP_ADMIN]` sentinel, greppable in CloudWatch).

## Operator workflow

1. Put the initial password in an SSM SecureString param before deploy.
2. Deploy the stack with `AdminPasswordSsmParam` set to that path.
3. First boot seeds `admin`; operator logs in, mints an agent API key,
   plants it under `/8th-layer/<aaisn>/admin-api-key`.

## Test plan

- [x] `tests/test_bootstrap_admin.py` — seed / idempotency / unset env /
  custom username / tenancy pinning + default fallback
- [x] Full backend suite: **862 passed, 5 skipped**
- [x] `aws cloudformation validate-template` on the edited template
- [x] `ruff check` clean on all changed files

## Notes

- Relates to #166 (`/auth/login` 504 on empty users table): first-boot
  bootstrap shrinks the trigger surface, but #166's defensive fix is
  independent and still wanted.
- `docs/marketplace-l2.yaml` is a separate, already-divergent copy —
  left untouched; `deploy/aws/marketplace-l2.yaml` is the deploy artifact.

Closes #165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)