### PR TITLE
ci: multi-arch cq-server image buildspec (agent#245)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,20 @@ Use descriptive branch names with one of these prefixes:
 - Write clear commit messages that explain *why* the change was made, not just *what* changed.
 - Keep commits atomic; each commit should represent one logical change.
 
+### Container images — do not hand-push
+
+Do **not** run `docker push` for `cq-server` (or any `public.ecr.aws/w2i0e4m6/*`
+image) from a workstation. The CodeBuild `cq-server-image` project
+(`ci/buildspecs/cq-server-image.yml`) builds and pushes a multi-arch
+(`linux/amd64` + `linux/arm64`) image index on every merge to `main`.
+
+A manual `docker push` from Apple Silicon without `--platform` produces an
+**arm64-only** manifest. Fargate is x86_64-only, so the next provisioning
+deploy then fails with `CannotPullContainerError ... does not contain
+descriptor matching platform 'linux/amd64'`. If you must build an image
+locally for testing, always pass `--platform linux/amd64` and push it under
+a throwaway tag — never `:latest`.
+
 ## Submitting Your Contribution
 
 1. Fork the repository and clone your fork.

--- a/ci/buildspecs/cq-server-image.yml
+++ b/ci/buildspecs/cq-server-image.yml
@@ -1,0 +1,81 @@
+version: 0.2
+
+# Build + push the cq-server container image, multi-arch, to ECR Public.
+# Runs in AWS CodeBuild — project `cq-server-image` (to be created),
+# account 124074140789, us-east-1.
+#
+# Trigger: push to `main`, via the `8th-layer-github` CodeConnections
+# webhook. Manual run:
+#   aws codebuild start-build --project-name cq-server-image \
+#     --profile 8th-layer-app --region us-east-1
+#
+# Why this exists (agent#245): `cq-server:latest` once drifted to an
+# arm64-only manifest because someone ran `docker push` from Apple
+# Silicon without `--platform`. Fargate is x86_64-only, so the next
+# provisioning smoke failed with `CannotPullContainerError ... does not
+# contain descriptor matching platform 'linux/amd64'`. This buildspec
+# makes every `main` build a reproducible linux/amd64 + linux/arm64
+# image index — no more hand-pushes, no more drift.
+#
+# The CodeBuild project MUST set `privilegedMode: true` — `docker buildx`
+# needs it both for the builder daemon and for the QEMU binfmt register
+# step that enables cross-arch builds.
+
+env:
+  variables:
+    IMAGE_REPO: public.ecr.aws/w2i0e4m6/cq-server
+    PLATFORMS: linux/amd64,linux/arm64
+    AWS_REGION: us-east-1
+
+phases:
+  pre_build:
+    commands:
+      - |
+        set -euo pipefail
+        # ECR Public login (registry-wide; the token is us-east-1 only).
+        aws ecr-public get-login-password --region us-east-1 \
+          | docker login --username AWS --password-stdin public.ecr.aws
+
+        # Register QEMU emulators so the non-native arch can be built.
+        docker run --rm --privileged tonistiigi/binfmt --install all
+
+        # A buildx builder backed by docker-container is required for
+        # multi-platform output (the default "docker" driver can't).
+        docker buildx create --name cqbuilder --driver docker-container --use
+        docker buildx inspect --bootstrap
+
+        SHA="git-$(echo "${CODEBUILD_RESOLVED_SOURCE_VERSION}" | cut -c1-12)"
+        echo "Tags — ${IMAGE_REPO}:latest and ${IMAGE_REPO}:${SHA}"
+        echo "$SHA" > /tmp/image_sha_tag
+  build:
+    commands:
+      - |
+        set -euo pipefail
+        SHA="$(cat /tmp/image_sha_tag)"
+
+        # One buildx invocation emits a single multi-arch image index for
+        # both platforms and pushes it directly — `--push` is required
+        # because a multi-platform result cannot load into the local
+        # docker image store. The Dockerfile lives in server/, and its
+        # COPY --from=frontend stage needs server/ as the build context.
+        docker buildx build \
+          --platform "${PLATFORMS}" \
+          --file server/Dockerfile \
+          --tag "${IMAGE_REPO}:latest" \
+          --tag "${IMAGE_REPO}:${SHA}" \
+          --push \
+          server/
+  post_build:
+    commands:
+      - |
+        set -euo pipefail
+        SHA="$(cat /tmp/image_sha_tag)"
+        # Fail the build loudly if :latest somehow lacks linux/amd64 —
+        # that is the exact regression agent#245 tracks.
+        MANIFEST="$(docker buildx imagetools inspect "${IMAGE_REPO}:latest" 2>&1)"
+        echo "$MANIFEST"
+        echo "$MANIFEST" | grep -q 'linux/amd64' \
+          || { echo "ERROR: ${IMAGE_REPO}:latest has no linux/amd64 manifest"; exit 1; }
+        echo "$MANIFEST" | grep -q 'linux/arm64' \
+          || { echo "ERROR: ${IMAGE_REPO}:latest has no linux/arm64 manifest"; exit 1; }
+        echo "cq-server image pushed multi-arch — :latest and :${SHA}"


### PR DESCRIPTION
## Summary

Q10 / agent#245 — `cq-server:latest` drifted to an **arm64-only** manifest (hand-pushed from Apple Silicon without `--platform`); the next Fargate provisioning smoke failed `CannotPullContainerError ... does not contain descriptor matching platform 'linux/amd64'`. Root cause: **there was no CI building the cq-server image** — `:latest` was whatever someone last pushed locally.

## Change

- **`ci/buildspecs/cq-server-image.yml`** — CodeBuild buildspec: on every push to `main`, `docker buildx build --platform linux/amd64,linux/arm64` (QEMU binfmt registered in `pre_build`), push a single multi-arch image index to ECR Public as `:latest` + `:git-<sha>`. `post_build` **fails the build** if `:latest` is missing either platform manifest — the exact regression this tracks.
- **`CONTRIBUTING.md`** — a "do not hand-push container images" note explaining the arm64-only failure mode.

## Remaining — CodeBuild project standup (this issue stays open)

The buildspec needs a `cq-server-image` CodeBuild project to run it. Unlike the test-only `ci-plugin` project, it needs **`privilegedMode: true`** (for buildx + QEMU) and a service role with **ECR Public push** (`ecr-public:*` + `sts:GetServiceBearerToken`) — the same role shape as the `cq-directory-deploy` project. That's an infra standup left as the follow-up step; details on the issue.

## Test plan

- [x] Buildspec is valid YAML; `version: 0.2` schema
- [ ] Green once the CodeBuild project is created (operator step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)