### PR TITLE
feat(deploy): AutoApprovePropose CFN parameter (agent#180)

### DIFF
--- a/deploy/aws/marketplace-l2.yaml
+++ b/deploy/aws/marketplace-l2.yaml
@@ -98,8 +98,22 @@ Parameters:
       parameter works as-is; a customer-managed-CMK-encrypted parameter
       additionally needs a key grant for the task execution role.
 
+  AutoApprovePropose:
+    Type: String
+    Default: "false"
+    AllowedValues: ["true", "false"]
+    Description: |
+      When "true", cq-server auto-approves VIBE-clean KUs at propose
+      time (sets `CQ_AUTO_APPROVE_PROPOSE`) so they are immediately
+      queryable without a manual review step (agent#180 / #123).
+      Recommended for solo-operator / single-L2 deployments. Leave
+      "false" for multi-operator deployments where the review-queue
+      ritual applies. Hard-finding KUs always route through the
+      pending_review tier regardless of this flag.
+
 Conditions:
   HasAdminPasswordParam: !Not [!Equals [!Ref AdminPasswordSsmParam, ""]]
+  AutoApproveOn: !Equals [!Ref AutoApprovePropose, "true"]
 
 Resources:
   # =====================================================================
@@ -441,6 +455,12 @@ Resources:
             - { Name: CQ_DIRECTORY_PULL_INTERVAL_SEC, Value: "60" }
             - { Name: CQ_AIGRP_IS_FIRST_DEPLOY, Value: "true" }
             - { Name: CQ_AIGRP_SEED_PEER_URL, Value: "" }
+            # agent#180 — only emitted when AutoApprovePropose=true, so a
+            # default deploy leaves the env unset (status='pending').
+            - !If
+              - AutoApproveOn
+              - { Name: CQ_AUTO_APPROVE_PROPOSE, Value: "true" }
+              - !Ref "AWS::NoValue"
             # Plain (non-secret) — the SSM path is logged at first-boot
             # bootstrap so operators can see where the seed came from.
             # The password itself is mounted via Secrets below.


### PR DESCRIPTION
## Summary

Q9 / agent#180 — "stand up the auto-approve worker for 8th-layer-corp/{engineering,sga}".

**There is no worker any more.** The team-dw-era `team-dw-l2-cq-auto-approve` ECS service was superseded by an in-process flag — `CQ_AUTO_APPROVE_PROPOSE` (#123): when set, `propose_unit` auto-approves VIBE-clean KUs inline (hard-finding KUs still route through `pending_review`). So the agent#180 gap is purely **deployment wiring**, not a service to stand up.

This adds option (a): an optional `AutoApprovePropose` parameter (`true`/`false`, default `false`) to `marketplace-l2.yaml`. When `true`, the container gets `CQ_AUTO_APPROVE_PROPOSE=true` via an `!If`/`AWS::NoValue` conditional — default deploys are unchanged (KUs land `pending`). Mirrors the `AdminPasswordSsmParam` conditional-env pattern from #271.

## Not in this PR

Flipping auto-approve **on for the live `engineering` + `sga` stacks** is a separate deploy action (update the running task definitions / stack params + redeploy) — left to the operator / setup-skill, since it modifies live L2 infrastructure. See the issue comment for the exact step.

## Test plan

- [x] `aws cloudformation validate-template` — `AutoApprovePropose` recognised

🤖 Generated with [Claude Code](https://claude.com/claude-code)