### PR TITLE
ops(deploy): bump L2 ALB idle timeout to 420s for FO-3 SSE stream

### DIFF
--- a/deploy/aws/marketplace-l2.yaml
+++ b/deploy/aws/marketplace-l2.yaml
@@ -512,6 +512,12 @@ Resources:
       Scheme: internet-facing
       Subnets: [!Ref PublicSubnetA, !Ref PublicSubnetB]
       SecurityGroups: [!Ref AlbSecurityGroup]
+      # 420s idle timeout: the FO-3 Create-L2 wizard streams an SSE
+      # progress feed for the full ~5min L2 standup. The 60s default
+      # would drop the connection mid-standup. See Decision 32 #4.
+      LoadBalancerAttributes:
+        - Key: idle_timeout.timeout_seconds
+          Value: "420"
 
   TargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup


### PR DESCRIPTION
## What

Add `LoadBalancerAttributes: idle_timeout.timeout_seconds = 420` to the marketplace L2 CloudFormation template (`deploy/aws/marketplace-l2.yaml`).

## Why

The FO-3 Create-L2 wizard streams an SSE progress feed for the full ~5min L2 standup. The ALB's default 60s idle timeout drops that connection mid-standup, killing the wizard's progress page. This is **Decision 32 #4** — scoped as a deliberate, separately-reviewed ops change.

This PR covers **newly auto-provisioned L2s**. The two live L2s (`eighth-layer-corp-engineering-l2`, `eighth-layer-corp-sga-l2`) were already bumped directly via `update-stack` change-sets as part of the FO-3 deploy — both verified at `idle_timeout=420`, healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)