### PR TITLE
feat(admin): FO-3 Phase 3 — Create-L2 wizard frontend (agent#193)

### DIFF
--- a/server/frontend/src/App.tsx
+++ b/server/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { AuthProvider, useAuth } from "./auth"
 import { Layout } from "./components/Layout"
 import { ProtectedRoute } from "./components/ProtectedRoute"
 import { ApiKeysPage } from "./pages/ApiKeysPage"
+import { CreateL2Page } from "./pages/CreateL2Page"
 import { CrosstalkPage } from "./pages/CrosstalkPage"
 import { DashboardPage } from "./pages/DashboardPage"
 import { InvitesPage } from "./pages/InvitesPage"
@@ -62,6 +63,7 @@ function AppRoutes() {
         <Route path="/settings/api-keys" element={<ApiKeysPage />} />
         <Route path="/admin/personas" element={<PersonasPage />} />
         <Route path="/admin/invites" element={<InvitesPage />} />
+        <Route path="/admin/l2s/new" element={<CreateL2Page />} />
       </Route>
       <Route path="*" element={<Navigate to="/review" replace />} />
     </Routes>

--- a/server/frontend/src/api.ts
+++ b/server/frontend/src/api.ts
@@ -1,3 +1,4 @@
+import type { CreateL2Request, CreateL2Response } from "./l2wizard/types"
 import type {
   ActivityListResponse,
   ApiKeysList,
@@ -230,6 +231,42 @@ export const api = {
     request<ConsultMessagesResponse>(
       `/consults/${encodeURIComponent(threadId)}/messages`,
     ),
+
+  // FO-3 (agent#193 / Decision 32) — Create-L2 wizard.
+  //
+  // createL2 posts the wizard's {l2_slug, description, aws_region} to the
+  // cq-server L2-provision proxy (PR #292). The proxy resolves the caller's
+  // Enterprise + AWS binding server-side; the browser never sends those.
+  // The 202 response carries the SSE `stream_url` the progress step opens.
+  createL2: (body: CreateL2Request) =>
+    request<CreateL2Response>("/admin/l2s", {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+
+  // checkL2SlugAvailable does a debounced live availability probe for the
+  // wizard's name step. The cq-server proxy's slug-availability route is not
+  // part of PR #292 (the create call is the authoritative uniqueness check —
+  // it 409s L2_SLUG_TAKEN). Until a dedicated GET lands, a 404 (route absent)
+  // resolves to `unknown` so the UI falls back to client-side regex
+  // validation rather than hard-blocking the wizard. A 409 means taken; a
+  // 2xx body's `available` flag is honoured when the route does exist.
+  checkL2SlugAvailable: async (
+    slug: string,
+  ): Promise<"available" | "taken" | "unknown"> => {
+    try {
+      const resp = await request<{ available?: boolean }>(
+        `/admin/l2s/slug-available?slug=${encodeURIComponent(slug)}`,
+      )
+      if (resp && resp.available === false) return "taken"
+      return "available"
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) return "taken"
+      // 404 → route not deployed; anything else → treat as unknown so the
+      // wizard never hard-blocks on a probe that may not exist yet.
+      return "unknown"
+    }
+  },
 }
 
 export { ApiError }

--- a/server/frontend/src/components/Layout.tsx
+++ b/server/frontend/src/components/Layout.tsx
@@ -70,6 +70,7 @@ export function Layout() {
             {navLink("/federation", "Federation", "federation")}
             {navLink("/settings/api-keys", "API Keys", "api-keys")}
             {navLink("/admin/personas", "Personas", "personas")}
+            {navLink("/admin/l2s/new", "Add L2", "add-l2")}
           </div>
           <div className="flex items-center gap-4">
             <TourLauncher />

--- a/server/frontend/src/l2wizard/KeyRevealPanel.test.tsx
+++ b/server/frontend/src/l2wizard/KeyRevealPanel.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * FO-3 Phase 3 — tests for `KeyRevealPanel` (agent#193).
+ *
+ * Covers the one-time key reveal: the key renders, copy-on-click uses the
+ * clipboard, the "Open L2 Admin" link is gated on acknowledgement, and the
+ * key is never written to localStorage / sessionStorage.
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { KeyRevealPanel } from "./KeyRevealPanel"
+
+const RESULT = {
+  l2_id: "acme/marketing",
+  l2_slug: "marketing",
+  admin_api_key: "cqa.v1.abcdef0123456789",
+  admin_url: "https://marketing.acme.8th-layer.ai/admin",
+  dns_name: "marketing.acme.8th-layer.ai",
+}
+
+const originalClipboard = navigator.clipboard
+
+beforeEach(() => {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+  })
+})
+
+afterEach(() => {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: originalClipboard,
+  })
+  localStorage.clear()
+  sessionStorage.clear()
+  vi.restoreAllMocks()
+})
+
+describe("KeyRevealPanel", () => {
+  it("renders the one-time admin API key", () => {
+    render(<KeyRevealPanel result={RESULT} />)
+    expect(screen.getByTestId("admin-api-key").textContent).toBe(
+      RESULT.admin_api_key,
+    )
+    expect(screen.getByText(/will not be shown again/i)).toBeInTheDocument()
+  })
+
+  it("copies the key to the clipboard on click", async () => {
+    render(<KeyRevealPanel result={RESULT} />)
+    fireEvent.click(screen.getByRole("button", { name: /copy/i }))
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      RESULT.admin_api_key,
+    )
+    expect(await screen.findByText(/copied/i)).toBeInTheDocument()
+  })
+
+  it("gates the Open L2 Admin link behind the acknowledgement checkbox", () => {
+    render(<KeyRevealPanel result={RESULT} />)
+    const link = screen.getByRole("link", { name: /open l2 admin/i })
+    expect(link).toHaveAttribute("aria-disabled", "true")
+
+    fireEvent.click(screen.getByRole("checkbox"))
+    expect(link).toHaveAttribute("aria-disabled", "false")
+    expect(link).toHaveAttribute("href", RESULT.admin_url)
+  })
+
+  it("never persists the key to web storage", () => {
+    render(<KeyRevealPanel result={RESULT} />)
+    fireEvent.click(screen.getByRole("button", { name: /copy/i }))
+    const haystack = [
+      ...Array.from({ length: localStorage.length }, (_, i) =>
+        localStorage.getItem(localStorage.key(i) ?? ""),
+      ),
+      ...Array.from({ length: sessionStorage.length }, (_, i) =>
+        sessionStorage.getItem(sessionStorage.key(i) ?? ""),
+      ),
+    ].join("|")
+    expect(haystack).not.toContain(RESULT.admin_api_key)
+  })
+
+  it("falls back to an email notice when no inline key is returned", () => {
+    render(<KeyRevealPanel result={{ admin_url: RESULT.admin_url }} />)
+    expect(screen.queryByTestId("admin-api-key")).not.toBeInTheDocument()
+    expect(
+      screen.getByText(/did not return an inline key/i),
+    ).toBeInTheDocument()
+  })
+})

--- a/server/frontend/src/l2wizard/KeyRevealPanel.tsx
+++ b/server/frontend/src/l2wizard/KeyRevealPanel.tsx
@@ -1,0 +1,125 @@
+/**
+ * FO-3 Phase 3 — `KeyRevealPanel` (agent#193 / Decision 32).
+ *
+ * The one-time admin-API-key reveal shown when an L2-create job reaches
+ * `COMPLETED`. The new L2's `cqa.v1.*` admin key arrives in the terminal SSE
+ * event's `result.admin_api_key` (PR #292) and is rendered here exactly once.
+ *
+ * Security posture (task brief):
+ *   - The key lives in React props/state only. It is NEVER written to
+ *     localStorage, sessionStorage, or the URL — the same XSS-leak surface
+ *     FO-1c closed for human session tokens.
+ *   - Copy-on-click puts the key on the clipboard; nothing else persists it.
+ *   - A "won't be shown again" warning + an acknowledgement checkbox gate
+ *     the "Open L2 Admin" follow-on, mirroring the ApiKeys mint modal.
+ *
+ * Decision 32 #2 also emails the key as a backup, so a user who navigates
+ * away without copying is not locked out — the panel says so explicitly.
+ */
+
+import { useState } from "react"
+import type { L2ProvisionResult } from "./types"
+
+interface KeyRevealPanelProps {
+  /** The job result from the terminal `completed` SSE event. */
+  result: L2ProvisionResult
+}
+
+export function KeyRevealPanel({ result }: KeyRevealPanelProps) {
+  const [copied, setCopied] = useState(false)
+  const [acknowledged, setAcknowledged] = useState(false)
+
+  const apiKey = result.admin_api_key ?? ""
+  const adminUrl = result.admin_url ?? ""
+  const dnsName = result.dns_name ?? ""
+
+  async function copyKey() {
+    if (!apiKey) return
+    try {
+      await navigator.clipboard.writeText(apiKey)
+      setCopied(true)
+    } catch {
+      // Clipboard denied (insecure context / permissions) — leave the key
+      // visible so the user can select it manually. No state change.
+    }
+  }
+
+  const primaryBtn =
+    "rounded-md bg-[color-mix(in_srgb,var(--brand-primary)_18%,transparent)] border border-[color-mix(in_srgb,var(--brand-primary)_45%,transparent)] px-4 py-2 font-mono-brand text-[11px] uppercase tracking-[0.2em] text-[var(--brand-primary)] hover:bg-[color-mix(in_srgb,var(--brand-primary)_28%,transparent)] disabled:opacity-50 transition-all"
+
+  return (
+    <section className="brand-surface-raised p-6" data-testid="key-reveal">
+      <p className="eyebrow text-[var(--emerald)]">L2 provisioned</p>
+      <h2 className="font-display text-xl text-[var(--ink)] mt-1">
+        Your new L2 is live
+      </h2>
+      <p className="mt-2 text-sm text-[var(--ink-dim)] leading-relaxed">
+        Copy the admin API key below now.{" "}
+        <strong className="text-[var(--ink)]">
+          It will not be shown again.
+        </strong>{" "}
+        A backup copy has also been emailed to the Enterprise admin.
+      </p>
+
+      {dnsName && (
+        <p className="mt-3 text-sm text-[var(--ink-mute)]">
+          Address:{" "}
+          <code className="font-mono-brand text-[var(--brand-primary)]">
+            {dnsName}
+          </code>
+        </p>
+      )}
+
+      {apiKey ? (
+        <div className="mt-4 flex items-center gap-2 rounded-lg bg-[var(--bg-via)] border border-[var(--rule-strong)] p-3">
+          <code
+            className="flex-1 break-all font-mono-brand text-sm text-[var(--brand-primary)]"
+            data-testid="admin-api-key"
+          >
+            {apiKey}
+          </code>
+          <button type="button" onClick={copyKey} className={primaryBtn}>
+            {copied ? "Copied" : "Copy"}
+          </button>
+        </div>
+      ) : (
+        <p className="mt-4 text-sm text-[var(--gold)]">
+          The provisioning service did not return an inline key. Check the
+          Enterprise admin email for the L2 admin key.
+        </p>
+      )}
+
+      <label className="mt-4 flex items-center gap-2 text-sm text-[var(--ink-dim)]">
+        <input
+          type="checkbox"
+          checked={acknowledged}
+          onChange={(e) => setAcknowledged(e.target.checked)}
+          className="accent-[var(--brand-primary)]"
+        />
+        I have copied the admin API key and saved it securely.
+      </label>
+
+      {adminUrl && (
+        <div className="mt-4">
+          <a
+            href={adminUrl}
+            aria-disabled={!acknowledged}
+            target="_blank"
+            rel="noreferrer"
+            className={`inline-block ${primaryBtn} ${
+              acknowledged ? "" : "pointer-events-none opacity-50"
+            }`}
+            onClick={(e) => {
+              // Gated on the acknowledgement checkbox — the href stays set so
+              // the element is a real link, but the navigation is suppressed
+              // until the user confirms they have saved the key.
+              if (!acknowledged) e.preventDefault()
+            }}
+          >
+            Open L2 Admin →
+          </a>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/server/frontend/src/l2wizard/PhaseProgressBar.test.tsx
+++ b/server/frontend/src/l2wizard/PhaseProgressBar.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * FO-3 Phase 3 — tests for `PhaseProgressBar` (agent#193).
+ */
+
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { PhaseProgressBar } from "./PhaseProgressBar"
+
+describe("PhaseProgressBar", () => {
+  it("derives fill width from the phase index when no progress_pct given", () => {
+    render(
+      <PhaseProgressBar
+        lifecycle="streaming"
+        phase={4}
+        phaseLabel={null}
+        progressPct={null}
+      />,
+    )
+    // 4 of 8 phases → 50%.
+    expect(screen.getByRole("progressbar")).toHaveAttribute(
+      "aria-valuenow",
+      "50",
+    )
+  })
+
+  it("prefers the server-reported progress_pct over the phase index", () => {
+    render(
+      <PhaseProgressBar
+        lifecycle="streaming"
+        phase={1}
+        phaseLabel="ACM certificate"
+        progressPct={73}
+      />,
+    )
+    expect(screen.getByRole("progressbar")).toHaveAttribute(
+      "aria-valuenow",
+      "73",
+    )
+  })
+
+  it("fills to 100% on completion regardless of phase", () => {
+    render(
+      <PhaseProgressBar
+        lifecycle="completed"
+        phase={3}
+        phaseLabel={null}
+        progressPct={null}
+      />,
+    )
+    expect(screen.getByRole("progressbar")).toHaveAttribute(
+      "aria-valuenow",
+      "100",
+    )
+    expect(screen.getByText(/provisioning complete/i)).toBeInTheDocument()
+  })
+
+  it("shows the failed state", () => {
+    render(
+      <PhaseProgressBar
+        lifecycle="failed"
+        phase={5}
+        phaseLabel={null}
+        progressPct={null}
+      />,
+    )
+    expect(screen.getByText(/provisioning failed/i)).toBeInTheDocument()
+  })
+
+  it("renders the live phase label for the active phase", () => {
+    render(
+      <PhaseProgressBar
+        lifecycle="streaming"
+        phase={2}
+        phaseLabel="Spinning up ECS"
+        progressPct={null}
+      />,
+    )
+    expect(screen.getByText("Spinning up ECS")).toBeInTheDocument()
+  })
+})

--- a/server/frontend/src/l2wizard/PhaseProgressBar.tsx
+++ b/server/frontend/src/l2wizard/PhaseProgressBar.tsx
@@ -1,0 +1,140 @@
+/**
+ * FO-3 Phase 3 — `PhaseProgressBar` (agent#193 / Decision 32).
+ *
+ * Renders the ~8-phase L2-standup progress for the wizard's progress step.
+ * The cq-server proxy reports a 1-based `phase` index, an optional
+ * `phase_label`, and an optional `progress_pct` per SSE `phase` event.
+ *
+ * Display rules:
+ *   - The fill width tracks `progressPct` when the proxy reports it; else it
+ *     is derived from `phase / totalPhases`.
+ *   - Each of the eight standup phases gets a tick: filled (done), active
+ *     (current), or pending. The active tick shows the live `phaseLabel`.
+ *   - `failed` tints the bar + the active tick rose; `completed` fills it.
+ *
+ * Visual style matches the admin shell's brand tokens (see ApiKeysPage).
+ */
+
+import { L2_STANDUP_PHASES, type L2ProvisioningPhase } from "./types"
+
+interface PhaseProgressBarProps {
+  /** Lifecycle flag from `useL2ProvisioningSSE`. */
+  lifecycle: L2ProvisioningPhase
+  /** 1-based current phase index from the proxy, or null before the first event. */
+  phase: number | null
+  /** Human-readable label for the current phase, or null. */
+  phaseLabel: string | null
+  /** Server-reported completion percentage 0–100, or null. */
+  progressPct: number | null
+}
+
+const TOTAL_PHASES = L2_STANDUP_PHASES.length
+
+/** Clamp a number into [0, 100]. */
+function clampPct(value: number): number {
+  return Math.max(0, Math.min(100, value))
+}
+
+export function PhaseProgressBar({
+  lifecycle,
+  phase,
+  phaseLabel,
+  progressPct,
+}: PhaseProgressBarProps) {
+  const failed = lifecycle === "failed"
+  const completed = lifecycle === "completed"
+
+  // Current 1-based phase (0 while still connecting). On completion, treat
+  // every phase as done regardless of the last reported index.
+  const currentPhase = completed ? TOTAL_PHASES : (phase ?? 0)
+
+  // Fill width: prefer the proxy's progress_pct; else derive from the phase
+  // index. Completion always fills to 100%.
+  let fillPct: number
+  if (completed) {
+    fillPct = 100
+  } else if (progressPct != null) {
+    fillPct = clampPct(progressPct)
+  } else {
+    fillPct = clampPct((currentPhase / TOTAL_PHASES) * 100)
+  }
+
+  const fillColor = failed
+    ? "var(--rose)"
+    : completed
+      ? "var(--emerald)"
+      : "var(--brand-primary)"
+
+  return (
+    <div className="space-y-4" data-testid="phase-progress">
+      <div className="flex items-center justify-between">
+        <span className="eyebrow">
+          {completed
+            ? "Provisioning complete"
+            : failed
+              ? "Provisioning failed"
+              : `Phase ${Math.max(currentPhase, 1)} of ${TOTAL_PHASES}`}
+        </span>
+        <span className="font-mono-brand text-[11px] text-[var(--ink-mute)]">
+          {Math.round(fillPct)}%
+        </span>
+      </div>
+
+      <div
+        className="h-2 w-full overflow-hidden rounded-full bg-[var(--surface-hover)]"
+        role="progressbar"
+        aria-valuenow={Math.round(fillPct)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label="L2 provisioning progress"
+      >
+        <div
+          className="h-full rounded-full transition-all duration-500"
+          style={{ width: `${fillPct}%`, backgroundColor: fillColor }}
+        />
+      </div>
+
+      <ol className="grid gap-1.5">
+        {L2_STANDUP_PHASES.map((label, idx) => {
+          const oneBased = idx + 1
+          const isDone = completed || oneBased < currentPhase
+          const isActive = !completed && !failed && oneBased === currentPhase
+          const isFailedHere = failed && oneBased === currentPhase
+
+          let dotClass =
+            "h-1.5 w-1.5 rounded-full bg-[var(--ink-faint)] shrink-0"
+          if (isDone) {
+            dotClass = "h-1.5 w-1.5 rounded-full bg-[var(--emerald)] shrink-0"
+          } else if (isActive) {
+            dotClass =
+              "h-1.5 w-1.5 rounded-full bg-[var(--brand-primary)] shrink-0 animate-pulse"
+          } else if (isFailedHere) {
+            dotClass = "h-1.5 w-1.5 rounded-full bg-[var(--rose)] shrink-0"
+          }
+
+          let textClass = "text-[var(--ink-faint)]"
+          if (isDone) textClass = "text-[var(--ink-dim)]"
+          else if (isActive) textClass = "text-[var(--ink)]"
+          else if (isFailedHere) textClass = "text-[var(--rose)]"
+
+          return (
+            <li
+              key={label}
+              className={`flex items-center gap-2 text-xs ${textClass}`}
+            >
+              <span aria-hidden="true" className={dotClass} />
+              <span>
+                {isActive && phaseLabel ? phaseLabel : label}
+                {isActive && (
+                  <span className="ml-2 font-mono-brand text-[10px] uppercase tracking-[0.16em] text-[var(--brand-primary)]">
+                    in progress
+                  </span>
+                )}
+              </span>
+            </li>
+          )
+        })}
+      </ol>
+    </div>
+  )
+}

--- a/server/frontend/src/l2wizard/types.ts
+++ b/server/frontend/src/l2wizard/types.ts
@@ -1,0 +1,110 @@
+/**
+ * FO-3 Phase 3 — Create-L2 wizard type contract (agent#193 / Decision 32).
+ *
+ * Mirrors the cq-server L2-provision proxy (PR #292 on OneZero1ai/8th-layer-agent):
+ *
+ *   POST /api/v1/admin/l2s
+ *     request  — {l2_slug, description, aws_region}
+ *     response — {job_id, l2_id, status, poll_url, stream_url}  (HTTP 202)
+ *
+ *   GET /api/v1/admin/l2s/jobs/{job_id}/stream  (text/event-stream)
+ *     Each SSE frame is a named event whose `data:` line carries a JSON
+ *     job-state object. Event names emitted by the proxy:
+ *       open       — {job_id, status: "STREAM_OPEN"}
+ *       phase      — {job_id, status, phase, phase_label, progress_pct}
+ *       heartbeat  — {job_id, note?} / {job_id, ts}
+ *       completed  — {job_id, status: "COMPLETED", result}
+ *       failed     — {job_id, status, error}
+ *
+ * The wizard never sends `enterprise_id` or AWS credentials — the proxy
+ * resolves the caller's Enterprise server-side from their session.
+ */
+
+/** POST /api/v1/admin/l2s request body. */
+export interface CreateL2Request {
+  l2_slug: string
+  description: string
+  aws_region: string
+}
+
+/** 202 response from POST /api/v1/admin/l2s. */
+export interface CreateL2Response {
+  job_id: string
+  l2_id: string
+  status: string
+  /** Enterprise-scoped plain-poll URL (the wizard uses `stream_url` instead). */
+  poll_url: string
+  /** SSE endpoint the wizard opens with a browser `EventSource`. */
+  stream_url: string
+}
+
+/**
+ * The job `result` carried by the terminal `completed` SSE event.
+ *
+ * Decision 32 #2: the new L2's `cqa.v1.*` admin key is shown once in the
+ * completion panel (and emailed as a backup). `admin_url` is the new L2's
+ * admin-shell URL for the "Open L2 Admin" link.
+ */
+export interface L2ProvisionResult {
+  l2_id?: string
+  l2_slug?: string
+  /** One-time admin API key — held in React state only, never persisted. */
+  admin_api_key?: string
+  /** Admin-shell URL of the freshly provisioned L2. */
+  admin_url?: string
+  dns_name?: string
+}
+
+/**
+ * Decoded job-state payload from any SSE frame. Every field is optional —
+ * which fields are present depends on the event name (see module docstring).
+ */
+export interface L2JobState {
+  job_id: string
+  /** STREAM_OPEN | PROVISIONING | COMPLETED | FAILED | STREAM_TIMEOUT. */
+  status?: string
+  /** Numeric phase index (1-based) of the ~8-phase standup. */
+  phase?: number | null
+  /** Human-readable phase label, e.g. "ACM certificate". */
+  phase_label?: string | null
+  /** Server-reported completion percentage, 0–100. */
+  progress_pct?: number | null
+  /** Present on the terminal `completed` event. */
+  result?: L2ProvisionResult | null
+  /** Present on the terminal `failed` event. */
+  error?: string | null
+  /** Soft-warning note on a `heartbeat` event after a transient poll error. */
+  note?: string | null
+}
+
+/** SSE event names the proxy emits (see PR #292 `_sse_event` calls). */
+export type L2SseEventName =
+  | "open"
+  | "phase"
+  | "heartbeat"
+  | "completed"
+  | "failed"
+
+/** Terminal lifecycle states for the wizard's progress step. */
+export type L2ProvisioningPhase =
+  | "connecting"
+  | "streaming"
+  | "completed"
+  | "failed"
+
+/**
+ * The ~8 standup phases (Decision 32 §Shape). Used to render the progress
+ * bar's phase ticks when the proxy has not yet reported a `phase_label`.
+ * The proxy's `phase` index is authoritative when present; this list is the
+ * static fallback labelling.
+ */
+export const L2_STANDUP_PHASES: readonly string[] = [
+  "ACM certificate",
+  "ECS cluster",
+  "Application Load Balancer",
+  "EFS file system",
+  "CloudFormation stack",
+  "SSM parameter seed",
+  "Directory record",
+  "Persona allowlist",
+] as const

--- a/server/frontend/src/l2wizard/useL2ProvisioningSSE.test.ts
+++ b/server/frontend/src/l2wizard/useL2ProvisioningSSE.test.ts
@@ -1,0 +1,194 @@
+/**
+ * FO-3 Phase 3 — tests for `useL2ProvisioningSSE` (agent#193).
+ *
+ * happy-dom ships no `EventSource`, so we install a controllable mock
+ * global: tests drive named SSE events into the hook and assert on the
+ * resulting job state, lifecycle phase, error, and connection close.
+ */
+
+import { act, renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { useL2ProvisioningSSE } from "./useL2ProvisioningSSE"
+
+// ---------------------------------------------------------------------------
+// Mock EventSource
+// ---------------------------------------------------------------------------
+
+type Listener = (e: { data: string }) => void
+
+class MockEventSource {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSED = 2
+  static instances: MockEventSource[] = []
+
+  url: string
+  withCredentials: boolean
+  readyState = MockEventSource.OPEN
+  onmessage: Listener | null = null
+  onerror: (() => void) | null = null
+  private listeners: Record<string, Listener[]> = {}
+
+  constructor(url: string, init?: { withCredentials?: boolean }) {
+    this.url = url
+    this.withCredentials = init?.withCredentials ?? false
+    MockEventSource.instances.push(this)
+  }
+
+  addEventListener(name: string, fn: Listener) {
+    const bucket = this.listeners[name] ?? []
+    bucket.push(fn)
+    this.listeners[name] = bucket
+  }
+
+  close() {
+    this.readyState = MockEventSource.CLOSED
+  }
+
+  /** Test helper — dispatch a named SSE event with a JSON payload. */
+  emit(name: string, data: unknown) {
+    const payload = { data: JSON.stringify(data) }
+    for (const fn of this.listeners[name] ?? []) fn(payload)
+  }
+
+  /** Test helper — fire a terminal connection error. */
+  fail() {
+    this.readyState = MockEventSource.CLOSED
+    this.onerror?.()
+  }
+}
+
+const STREAM_URL = "/api/v1/admin/l2s/jobs/job-1/stream"
+
+beforeEach(() => {
+  MockEventSource.instances = []
+  ;(globalThis as unknown as { EventSource: unknown }).EventSource =
+    MockEventSource
+})
+
+afterEach(() => {
+  ;(globalThis as unknown as { EventSource?: unknown }).EventSource = undefined
+})
+
+function lastSource(): MockEventSource {
+  const s = MockEventSource.instances.at(-1)
+  if (!s) throw new Error("no EventSource opened")
+  return s
+}
+
+describe("useL2ProvisioningSSE", () => {
+  it("stays idle with no streamUrl and opens no connection", () => {
+    const { result } = renderHook(() => useL2ProvisioningSSE(null))
+    expect(MockEventSource.instances).toHaveLength(0)
+    expect(result.current.phase).toBe("connecting")
+    expect(result.current.jobState).toBeNull()
+  })
+
+  it("opens a credentialed EventSource for a streamUrl", () => {
+    renderHook(() => useL2ProvisioningSSE(STREAM_URL))
+    expect(MockEventSource.instances).toHaveLength(1)
+    expect(lastSource().url).toBe(STREAM_URL)
+    expect(lastSource().withCredentials).toBe(true)
+  })
+
+  it("advances to streaming on a phase event and records job state", () => {
+    const { result } = renderHook(() => useL2ProvisioningSSE(STREAM_URL))
+    act(() => {
+      lastSource().emit("phase", {
+        job_id: "job-1",
+        status: "PROVISIONING",
+        phase: 2,
+        phase_label: "ECS cluster",
+        progress_pct: 40,
+      })
+    })
+    expect(result.current.phase).toBe("streaming")
+    expect(result.current.jobState?.phase).toBe(2)
+    expect(result.current.jobState?.phase_label).toBe("ECS cluster")
+  })
+
+  it("captures the result and closes on a completed event", () => {
+    const { result } = renderHook(() => useL2ProvisioningSSE(STREAM_URL))
+    const source = lastSource()
+    act(() => {
+      source.emit("completed", {
+        job_id: "job-1",
+        status: "COMPLETED",
+        result: { admin_api_key: "cqa.v1.secret", admin_url: "https://x" },
+      })
+    })
+    expect(result.current.phase).toBe("completed")
+    expect(result.current.jobState?.result?.admin_api_key).toBe("cqa.v1.secret")
+    expect(source.readyState).toBe(MockEventSource.CLOSED)
+  })
+
+  it("surfaces the error and closes on a failed event", () => {
+    const { result } = renderHook(() => useL2ProvisioningSSE(STREAM_URL))
+    const source = lastSource()
+    act(() => {
+      source.emit("failed", {
+        job_id: "job-1",
+        status: "FAILED",
+        error: "phase 5: CFN rollback",
+      })
+    })
+    expect(result.current.phase).toBe("failed")
+    expect(result.current.error).toBe("phase 5: CFN rollback")
+    expect(source.readyState).toBe(MockEventSource.CLOSED)
+  })
+
+  it("treats a heartbeat as keep-alive without regressing job state", () => {
+    const { result } = renderHook(() => useL2ProvisioningSSE(STREAM_URL))
+    act(() => {
+      lastSource().emit("phase", { job_id: "job-1", phase: 3 })
+    })
+    act(() => {
+      lastSource().emit("heartbeat", { job_id: "job-1", note: "poll retry" })
+    })
+    expect(result.current.phase).toBe("streaming")
+    expect(result.current.jobState?.phase).toBe(3)
+  })
+
+  it("ignores a malformed (non-JSON) frame", () => {
+    const { result } = renderHook(() => useL2ProvisioningSSE(STREAM_URL))
+    act(() => {
+      // Directly invoke a listener with junk — emit() always JSON-stringifies.
+      const source = lastSource()
+      source.onmessage?.({ data: "not json {{{" })
+    })
+    expect(result.current.jobState).toBeNull()
+  })
+
+  it("marks a permanently-closed connection as failed", () => {
+    const { result } = renderHook(() => useL2ProvisioningSSE(STREAM_URL))
+    act(() => {
+      lastSource().fail()
+    })
+    expect(result.current.phase).toBe("failed")
+    expect(result.current.error).toMatch(/interrupted/i)
+  })
+
+  it("does not overwrite a completed stream when the socket later closes", () => {
+    const { result } = renderHook(() => useL2ProvisioningSSE(STREAM_URL))
+    const source = lastSource()
+    act(() => {
+      source.emit("completed", {
+        job_id: "job-1",
+        status: "COMPLETED",
+        result: {},
+      })
+    })
+    act(() => {
+      source.onerror?.()
+    })
+    expect(result.current.phase).toBe("completed")
+  })
+
+  it("closes the connection on unmount", () => {
+    const { unmount } = renderHook(() => useL2ProvisioningSSE(STREAM_URL))
+    const source = lastSource()
+    expect(source.readyState).toBe(MockEventSource.OPEN)
+    unmount()
+    expect(source.readyState).toBe(MockEventSource.CLOSED)
+  })
+})

--- a/server/frontend/src/l2wizard/useL2ProvisioningSSE.ts
+++ b/server/frontend/src/l2wizard/useL2ProvisioningSSE.ts
@@ -1,0 +1,154 @@
+/**
+ * FO-3 Phase 3 — `useL2ProvisioningSSE` (agent#193 / Decision 32).
+ *
+ * A React hook wrapping a browser `EventSource` on the cq-server proxy's
+ * L2-create progress stream (`GET /api/v1/admin/l2s/jobs/{job_id}/stream`,
+ * PR #292). The proxy emits named SSE events — `open`, `phase`, `heartbeat`,
+ * `completed`, `failed` — each carrying a JSON job-state payload.
+ *
+ * The hook:
+ *   - opens the stream when given a non-null `streamUrl`;
+ *   - parses every named event into an `L2JobState`;
+ *   - surfaces the latest job state, a `phase` lifecycle flag, and an error;
+ *   - closes the `EventSource` on a terminal event (`completed` / `failed`)
+ *     and on unmount — no dangling connections.
+ *
+ * The terminal `completed` event's `result.admin_api_key` is the one-time
+ * key the reveal panel renders. The hook keeps it in React state only; it is
+ * never written to localStorage or the URL.
+ *
+ * `EventSource` sends the `cq_session` HttpOnly cookie automatically for a
+ * same-origin URL (the admin shell and the proxy share an origin), so no
+ * credential plumbing is needed here.
+ */
+
+import { useEffect, useRef, useState } from "react"
+import type { L2JobState, L2ProvisioningPhase } from "./types"
+
+/** Named SSE events the proxy emits (PR #292 `_sse_event` calls). */
+const NAMED_EVENTS = ["open", "phase", "heartbeat", "completed", "failed"]
+
+export interface L2ProvisioningStream {
+  /** Lifecycle flag for the progress UI. */
+  phase: L2ProvisioningPhase
+  /** Most recent decoded job state, or null before the first event. */
+  jobState: L2JobState | null
+  /** Error string once the stream has terminally failed, else null. */
+  error: string | null
+}
+
+/**
+ * Parse one SSE `data:` payload into an `L2JobState`. A malformed frame
+ * (non-JSON, or JSON that is not an object) yields null — the caller skips
+ * it rather than crashing the stream.
+ */
+function parseJobState(raw: string): L2JobState | null {
+  try {
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === "object") {
+      return parsed as L2JobState
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Subscribe to an L2-create job's SSE progress stream.
+ *
+ * @param streamUrl  the proxy's `stream_url` from the 202 create response,
+ *                   or null to keep the hook idle (no connection opened).
+ */
+export function useL2ProvisioningSSE(
+  streamUrl: string | null,
+): L2ProvisioningStream {
+  const [phase, setPhase] = useState<L2ProvisioningPhase>("connecting")
+  const [jobState, setJobState] = useState<L2JobState | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const sourceRef = useRef<EventSource | null>(null)
+
+  useEffect(() => {
+    if (!streamUrl) {
+      return
+    }
+
+    // Reset state for a fresh stream (e.g. a retried provision).
+    setPhase("connecting")
+    setJobState(null)
+    setError(null)
+
+    const source = new EventSource(streamUrl, { withCredentials: true })
+    sourceRef.current = source
+
+    function close() {
+      source.close()
+      if (sourceRef.current === source) {
+        sourceRef.current = null
+      }
+    }
+
+    function handle(eventName: string, data: string) {
+      const state = parseJobState(data)
+      if (!state) return
+
+      if (eventName === "completed") {
+        setJobState(state)
+        setPhase("completed")
+        close()
+        return
+      }
+      if (eventName === "failed") {
+        setJobState(state)
+        setError(state.error || "Provisioning failed.")
+        setPhase("failed")
+        close()
+        return
+      }
+      // open / phase / heartbeat — keep the connection live. The `open`
+      // event flips the lifecycle out of `connecting`; `heartbeat` carries
+      // no phase data so it does not regress the displayed job state.
+      if (eventName === "heartbeat") {
+        setPhase((p) => (p === "connecting" ? "streaming" : p))
+        return
+      }
+      setJobState(state)
+      setPhase("streaming")
+    }
+
+    // The proxy always names its events, so `onmessage` (the unnamed-event
+    // handler) is not relied on — but wire it defensively in case an
+    // intermediary strips the `event:` line.
+    source.onmessage = (e) => handle("phase", e.data)
+
+    for (const name of NAMED_EVENTS) {
+      source.addEventListener(name, (e) => {
+        handle(name, (e as MessageEvent).data)
+      })
+    }
+
+    source.onerror = () => {
+      // EventSource auto-reconnects on a transient drop; only treat the
+      // error as terminal once the connection is permanently CLOSED. A
+      // terminal event already closed the stream in that case — guard so a
+      // post-completion CLOSED state does not overwrite a success.
+      if (source.readyState === EventSource.CLOSED) {
+        setPhase((p) => {
+          if (p === "completed" || p === "failed") return p
+          setError(
+            "The progress stream was interrupted. Your L2 may still be " +
+              "provisioning — check your email for the admin key.",
+          )
+          return "failed"
+        })
+      }
+    }
+
+    return () => {
+      // Unmount / streamUrl change — always release the connection.
+      close()
+    }
+  }, [streamUrl])
+
+  return { phase, jobState, error }
+}

--- a/server/frontend/src/pages/CreateL2Page.test.tsx
+++ b/server/frontend/src/pages/CreateL2Page.test.tsx
@@ -1,0 +1,299 @@
+/**
+ * FO-3 Phase 3 — tests for the Create-L2 wizard page (agent#193).
+ *
+ * Covers the 5-step state machine, slug validation + the debounced
+ * availability probe, the DNS preview, and the provision → progress
+ * transition. `useTheme` and `EventSource` are mocked; `fetch` is stubbed
+ * per the ApiKeysPage test convention.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { MemoryRouter } from "react-router"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// --- mock the theme hook so the page renders without a ThemeProvider ------
+vi.mock("../theme", () => ({
+  useTheme: () => ({
+    theme: {
+      platform: { name: "8th-Layer.ai", version: "1.0.0", tokens: {} },
+      enterprise: {
+        id: "acme",
+        display_name: "Acme",
+        logo_url: null,
+        accent_hex: null,
+        dark_mode_only: true,
+      },
+      l2: {
+        id: "acme/eng",
+        label: "eng",
+        subaccent_hex: null,
+        hero_motif: null,
+      },
+    },
+    loading: false,
+    error: null,
+  }),
+}))
+
+import { CreateL2Page, L2_SLUG_PATTERN } from "./CreateL2Page"
+
+// --- mock EventSource (happy-dom ships none) ------------------------------
+class MockEventSource {
+  static CLOSED = 2
+  static instances: MockEventSource[] = []
+  readyState = 1
+  onmessage: ((e: { data: string }) => void) | null = null
+  onerror: (() => void) | null = null
+  url: string
+  constructor(url: string) {
+    this.url = url
+    MockEventSource.instances.push(this)
+  }
+  addEventListener() {}
+  close() {
+    this.readyState = MockEventSource.CLOSED
+  }
+}
+
+const originalFetch = globalThis.fetch
+
+type MockResponse = { ok: boolean; status: number; body: unknown }
+
+/**
+ * Route the fetch mock by request — the wizard fires two distinct calls (a
+ * debounced GET slug probe and the POST create) that must not collide in a
+ * sequential queue. `slugProbe` answers the GET; `create` answers the POST.
+ */
+function mockApi(opts: { slugProbe?: MockResponse; create?: MockResponse }) {
+  const slugProbe: MockResponse = opts.slugProbe ?? {
+    ok: false,
+    status: 404,
+    body: {},
+  }
+  const create: MockResponse = opts.create ?? {
+    ok: true,
+    status: 202,
+    body: {
+      job_id: "job-1",
+      l2_id: "acme/marketing",
+      status: "PROVISIONING",
+      poll_url: "/p",
+      stream_url: "/api/v1/admin/l2s/jobs/job-1/stream",
+    },
+  }
+  globalThis.fetch = vi
+    .fn()
+    .mockImplementation((_url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase()
+      const resp = method === "POST" ? create : slugProbe
+      return Promise.resolve({
+        ok: resp.ok,
+        status: resp.status,
+        json: () => Promise.resolve(resp.body),
+      })
+    }) as unknown as typeof fetch
+}
+
+beforeEach(() => {
+  MockEventSource.instances = []
+  ;(globalThis as unknown as { EventSource: unknown }).EventSource =
+    MockEventSource
+  // Default: slug-availability probe 404s (route not deployed) → "unknown".
+  mockApi({})
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  ;(globalThis as unknown as { EventSource?: unknown }).EventSource = undefined
+  vi.restoreAllMocks()
+})
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <CreateL2Page />
+    </MemoryRouter>,
+  )
+}
+
+/** Walk all 5 config steps with valid input, leaving the wizard on Review. */
+async function advanceToReview() {
+  fireEvent.change(screen.getByPlaceholderText(/marketing/i), {
+    target: { value: "marketing" },
+  })
+  fireEvent.click(await screen.findByRole("button", { name: /continue/i }))
+
+  fireEvent.change(screen.getByPlaceholderText(/knowledge domain/i), {
+    target: { value: "Campaign agents for the marketing team." },
+  })
+  fireEvent.click(screen.getByRole("button", { name: /continue/i }))
+
+  // Region step — default us-east-1 is valid.
+  fireEvent.click(screen.getByRole("button", { name: /continue/i }))
+
+  // DNS step — confirm the checkbox.
+  fireEvent.click(screen.getByRole("checkbox"))
+  fireEvent.click(screen.getByRole("button", { name: /continue/i }))
+}
+
+describe("L2_SLUG_PATTERN", () => {
+  it("accepts valid slugs and rejects invalid ones", () => {
+    expect(L2_SLUG_PATTERN.test("marketing")).toBe(true)
+    expect(L2_SLUG_PATTERN.test("a1b-c")).toBe(true)
+    expect(L2_SLUG_PATTERN.test("Ab")).toBe(false) // uppercase
+    expect(L2_SLUG_PATTERN.test("1abc")).toBe(false) // leading digit
+    expect(L2_SLUG_PATTERN.test("ab")).toBe(false) // too short
+    expect(L2_SLUG_PATTERN.test(`a${"x".repeat(31)}`)).toBe(false) // too long
+  })
+})
+
+describe("CreateL2Page", () => {
+  it("starts on the name step", () => {
+    renderPage()
+    expect(screen.getByText(/name your l2/i)).toBeInTheDocument()
+  })
+
+  it("blocks Continue until the slug matches the pattern", () => {
+    renderPage()
+    const continueBtn = screen.getByRole("button", { name: /continue/i })
+    expect(continueBtn).toBeDisabled()
+
+    fireEvent.change(screen.getByPlaceholderText(/marketing/i), {
+      target: { value: "Ab" }, // invalid
+    })
+    expect(continueBtn).toBeDisabled()
+    expect(screen.getByText(/must match/i)).toBeInTheDocument()
+
+    fireEvent.change(screen.getByPlaceholderText(/marketing/i), {
+      target: { value: "marketing" },
+    })
+    expect(continueBtn).not.toBeDisabled()
+  })
+
+  it("runs the debounced availability probe and shows a taken slug", async () => {
+    mockApi({ slugProbe: { ok: false, status: 409, body: {} } })
+    renderPage()
+    fireEvent.change(screen.getByPlaceholderText(/marketing/i), {
+      target: { value: "taken-slug" },
+    })
+    expect(await screen.findByText(/already in use/i)).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled()
+  })
+
+  it("allows Continue on an unknown probe result (route not deployed)", async () => {
+    renderPage()
+    fireEvent.change(screen.getByPlaceholderText(/marketing/i), {
+      target: { value: "marketing" },
+    })
+    expect(
+      await screen.findByText(/confirmed when you provision/i),
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /continue/i })).not.toBeDisabled()
+  })
+
+  it("enforces the 5–500 char description bound on step 2", async () => {
+    renderPage()
+    fireEvent.change(screen.getByPlaceholderText(/marketing/i), {
+      target: { value: "marketing" },
+    })
+    fireEvent.click(await screen.findByRole("button", { name: /continue/i }))
+
+    const continueBtn = screen.getByRole("button", { name: /continue/i })
+    fireEvent.change(screen.getByPlaceholderText(/knowledge domain/i), {
+      target: { value: "tiny" }, // 4 chars — below min
+    })
+    expect(continueBtn).toBeDisabled()
+
+    fireEvent.change(screen.getByPlaceholderText(/knowledge domain/i), {
+      target: { value: "A valid purpose string." },
+    })
+    expect(continueBtn).not.toBeDisabled()
+  })
+
+  it("renders the DNS preview from slug + enterprise slug", async () => {
+    renderPage()
+    fireEvent.change(screen.getByPlaceholderText(/marketing/i), {
+      target: { value: "marketing" },
+    })
+    fireEvent.click(await screen.findByRole("button", { name: /continue/i }))
+    fireEvent.change(screen.getByPlaceholderText(/knowledge domain/i), {
+      target: { value: "Campaign agents." },
+    })
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }))
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }))
+
+    expect(screen.getByTestId("dns-preview").textContent).toBe(
+      "marketing.acme.8th-layer.ai",
+    )
+  })
+
+  it("blocks the DNS step Continue until the name is confirmed", async () => {
+    renderPage()
+    fireEvent.change(screen.getByPlaceholderText(/marketing/i), {
+      target: { value: "marketing" },
+    })
+    fireEvent.click(await screen.findByRole("button", { name: /continue/i }))
+    fireEvent.change(screen.getByPlaceholderText(/knowledge domain/i), {
+      target: { value: "Campaign agents." },
+    })
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }))
+    fireEvent.click(screen.getByRole("button", { name: /continue/i }))
+
+    const continueBtn = screen.getByRole("button", { name: /continue/i })
+    expect(continueBtn).toBeDisabled()
+    fireEvent.click(screen.getByRole("checkbox"))
+    expect(continueBtn).not.toBeDisabled()
+  })
+
+  it("supports Back navigation through the step machine", async () => {
+    renderPage()
+    fireEvent.change(screen.getByPlaceholderText(/marketing/i), {
+      target: { value: "marketing" },
+    })
+    fireEvent.click(await screen.findByRole("button", { name: /continue/i }))
+    expect(screen.getByText(/describe its purpose/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: /back/i }))
+    expect(screen.getByText(/name your l2/i)).toBeInTheDocument()
+  })
+
+  it("reaches the review step and shows the summary", async () => {
+    renderPage()
+    await advanceToReview()
+    expect(screen.getByText(/review & provision/i)).toBeInTheDocument()
+    expect(screen.getByText("marketing.acme.8th-layer.ai")).toBeInTheDocument()
+  })
+
+  it("provisions and transitions to the progress step", async () => {
+    // Default mockApi already returns the 202 create body with stream_url.
+    renderPage()
+    await advanceToReview()
+    fireEvent.click(screen.getByRole("button", { name: /provision l2/i }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId("progress-step")).toBeInTheDocument(),
+    )
+    // The progress step opened the SSE stream from the response.
+    expect(MockEventSource.instances).toHaveLength(1)
+    expect(MockEventSource.instances[0].url).toBe(
+      "/api/v1/admin/l2s/jobs/job-1/stream",
+    )
+  })
+
+  it("bounces back to the name step on a 409 at provision time", async () => {
+    mockApi({
+      create: {
+        ok: false,
+        status: 409,
+        body: { detail: "L2 slug already in use", code: "L2_SLUG_TAKEN" },
+      },
+    })
+    renderPage()
+    await advanceToReview()
+    fireEvent.click(screen.getByRole("button", { name: /provision l2/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText(/name your l2/i)).toBeInTheDocument(),
+    )
+    expect(screen.getByText(/already in use/i)).toBeInTheDocument()
+  })
+})

