### PR TITLE
feat(admin): FO-3 slug-available passthrough (agent#193)

### DIFF
--- a/server/backend/src/cq_server/l2_provision_routes.py
+++ b/server/backend/src/cq_server/l2_provision_routes.py
@@ -654,3 +654,113 @@ async def stream_l2_job(
             "Connection": "keep-alive",
         },
     )
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/admin/l2s/slug-available/{l2_slug} — slug-availability passthrough
+# ---------------------------------------------------------------------------
+#
+# FO-3 Phase 3's Create-L2 wizard (agent#193) debounce-probes this route from
+# its slug field for a live "is this L2 slug free" check. The directory owns
+# the authoritative answer — the proxy holds no L2-slug state — so this is a
+# thin passthrough to the directory's
+# ``GET .../enterprises/{enterprise_id}/l2s/slug-available/{l2_slug}``.
+#
+# Like the SSE job-poll, this directory GET is auth-gated (directory #22 /
+# directory PR #22's FO-3 contract): the caller presents an Enterprise-root
+# identity proof in the ``X-8L-Identity-Proof`` header — the SAME proof the
+# poll loop builds. The directory's contract:
+#   200 {l2_slug, available: true}   — slug is free
+#   409 {l2_slug, available: false}  — slug is taken
+# Both are relayed verbatim with their status; the create call remains the
+# authoritative 409 at provision time, this is only the wizard's live hint.
+
+
+@router.get(
+    "/slug-available/{l2_slug}",
+    summary="Check whether an L2 slug is free in the caller's Enterprise (proxy → provisioning service)",
+    # The handler returns either the directory's {l2_slug, available} body or
+    # a JSONResponse error envelope — neither is a fixed pydantic model.
+    response_model=None,
+)
+async def slug_available(
+    l2_slug: str,
+    admin: str = Depends(require_admin),
+    store: SqliteStore = Depends(get_store),
+) -> JSONResponse:
+    """FO-3 Phase 2 — proxy the wizard's live L2-slug availability probe.
+
+    Auth: ``require_admin`` — the wizard's slug field is admin-only, and a
+    slug-existence answer is itself tenancy information. Tenancy: the check
+    runs against the calling admin's own Enterprise (resolved from their user
+    row); the browser never sends ``enterprise_id``.
+
+    Forwards to the directory's
+    ``GET /api/v1/enterprises/{enterprise_id}/l2s/slug-available/{l2_slug}``
+    with a freshly-signed ``X-8L-Identity-Proof`` header (directory #22 auth
+    contract). The directory returns ``200 {l2_slug, available: true}`` when
+    the slug is free and ``409 {l2_slug, available: false}`` when taken; both
+    are relayed verbatim with their status. Transport failures map to
+    ``502 PROVISIONING_UNREACHABLE``; a missing identity-key mount → 500.
+    """
+    try:
+        enterprise_id = await _resolve_caller_enterprise(store, admin)
+    except _TenancyError as exc:
+        return _error("TENANCY", "Caller is not scoped to an Enterprise.", str(exc), status=403)
+
+    # Directory #22 auth contract: the body-less GET carries the Enterprise-
+    # root identity proof in a header. Load the key up-front so a missing
+    # mount fails as a clean 500 rather than sending an unsigned (rejected)
+    # request — identical handling to the create + SSE routes.
+    try:
+        privkey = _load_enterprise_root_key()
+    except _SigningError as exc:
+        log.error("FO-3 slug-available: cannot sign directory identity proof: %s", exc)
+        return _error(
+            "IDENTITY_KEY_UNAVAILABLE",
+            "This L2 cannot authenticate to the provisioning service.",
+            str(exc),
+            status=500,
+        )
+
+    base = get_provisioning_api_url()
+    forward_url = f"{base}/api/v1/enterprises/{enterprise_id}/l2s/slug-available/{l2_slug}"
+    headers = {"X-8L-Identity-Proof": _build_identity_proof_header(privkey, enterprise_id=enterprise_id)}
+
+    try:
+        async with httpx.AsyncClient(timeout=_FORWARD_TIMEOUT_SEC) as http:
+            resp = await http.get(forward_url, headers=headers)
+    except httpx.HTTPError as exc:
+        log.warning("FO-3 slug-available forward failed: %s (%s)", exc, forward_url)
+        return _error(
+            "PROVISIONING_UNREACHABLE",
+            "The provisioning service is unreachable. Please retry shortly.",
+            str(exc),
+            status=502,
+        )
+
+    # Relay the directory's verdict verbatim. 200 and 409 are both expected
+    # "answers" here (free / taken) and carry a {l2_slug, available} body,
+    # not a {error, code, detail} envelope — pass them straight through.
+    if resp.status_code in (200, 409):
+        try:
+            body = resp.json()
+        except (json.JSONDecodeError, ValueError):
+            return _error(
+                "PROVISIONING_ERROR",
+                "The provisioning service returned an unreadable response.",
+                f"status {resp.status_code}",
+                status=502,
+            )
+        return JSONResponse(status_code=resp.status_code, content=body)
+
+    # Anything else (401/403 rejected proof, 404 unknown Enterprise, 422
+    # malformed slug, 5xx) is a real error — surface the directory's
+    # {error, code, detail} envelope verbatim where it speaks one.
+    log.info(
+        "FO-3 slug-available upstream non-answer: status=%s enterprise=%s slug=%s",
+        resp.status_code,
+        enterprise_id,
+        l2_slug,
+    )
+    return _passthrough_upstream_error(resp)

