### PR TITLE
test(auth): pin agent#166 — login on empty users table returns fast 401

### DIFF
--- a/server/backend/tests/test_auth.py
+++ b/server/backend/tests/test_auth.py
@@ -95,6 +95,24 @@ class TestLoginEndpoint:
         resp = client.post("/auth/login", json={"username": "nobody", "password": self.test_password})
         assert resp.status_code == 401
 
+    def test_login_empty_users_table_returns_401_fast(self, client: TestClient) -> None:
+        """agent#166 regression: login against a completely empty users
+        table must return a prompt 401, never hang into a 504.
+
+        The ``client`` fixture seeds no users, so the table is genuinely
+        empty here. The handler's ``user is None`` short-circuit returns
+        before ``verify_password`` is ever reached. If this regresses
+        into a hang the TestClient call blocks and CI flags the timeout;
+        the elapsed-time assertion is a generous belt-and-braces guard.
+        """
+        import time as _time
+
+        t0 = _time.monotonic()
+        resp = client.post("/auth/login", json={"username": "admin", "password": "anything"})
+        elapsed = _time.monotonic() - t0
+        assert resp.status_code == 401
+        assert elapsed < 5.0, f"login on empty users table took {elapsed:.1f}s — agent#166 regression"
+
 
 class TestAuthMe:
     test_password = "secret123"  # pragma: allowlist secret


### PR DESCRIPTION
## Summary

agent#166 reported `POST /api/v1/auth/login` 504-hanging when the
`users` table is empty — filed 2026-05-09 against the
`phase18-crosstalk` image.

**Not reproducible on current `main`.** Verified three ways:

1. `test_login_unknown_user` already posts a login against the
   unseeded (empty) users table — the suite is green.
2. Live probe against the engineering L2: `POST /auth/login` with an
   unknown user → **HTTP 401 in 0.35s**.
3. Code path: the handler's `user is None` short-circuit returns a 401
   before `verify_password` is ever reached; `get_user` is a plain
   indexed `SELECT … WHERE username = :u` that returns `None`
   instantly on an empty table. There is no hang path.

The auth handler was reworked after the issue was filed
(#251 / #252 / #253), and `#165` (just merged) removes the
empty-users state in normal operation anyway. Whatever produced the
original 504 on `phase18-crosstalk` is gone.

## Change

Adds `test_login_empty_users_table_returns_401_fast` — an explicit
regression test for the exact agent#166 scenario (a genuinely empty
users table, distinct from "unknown user on a populated table"), with
a generous elapsed-time guard so any future hang fails fast and loud.

## Test plan

- [x] `tests/test_auth.py` — 30 passed
- [x] `ruff check` clean

Closes #166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)