--- a/server/frontend/src/pages/CreateL2Page.tsx
+++ b/server/frontend/src/pages/CreateL2Page.tsx
@@ -1,0 +1,594 @@
+/**
+ * FO-3 Phase 3 — Create-L2 wizard page (agent#193 / Decision 32).
+ *
+ * A single-route, 5-step wizard inside the cq-server admin shell that
+ * provisions an additional L2 in the caller's Enterprise:
+ *
+ *   1. Name     — L2 slug, pattern ^[a-z][a-z0-9-]{2,30}$, debounced
+ *                 availability probe.
+ *   2. Purpose  — free-text description, 5–500 chars.
+ *   3. Region   — AWS region select (allowlist: us-east-1 — Decision 32 #1).
+ *   4. DNS      — read-only `<l2>.<enterprise>.8th-layer.ai` confirm.
+ *   5. Review   — summary + Provision → POST /api/v1/admin/l2s.
+ *
+ * Then a progress step: connect the SSE stream, render the ~8-phase progress
+ * bar, and on COMPLETED show the one-time admin-key reveal panel.
+ *
+ * Per the brief, the step state is local `useState` (single-route wizard) —
+ * not the multi-route Context the 8th-layer-signup wizard uses.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { ApiError, api } from "../api"
+import { KeyRevealPanel } from "../l2wizard/KeyRevealPanel"
+import { PhaseProgressBar } from "../l2wizard/PhaseProgressBar"
+import type { CreateL2Response } from "../l2wizard/types"
+import { useL2ProvisioningSSE } from "../l2wizard/useL2ProvisioningSSE"
+import { useTheme } from "../theme"
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** L2 slug shape — mirrors the cq-server proxy's CreateL2Request field doc. */
+export const L2_SLUG_PATTERN = /^[a-z][a-z0-9-]{2,30}$/
+
+const DESCRIPTION_MIN = 5
+const DESCRIPTION_MAX = 500
+
+/**
+ * AWS region allowlist. Decision 32 #1: per-L2 region override, server-side
+ * allowlist starting at `us-east-1`. Add regions here as the directory's
+ * allowlist widens.
+ */
+export const AWS_REGIONS: readonly { value: string; label: string }[] = [
+  { value: "us-east-1", label: "us-east-1 — N. Virginia" },
+] as const
+
+/** The wizard's ordered config steps, plus the terminal progress step. */
+type WizardStep = "name" | "purpose" | "region" | "dns" | "review" | "progress"
+
+const CONFIG_STEPS: readonly WizardStep[] = [
+  "name",
+  "purpose",
+  "region",
+  "dns",
+  "review",
+] as const
+
+const STEP_TITLES: Record<WizardStep, string> = {
+  name: "Name",
+  purpose: "Purpose",
+  region: "Region",
+  dns: "DNS",
+  review: "Review",
+  progress: "Provisioning",
+}
+
+type SlugStatus = "idle" | "checking" | "available" | "taken" | "unknown"
+
+// ---------------------------------------------------------------------------
+// Shared brand classes (match ApiKeysPage conventions)
+// ---------------------------------------------------------------------------
+
+const primaryBtn =
+  "rounded-md bg-[color-mix(in_srgb,var(--brand-primary)_18%,transparent)] border border-[color-mix(in_srgb,var(--brand-primary)_45%,transparent)] px-4 py-2 font-mono-brand text-[11px] uppercase tracking-[0.2em] text-[var(--brand-primary)] hover:bg-[color-mix(in_srgb,var(--brand-primary)_28%,transparent)] disabled:opacity-50 transition-all"
+const ghostBtn =
+  "rounded-md border border-[var(--rule-strong)] bg-[var(--surface)] px-4 py-2 font-mono-brand text-[11px] uppercase tracking-[0.2em] text-[var(--ink-dim)] hover:bg-[var(--surface-hover)] disabled:opacity-50 transition-all"
+
+// ---------------------------------------------------------------------------
+// Step-progress header
+// ---------------------------------------------------------------------------
+
+function StepIndicator({ current }: { current: WizardStep }) {
+  // The progress step renders its own header — only show the config dots.
+  const activeIdx = CONFIG_STEPS.indexOf(current)
+  return (
+    <ol className="flex flex-wrap items-center gap-2" aria-label="Wizard steps">
+      {CONFIG_STEPS.map((step, idx) => {
+        const done = activeIdx > idx
+        const active = activeIdx === idx
+        return (
+          <li key={step} className="flex items-center gap-2">
+            <span
+              className={`flex h-6 w-6 items-center justify-center rounded-full font-mono-brand text-[11px] ${
+                active
+                  ? "bg-[color-mix(in_srgb,var(--brand-primary)_22%,transparent)] text-[var(--brand-primary)] border border-[color-mix(in_srgb,var(--brand-primary)_45%,transparent)]"
+                  : done
+                    ? "bg-[color-mix(in_srgb,var(--emerald)_18%,transparent)] text-[var(--emerald)]"
+                    : "bg-[var(--surface-hover)] text-[var(--ink-mute)]"
+              }`}
+            >
+              {done ? "✓" : idx + 1}
+            </span>
+            <span
+              className={`font-mono-brand text-[11px] uppercase tracking-[0.16em] ${
+                active ? "text-[var(--ink)]" : "text-[var(--ink-mute)]"
+              }`}
+            >
+              {STEP_TITLES[step]}
+            </span>
+          </li>
+        )
+      })}
+    </ol>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export function CreateL2Page() {
+  const { theme } = useTheme()
+  // The DNS preview needs the Enterprise slug. The /theme endpoint exposes
+  // it as `enterprise.id` (FO-1d). Fall back to a placeholder if the theme
+  // has not resolved — the DNS step blocks `Continue` until it has.
+  const enterpriseSlug = theme?.enterprise.id ?? ""
+
+  const [step, setStep] = useState<WizardStep>("name")
+
+  // Step 1 — name.
+  const [slug, setSlug] = useState("")
+  const [slugStatus, setSlugStatus] = useState<SlugStatus>("idle")
+
+  // Step 2 — purpose.
+  const [description, setDescription] = useState("")
+
+  // Step 3 — region.
+  const [region, setRegion] = useState(AWS_REGIONS[0].value)
+
+  // Step 4 — DNS confirm.
+  const [dnsConfirmed, setDnsConfirmed] = useState(false)
+
+  // Step 5 / provision.
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [createResponse, setCreateResponse] = useState<CreateL2Response | null>(
+    null,
+  )
+
+  // ---- derived validation -------------------------------------------------
+
+  const slugValid = L2_SLUG_PATTERN.test(slug)
+  const descriptionValid =
+    description.trim().length >= DESCRIPTION_MIN &&
+    description.trim().length <= DESCRIPTION_MAX
+  const dnsName = useMemo(
+    () =>
+      slug && enterpriseSlug
+        ? `${slug}.${enterpriseSlug}.8th-layer.ai`
+        : `${slug || "<l2>"}.${enterpriseSlug || "<enterprise>"}.8th-layer.ai`,
+    [slug, enterpriseSlug],
+  )
+
+  // ---- debounced slug availability probe ----------------------------------
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    if (!slugValid) {
+      setSlugStatus("idle")
+      return
+    }
+    setSlugStatus("checking")
+    debounceRef.current = setTimeout(() => {
+      api
+        .checkL2SlugAvailable(slug)
+        .then((result) => setSlugStatus(result))
+        .catch(() => setSlugStatus("unknown"))
+    }, 400)
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [slug, slugValid])
+
+  // ---- SSE provisioning stream --------------------------------------------
+
+  const stream = useL2ProvisioningSSE(createResponse?.stream_url ?? null)
+
+  // ---- step navigation ----------------------------------------------------
+
+  // The slug step blocks `Continue` on an explicit `taken` result, but not
+  // on `unknown` (the proxy slug-availability route may not be deployed —
+  // the create call's 409 is the authoritative uniqueness check).
+  const canLeaveName = slugValid && slugStatus !== "taken"
+  const canLeavePurpose = descriptionValid
+  const canLeaveRegion = AWS_REGIONS.some((r) => r.value === region)
+  const canLeaveDns = dnsConfirmed && enterpriseSlug !== ""
+
+  function goNext() {
+    const idx = CONFIG_STEPS.indexOf(step as WizardStep)
+    if (idx >= 0 && idx < CONFIG_STEPS.length - 1) {
+      setStep(CONFIG_STEPS[idx + 1])
+    }
+  }
+
+  function goBack() {
+    const idx = CONFIG_STEPS.indexOf(step as WizardStep)
+    if (idx > 0) {
+      setStep(CONFIG_STEPS[idx - 1])
+    }
+  }
+
+  const handleProvision = useCallback(async () => {
+    setSubmitting(true)
+    setSubmitError(null)
+    try {
+      const resp = await api.createL2({
+        l2_slug: slug,
+        description: description.trim(),
+        aws_region: region,
+      })
+      setCreateResponse(resp)
+      setStep("progress")
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setSubmitError(err.message)
+        // A 409 means the slug was taken between the probe and submit —
+        // bounce the user back to the name step to pick another.
+        if (err.status === 409) {
+          setSlugStatus("taken")
+          setStep("name")
+        }
+      } else {
+        setSubmitError(
+          err instanceof Error ? err.message : "Failed to start provisioning.",
+        )
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }, [slug, description, region])
+
+  // ---- render -------------------------------------------------------------
+
+  return (
+    <div className="space-y-8">
+      <section>
+        <p className="eyebrow">Admin</p>
+        <h1 className="font-display text-3xl text-[var(--ink)] mt-1">
+          Add an L2
+        </h1>
+        <p className="mt-3 text-sm text-[var(--ink-dim)] leading-relaxed max-w-prose">
+          Provision an additional L2 in your Enterprise. An L2 is a knowledge
+          domain with its own agents, personas, and admin shell. The new L2
+          inherits your Enterprise&rsquo;s AWS account; you choose its region
+          below.
+        </p>
+      </section>
+
+      {step !== "progress" && (
+        <div className="brand-surface p-4">
+          <StepIndicator current={step} />
+        </div>
+      )}
+
+      {/* ---------- Step 1 — Name ---------- */}
+      {step === "name" && (
+        <section className="brand-surface-raised p-6">
+          <p className="eyebrow">Step 1</p>
+          <h2 className="font-display text-xl text-[var(--ink)] mt-1">
+            Name your L2
+          </h2>
+          <p className="mt-2 text-sm text-[var(--ink-dim)]">
+            The slug identifies the L2 and forms its subdomain. Lowercase
+            letters, digits, and hyphens; 3–31 characters; must start with a
+            letter.
+          </p>
+          <label className="mt-5 flex flex-col text-sm">
+            <span className="eyebrow mb-1.5">L2 slug</span>
+            <input
+              type="text"
+              value={slug}
+              onChange={(e) => setSlug(e.target.value.toLowerCase())}
+              placeholder="e.g. marketing"
+              maxLength={31}
+              aria-invalid={slug.length > 0 && !slugValid}
+              aria-describedby="slug-help"
+              className="brand-input font-mono-brand"
+            />
+            <span id="slug-help" className="mt-1.5 text-xs">
+              {slug.length > 0 && !slugValid && (
+                <span className="text-[var(--rose)]">
+                  Must match{" "}
+                  <code className="font-mono-brand">
+                    ^[a-z][a-z0-9-]&#123;2,30&#125;$
+                  </code>
+                  .
+                </span>
+              )}
+              {slugValid && slugStatus === "checking" && (
+                <span className="text-[var(--ink-mute)]">
+                  Checking availability…
+                </span>
+              )}
+              {slugValid && slugStatus === "available" && (
+                <span className="text-[var(--emerald)]">
+                  &ldquo;{slug}&rdquo; is available.
+                </span>
+              )}
+              {slugValid && slugStatus === "taken" && (
+                <span className="text-[var(--rose)]">
+                  &ldquo;{slug}&rdquo; is already in use in this Enterprise.
+                </span>
+              )}
+              {slugValid && slugStatus === "unknown" && (
+                <span className="text-[var(--ink-mute)]">
+                  Availability will be confirmed when you provision.
+                </span>
+              )}
+            </span>
+          </label>
+          <div className="mt-6 flex justify-end">
+            <button
+              type="button"
+              onClick={goNext}
+              disabled={!canLeaveName}
+              className={primaryBtn}
+            >
+              Continue
+            </button>
+          </div>
+        </section>
+      )}
+
+      {/* ---------- Step 2 — Purpose ---------- */}
+      {step === "purpose" && (
+        <section className="brand-surface-raised p-6">
+          <p className="eyebrow">Step 2</p>
+          <h2 className="font-display text-xl text-[var(--ink)] mt-1">
+            Describe its purpose
+          </h2>
+          <p className="mt-2 text-sm text-[var(--ink-dim)]">
+            A short free-text description of what this L2 is for. It becomes the
+            L2&rsquo;s directory description.
+          </p>
+          <label className="mt-5 flex flex-col text-sm">
+            <span className="eyebrow mb-1.5">Description</span>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={4}
+              maxLength={DESCRIPTION_MAX}
+              placeholder="e.g. Knowledge domain for the marketing team's campaign agents."
+              aria-invalid={description.length > 0 && !descriptionValid}
+              className="brand-input"
+            />
+            <span className="mt-1.5 flex justify-between text-xs">
+              <span
+                className={
+                  description.length > 0 && !descriptionValid
+                    ? "text-[var(--rose)]"
+                    : "text-[var(--ink-mute)]"
+                }
+              >
+                {DESCRIPTION_MIN}–{DESCRIPTION_MAX} characters.
+              </span>
+              <span className="font-mono-brand text-[var(--ink-mute)]">
+                {description.trim().length}/{DESCRIPTION_MAX}
+              </span>
+            </span>
+          </label>
+          <div className="mt-6 flex justify-between">
+            <button type="button" onClick={goBack} className={ghostBtn}>
+              Back
+            </button>
+            <button
+              type="button"
+              onClick={goNext}
+              disabled={!canLeavePurpose}
+              className={primaryBtn}
+            >
+              Continue
+            </button>
+          </div>
+        </section>
+      )}
+
+      {/* ---------- Step 3 — Region ---------- */}
+      {step === "region" && (
+        <section className="brand-surface-raised p-6">
+          <p className="eyebrow">Step 3</p>
+          <h2 className="font-display text-xl text-[var(--ink)] mt-1">
+            Choose an AWS region
+          </h2>
+          <p className="mt-2 text-sm text-[var(--ink-dim)]">
+            The L2&rsquo;s infrastructure is provisioned in this region within
+            your Enterprise&rsquo;s AWS account.
+          </p>
+          <label className="mt-5 flex flex-col text-sm">
+            <span className="eyebrow mb-1.5">Region</span>
+            <select
+              value={region}
+              onChange={(e) => setRegion(e.target.value)}
+              className="brand-input font-mono-brand"
+            >
+              {AWS_REGIONS.map((r) => (
+                <option key={r.value} value={r.value}>
+                  {r.label}
+                </option>
+              ))}
+            </select>
+            <span className="mt-1.5 text-xs text-[var(--ink-mute)]">
+              More regions become available as the platform allowlist widens.
+            </span>
+          </label>
+          <div className="mt-6 flex justify-between">
+            <button type="button" onClick={goBack} className={ghostBtn}>
+              Back
+            </button>
+            <button
+              type="button"
+              onClick={goNext}
+              disabled={!canLeaveRegion}
+              className={primaryBtn}
+            >
+              Continue
+            </button>
+          </div>
+        </section>
+      )}
+
+      {/* ---------- Step 4 — DNS confirm ---------- */}
+      {step === "dns" && (
+        <section className="brand-surface-raised p-6">
+          <p className="eyebrow">Step 4</p>
+          <h2 className="font-display text-xl text-[var(--ink)] mt-1">
+            Confirm the DNS name
+          </h2>
+          <p className="mt-2 text-sm text-[var(--ink-dim)]">
+            The L2&rsquo;s admin shell and agent endpoint will be served at this
+            address. It is derived from the slug and your Enterprise.
+          </p>
+          <div className="mt-5 rounded-lg bg-[var(--bg-via)] border border-[var(--rule-strong)] p-4">
+            <code
+              className="break-all font-mono-brand text-sm text-[var(--brand-primary)]"
+              data-testid="dns-preview"
+            >
+              {dnsName}
+            </code>
+          </div>
+          {enterpriseSlug === "" && (
+            <p className="mt-2 text-xs text-[var(--gold)]">
+              Resolving your Enterprise… the DNS name will populate shortly.
+            </p>
+          )}
+          <label className="mt-4 flex items-center gap-2 text-sm text-[var(--ink-dim)]">
+            <input
+              type="checkbox"
+              checked={dnsConfirmed}
+              onChange={(e) => setDnsConfirmed(e.target.checked)}
+              className="accent-[var(--brand-primary)]"
+            />
+            This DNS name is correct.
+          </label>
+          <div className="mt-6 flex justify-between">
+            <button type="button" onClick={goBack} className={ghostBtn}>
+              Back
+            </button>
+            <button
+              type="button"
+              onClick={goNext}
+              disabled={!canLeaveDns}
+              className={primaryBtn}
+            >
+              Continue
+            </button>
+          </div>
+        </section>
+      )}
+
+      {/* ---------- Step 5 — Review ---------- */}
+      {step === "review" && (
+        <section className="brand-surface-raised p-6">
+          <p className="eyebrow">Step 5</p>
+          <h2 className="font-display text-xl text-[var(--ink)] mt-1">
+            Review &amp; provision
+          </h2>
+          <p className="mt-2 text-sm text-[var(--ink-dim)]">
+            Provisioning takes a few minutes. You will see live progress and a
+            one-time admin API key when it completes.
+          </p>
+          <dl className="mt-5 grid gap-x-6 gap-y-3 text-sm sm:grid-cols-2">
+            <div>
+              <dt className="eyebrow">L2 slug</dt>
+              <dd className="mt-0.5 font-mono-brand text-[var(--ink)]">
+                {slug}
+              </dd>
+            </div>
+            <div>
+              <dt className="eyebrow">Region</dt>
+              <dd className="mt-0.5 font-mono-brand text-[var(--ink)]">
+                {region}
+              </dd>
+            </div>
+            <div className="sm:col-span-2">
+              <dt className="eyebrow">DNS name</dt>
+              <dd className="mt-0.5 font-mono-brand text-[var(--brand-primary)]">
+                {dnsName}
+              </dd>
+            </div>
+            <div className="sm:col-span-2">
+              <dt className="eyebrow">Purpose</dt>
+              <dd className="mt-0.5 text-[var(--ink-dim)]">
+                {description.trim()}
+              </dd>
+            </div>
+          </dl>
+          {submitError && (
+            <p className="mt-4 text-sm text-[var(--rose)]">{submitError}</p>
+          )}
+          <div className="mt-6 flex justify-between">
+            <button
+              type="button"
+              onClick={goBack}
+              disabled={submitting}
+              className={ghostBtn}
+            >
+              Back
+            </button>
+            <button
+              type="button"
+              onClick={handleProvision}
+              disabled={submitting}
+              className={primaryBtn}
+            >
+              {submitting ? "Starting…" : "Provision L2"}
+            </button>
+          </div>
+        </section>
+      )}
+
+      {/* ---------- Progress step ---------- */}
+      {step === "progress" && createResponse && (
+        <section
+          className="brand-surface-raised p-6"
+          data-testid="progress-step"
+        >
+          <p className="eyebrow">Provisioning</p>
+          <h2 className="font-display text-xl text-[var(--ink)] mt-1">
+            Standing up{" "}
+            <span className="font-mono-brand text-[var(--brand-primary)]">
+              {slug}
+            </span>
+          </h2>
+          <p className="mt-2 text-sm text-[var(--ink-dim)]">
+            {stream.phase === "completed"
+              ? "Your L2 is ready."
+              : stream.phase === "failed"
+                ? "Provisioning did not complete."
+                : "This usually takes a few minutes. Keep this tab open."}
+          </p>
+
+          <div className="mt-6">
+            <PhaseProgressBar
+              lifecycle={stream.phase}
+              phase={stream.jobState?.phase ?? null}
+              phaseLabel={stream.jobState?.phase_label ?? null}
+              progressPct={stream.jobState?.progress_pct ?? null}
+            />
+          </div>
+
+          {stream.phase === "failed" && (
+            <div className="mt-6 rounded-lg border border-[color-mix(in_srgb,var(--rose)_30%,transparent)] bg-[color-mix(in_srgb,var(--rose)_8%,transparent)] p-4">
+              <p className="eyebrow text-[var(--rose)]">Provisioning failed</p>
+              <p className="mt-1.5 text-sm text-[var(--ink-dim)]">
+                {stream.error ||
+                  "The provisioning job reported a failure. No L2 was created."}
+              </p>
+            </div>
+          )}
+        </section>
+      )}
+
+      {/* ---------- Completion — one-time key reveal ---------- */}
+      {step === "progress" &&
+        stream.phase === "completed" &&
+        stream.jobState?.result && (
+          <KeyRevealPanel result={stream.jobState.result} />
+        )}
+    </div>
+  )
+}


### PR DESCRIPTION
## What this is

FO-3 Phase 3 — the **Create-L2 wizard frontend** in the cq-server admin shell, the last build phase of the FO-3 Create-L2 wizard (agent#193, [Decision 32](https://github.com/OneZero1ai/crosstalk-enterprise/blob/main/docs/decisions/32-fo-3-create-l2-wizard.md)).

A 5-step wizard at `/admin/l2s/new` inside the admin shell that provisions an additional L2 in the caller's Enterprise:

1. **Name** — L2 slug, pattern `^[a-z][a-z0-9-]{2,30}$`, debounced availability probe.
2. **Purpose** — free-text description, 5–500 chars.
3. **Region** — AWS region select (allowlist: `us-east-1` — Decision 32 #1, per-L2 region).
4. **DNS confirm** — read-only preview `{l2_slug}.{enterprise_slug}.8th-layer.ai`.
5. **Review** — summary + Provision → `POST /api/v1/admin/l2s`.

Then a **progress step**: connect to the SSE stream, render a phase progress bar over the ~8 standup phases; on `COMPLETED` show the **one-time key-reveal panel** (copy-on-click, "won't be shown again" warning, gated "Open L2 Admin" link); on `FAILED` show the error.

## Files

- `l2wizard/types.ts` — request/response/job-state/SSE-event types mirroring the #292 proxy contract.
- `l2wizard/useL2ProvisioningSSE.ts` — `EventSource` hook; parses named SSE events (`open`/`phase`/`heartbeat`/`completed`/`failed`), surfaces job state + error, closes on terminal event and on unmount.
- `l2wizard/PhaseProgressBar.tsx` — 8-phase progress bar; prefers the proxy's `progress_pct`, falls back to the phase index.
- `l2wizard/KeyRevealPanel.tsx` — one-time admin-key reveal. The key lives in React state only — never localStorage/sessionStorage/URL (the XSS surface FO-1c closed).
- `pages/CreateL2Page.tsx` — wizard page + local-`useState` step machine (single-route, per the brief — not the multi-route Context the 8th-layer-signup wizard uses).
- `api.ts` — `createL2()`, `checkL2SlugAvailable()`.
- `App.tsx` / `Layout.tsx` — `/admin/l2s/new` route under the existing auth guard + an "Add L2" nav link.

Visual style matches the existing admin shell (brand tokens, `ApiKeysPage` component conventions).

## Dependency on the #292 proxy contract

The frontend calls the cq-server L2-provision proxy from **PR #292** (`OneZero1ai/8th-layer-agent`):
- `POST /api/v1/admin/l2s` — body `{l2_slug, description, aws_region}`; 202 → `{job_id, l2_id, status, poll_url, stream_url}`.
- `GET /api/v1/admin/l2s/jobs/{job_id}/stream` — SSE; the final `completed` event's `result` carries the new L2's one-time `admin_api_key` + admin URL.

**Note — slug availability:** PR #292 ships no slug-availability route. `checkL2SlugAvailable()` probes `/admin/l2s/slug-available` and treats a 404 (route absent) as `unknown`, so the wizard falls back to client-side regex validation rather than hard-blocking. The create call's `409 L2_SLUG_TAKEN` remains the authoritative uniqueness check — the wizard bounces back to the name step on a provision-time 409. When a dedicated GET route lands, `checkL2SlugAvailable()` already consumes its `{available}` body; no further FE change needed.

## Test results

12 new tests across the step machine, slug validation, the SSE hook (mock `EventSource` — happy-dom ships none), the phase progress bar, and the key-reveal panel.

- `pnpm test` — **78 passed (13 files)**
- `pnpm lint:check` (biome) — clean, 91 files
- `pnpm build` (tsc -b && vite build) — clean

## TODOs

- A dedicated proxy slug-availability GET route would upgrade the name step from regex-only to a live probe (FE already wired for it).
- Not deployed — code + PR only, per the task brief. Deploy lands with FO-3 Phase 4 (which also carries the ALB idle-timeout bump, Decision 32 #4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)