--- a/server/backend/tests/test_l2_provision_routes.py
+++ b/server/backend/tests/test_l2_provision_routes.py
@@ -100,9 +100,7 @@ def root_key_path(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def client(
-    tmp_path: Path, root_key_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> Iterator[TestClient]:
+def client(tmp_path: Path, root_key_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
     """A TestClient with one Enterprise-A admin and one Enterprise-A plain user."""
     monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "l2prov.db"))
     monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
@@ -227,9 +225,7 @@ class TestCreateL2Forward:
         assert fwd.method == "POST"
         assert str(fwd.url) == f"{PROVISIONING_BASE}/api/v1/enterprises/{ENT_A}/l2s"
 
-    def test_post_body_is_a_signed_envelope(
-        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_post_body_is_a_signed_envelope(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
         """Directory #22 auth contract — the proxy actually signs the body.
 
         The forward body must be a SignedEnvelope (not the plain wizard
@@ -305,9 +301,7 @@ class TestCreateL2Forward:
         payload = _assert_signed_envelope(json.loads(seen[0].content), expected_enterprise_id=ENT_A)
         assert payload["enterprise_id"] == ENT_A
 
-    def test_missing_identity_key_is_500(
-        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_missing_identity_key_is_500(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
         """No Enterprise root key mount → 500 IDENTITY_KEY_UNAVAILABLE, no forward."""
         monkeypatch.delenv("CQ_ENTERPRISE_ROOT_PRIVKEY_PATH", raising=False)
         seen = _mock_provisioning(monkeypatch, lambda r: httpx.Response(202, json={}))
@@ -322,9 +316,7 @@ class TestCreateL2Forward:
         # The proxy must NOT have forwarded an unsigned request.
         assert seen == []
 
-    def test_upstream_error_envelope_passed_through(
-        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_upstream_error_envelope_passed_through(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
         def _handler(request: httpx.Request) -> httpx.Response:
             return httpx.Response(
                 409,
@@ -345,9 +337,7 @@ class TestCreateL2Forward:
         assert resp.status_code == 409
         assert resp.json()["code"] == "L2_SLUG_TAKEN"
 
-    def test_upstream_403_forbidden_passed_through(
-        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_upstream_403_forbidden_passed_through(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
         """A directory 403 FORBIDDEN (wrong Enterprise) relays verbatim."""
 
         def _handler(request: httpx.Request) -> httpx.Response:
@@ -366,9 +356,7 @@ class TestCreateL2Forward:
         assert resp.status_code == 403
         assert resp.json()["code"] == "FORBIDDEN"
 
-    def test_transport_failure_maps_to_502(
-        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_transport_failure_maps_to_502(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
         def _handler(request: httpx.Request) -> httpx.Response:
             raise httpx.ConnectError("connection refused", request=request)
 
@@ -409,9 +397,7 @@ class TestStreamAuth:
         resp = client.get("/api/v1/admin/l2s/jobs/job-1/stream")
         assert resp.status_code == 401
 
-    def test_stream_missing_identity_key_is_500(
-        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_stream_missing_identity_key_is_500(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("CQ_ENTERPRISE_ROOT_PRIVKEY_PATH", raising=False)
         token = _login(client, USER_A)
         resp = client.get(
@@ -596,9 +582,7 @@ async def test_stream_survives_transient_poll_failure(
     assert "event: completed" in blob
 
 
-async def test_stream_404_job_closes_as_failed(
-    monkeypatch: pytest.MonkeyPatch, stream_key: Ed25519PrivateKey
-) -> None:
+async def test_stream_404_job_closes_as_failed(monkeypatch: pytest.MonkeyPatch, stream_key: Ed25519PrivateKey) -> None:
     """A 404 from the directory poll route is terminal — stream closes failed."""
     rows = [{"_http_status": 404, "error": "not found", "code": "NOT_FOUND", "detail": ""}]
     _install_scripted(monkeypatch, rows)
@@ -624,3 +608,149 @@ async def test_stream_auth_rejected_closes_as_failed(
     failed = [f for f in frames if "event: failed" in f][0]
     payload = json.loads(failed.split("data: ", 1)[1].strip())
     assert "identity proof" in payload["error"]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/admin/l2s/slug-available/{l2_slug} — slug-availability passthrough
+# ---------------------------------------------------------------------------
+#
+# The wizard's slug field debounce-probes this route for a live "is this L2
+# slug free" hint. It is a thin passthrough to the directory's auth-gated
+# GET .../l2s/slug-available/{l2_slug} — the directory returns 200
+# {available: true} when free / 409 {available: false} when taken, and the
+# proxy presents the same X-8L-Identity-Proof header the SSE poll loop builds.
+
+
+class TestSlugAvailableAuth:
+    def test_requires_authentication(self, client: TestClient) -> None:
+        resp = client.get("/api/v1/admin/l2s/slug-available/sales")
+        assert resp.status_code == 401
+
+    def test_non_admin_forbidden(self, client: TestClient) -> None:
+        token = _login(client, USER_A)
+        resp = client.get(
+            "/api/v1/admin/l2s/slug-available/sales",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 403
+
+
+class TestSlugAvailableForward:
+    def test_available_slug_returns_200_and_forwards_to_callers_enterprise(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A free slug → directory 200 {available: true}, relayed verbatim.
+
+        The forward URL must carry the caller's OWN enterprise_id and the
+        directory's slug-available path; the browser never sends a tenancy.
+        """
+
+        def _handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"l2_slug": "sales", "available": True})
+
+        seen = _mock_provisioning(monkeypatch, _handler)
+        token = _login(client, ADMIN_A)
+        resp = client.get(
+            "/api/v1/admin/l2s/slug-available/sales",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {"l2_slug": "sales", "available": True}
+
+        # Tenancy: the forward URL carries the caller's own enterprise_id.
+        assert len(seen) == 1
+        fwd = seen[0]
+        assert fwd.method == "GET"
+        assert str(fwd.url) == (f"{PROVISIONING_BASE}/api/v1/enterprises/{ENT_A}/l2s/slug-available/sales")
+
+    def test_taken_slug_returns_409_passthrough(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A taken slug → directory 409 {available: false}, relayed verbatim.
+
+        The directory's 409 body is the {l2_slug, available} answer shape,
+        NOT a {error, code, detail} envelope — it must pass straight through.
+        """
+
+        def _handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(409, json={"l2_slug": "taken", "available": False})
+
+        _mock_provisioning(monkeypatch, _handler)
+        token = _login(client, ADMIN_A)
+        resp = client.get(
+            "/api/v1/admin/l2s/slug-available/taken",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 409
+        assert resp.json() == {"l2_slug": "taken", "available": False}
+
+    def test_forward_sends_signed_identity_proof_header(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Directory #22 auth contract — the GET carries a signed identity proof.
+
+        The body-less GET presents an X-8L-Identity-Proof header whose
+        SignedEnvelope verifies and binds to the caller's Enterprise.
+        """
+
+        def _handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"l2_slug": "sales", "available": True})
+
+        seen = _mock_provisioning(monkeypatch, _handler)
+        token = _login(client, ADMIN_A)
+        resp = client.get(
+            "/api/v1/admin/l2s/slug-available/sales",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200, resp.text
+
+        proof = seen[0].headers.get("X-8L-Identity-Proof")
+        assert proof, "forward request missing X-8L-Identity-Proof header"
+        envelope = _decode_proof_header(proof)
+        _assert_signed_envelope(envelope, expected_enterprise_id=ENT_A)
+        # The signing key is the Enterprise root key.
+        root = load_private_key(Path(os.environ["CQ_ENTERPRISE_ROOT_PRIVKEY_PATH"]))
+        assert envelope["signing_key_id"] == public_key_b64u(root)
+
+    def test_missing_identity_key_is_500(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No Enterprise root key mount → 500 IDENTITY_KEY_UNAVAILABLE, no forward."""
+        monkeypatch.delenv("CQ_ENTERPRISE_ROOT_PRIVKEY_PATH", raising=False)
+        seen = _mock_provisioning(monkeypatch, lambda r: httpx.Response(200, json={}))
+        token = _login(client, ADMIN_A)
+        resp = client.get(
+            "/api/v1/admin/l2s/slug-available/sales",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 500
+        assert resp.json()["code"] == "IDENTITY_KEY_UNAVAILABLE"
+        # The proxy must NOT have forwarded an unsigned request.
+        assert seen == []
+
+    def test_transport_failure_maps_to_502(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("connection refused", request=request)
+
+        _mock_provisioning(monkeypatch, _handler)
+        token = _login(client, ADMIN_A)
+        resp = client.get(
+            "/api/v1/admin/l2s/slug-available/sales",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 502
+        assert resp.json()["code"] == "PROVISIONING_UNREACHABLE"
+
+    def test_upstream_auth_rejection_passed_through(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A directory 403 FORBIDDEN (rejected proof) relays its envelope verbatim."""
+
+        def _handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                403,
+                json={"error": "enterprise mismatch", "code": "FORBIDDEN", "detail": ""},
+            )
+
+        _mock_provisioning(monkeypatch, _handler)
+        token = _login(client, ADMIN_A)
+        resp = client.get(
+            "/api/v1/admin/l2s/slug-available/sales",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 403
+        assert resp.json()["code"] == "FORBIDDEN"

--- a/server/frontend/src/api.ts
+++ b/server/frontend/src/api.ts
@@ -245,18 +245,19 @@ export const api = {
     }),
 
   // checkL2SlugAvailable does a debounced live availability probe for the
-  // wizard's name step. The cq-server proxy's slug-availability route is not
-  // part of PR #292 (the create call is the authoritative uniqueness check —
-  // it 409s L2_SLUG_TAKEN). Until a dedicated GET lands, a 404 (route absent)
-  // resolves to `unknown` so the UI falls back to client-side regex
-  // validation rather than hard-blocking the wizard. A 409 means taken; a
-  // 2xx body's `available` flag is honoured when the route does exist.
+  // wizard's name step. It hits the cq-server proxy's slug-availability
+  // passthrough (agent#193, PR #295) — a path-param route matching the
+  // directory contract: GET .../l2s/slug-available/{l2_slug}. The directory
+  // answers 200 {available:true} / 409 {available:false}; a 404 (route not
+  // deployed on this L2 yet) still resolves to `unknown` so the UI falls
+  // back to client-side regex rather than hard-blocking the wizard. The
+  // create call remains the authoritative uniqueness check (409 at provision).
   checkL2SlugAvailable: async (
     slug: string,
   ): Promise<"available" | "taken" | "unknown"> => {
     try {
       const resp = await request<{ available?: boolean }>(
-        `/admin/l2s/slug-available?slug=${encodeURIComponent(slug)}`,
+        `/admin/l2s/slug-available/${encodeURIComponent(slug)}`,
       )
       if (resp && resp.available === false) return "taken"
       return "available"


### PR DESCRIPTION
## What

End-to-end FO-3 slug-availability check. Two commits:

**1. Backend** — adds `GET /api/v1/admin/l2s/slug-available/{l2_slug}` to the FO-3 cq-server L2-provision proxy (`l2_provision_routes.py`, the module from #292).

The route is `require_admin`, resolves the caller's `enterprise_id` from their user row via the existing `_resolve_caller_enterprise` helper, and forwards to the directory's auth-gated `GET /api/v1/enterprises/{enterprise_id}/l2s/slug-available/{l2_slug}`. It reuses the exact `X-8L-Identity-Proof` Enterprise-root signing helper (`_build_identity_proof_header`) the SSE poll loop already builds — same directory PR #22 FO-3 auth contract.

Passthrough behaviour, verified against `8th-layer-directory/src/directory/routes/provisioning_l2.py`:
- `200 {l2_slug, available: true}` (free) and `409 {l2_slug, available: false}` (taken) — both are *answer* bodies, not `{error,code,detail}` envelopes; relayed verbatim with their status.
- `401/403` (rejected proof), `404` (unknown Enterprise), `422` (malformed slug), `5xx` — surface the directory's `{error,code,detail}` envelope via the module's existing `_passthrough_upstream_error`.
- Transport failure → `502 PROVISIONING_UNREACHABLE`; missing identity-key mount → `500 IDENTITY_KEY_UNAVAILABLE` (no unsigned request leaves the proxy) — identical handling to the create + SSE routes.

**2. Frontend caller fix** — `checkL2SlugAvailable()` in `server/frontend/src/api.ts` previously probed the query-param form `/admin/l2s/slug-available?slug={slug}`. Switched it to the path-param form `/admin/l2s/slug-available/{slug}` (slug `encodeURIComponent`-escaped) so it matches the new backend route + the directory contract. The 404→`unknown` fallback is unchanged, so the wizard still degrades gracefully on an L2 where the route isn't deployed yet.

With both commits, #295 is the complete, end-to-end slug-available change — backend route + frontend caller.

## Why

The FO-3 Create-L2 wizard (merged in #294) calls `checkL2SlugAvailable()` for a debounced live availability hint. The backend route did not exist and the frontend used a mismatched URL shape — the wizard degraded to client-side regex + the authoritative 409 at provision time. This wires the live check end-to-end.

## Test results

Backend — 8 new cases in `test_l2_provision_routes.py` (`TestSlugAvailableAuth` + `TestSlugAvailableForward`): available→200, taken→409, identity-proof header sent + signed + verifies against the Enterprise root key, auth required (401 unauth / 403 non-admin), missing key→500 with no forward, transport→502, upstream auth-rejection envelope passthrough.
- `uv run pytest tests/test_l2_provision_routes.py` — 27 passed (19 existing + 8 new).
- `ruff check` + `ruff format --check` — clean on both touched files.

Frontend — no dedicated `checkL2SlugAvailable` test existed; the change is a one-line URL shape.
- `scripts/lint-frontend.sh` (biome + tsc) — clean.
- `pnpm test --run` — 78 passed (13 files).

No deploy — code + PR only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)