### PR TITLE
fix(consult-open): stale crosstalk-enterprise repo URL → 8th-layer-core

### DIFF
--- a/plugins/cq/commands/consult-open.md
+++ b/plugins/cq/commands/consult-open.md
@@ -35,7 +35,7 @@ respond:
 
 > `CQ_ADDR` and/or `CQ_API_KEY` not set. See the runbook step 9
 > (configure your Claude Code session) at
-> https://github.com/OneZero1ai/crosstalk-enterprise/blob/main/docs/runbooks/01-customer-onboarding-zero-to-peered.md
+> https://github.com/OneZero1ai/8th-layer-core/blob/main/docs/runbooks/01-customer-onboarding-zero-to-peered.md
 
 …and stop.
 


### PR DESCRIPTION
Q7 / agent#164. The `consult-open` command's "CQ_ADDR/CQ_API_KEY not set" callout linked `OneZero1ai/crosstalk-enterprise` — renamed to `8th-layer-core`. Target runbook verified to still resolve at the new path.

Closes #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)