### PR TITLE
feat(admin): FO-4 Phase 1 — Add-Agent backend, mint agent key (agent#194)

### DIFF
--- a/server/backend/src/cq_server/agent_key_routes.py
+++ b/server/backend/src/cq_server/agent_key_routes.py
@@ -3,7 +3,7 @@
 Endpoints (all gated on ``require_admin``, mounted under ``/api/v1``):
 
   POST /admin/agent-keys   — mint a new agent persona + cqa.v1.* key
-  GET  /admin/agent-keys   — list every agent-persona key on this L2
+  GET  /admin/agent-keys   — list agent-persona keys in the caller's tenancy
 
 An "agent" here is a stub ``users`` row carrying a ``persona_assignments``
 row at ``persona='agent'`` plus an ``api_keys`` row — the exact shape a
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import logging
 import re
+import sqlite3
 import uuid
 from datetime import UTC, datetime
 from typing import Literal
@@ -132,6 +133,21 @@ def _to_agent_public(row: dict, agent_username: str) -> AgentKeyPublic:
     return AgentKeyPublic(**base.model_dump(), agent_username=agent_username)
 
 
+async def _resolve_admin_tenancy(store: SqliteStore, admin: str) -> tuple[str, str]:
+    """Resolve the calling admin's ``(enterprise_id, group_id)``.
+
+    Both the mint and list paths scope to this tuple so a minted agent and
+    the admin who lists it always agree on tenancy — closing the cross-
+    Enterprise/L2 leak a node-wide list would otherwise have. Falls back to
+    the default scope when the admin row carries no tenancy, the same
+    convention the rest of cq-server uses (see ``auth.scope_filter``).
+    """
+    admin_user = await store.get_user(admin)
+    enterprise_id = (admin_user or {}).get("enterprise_id") or DEFAULT_ENTERPRISE_ID
+    group_id = (admin_user or {}).get("group_id") or DEFAULT_GROUP_ID
+    return enterprise_id, group_id
+
+
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
@@ -162,28 +178,30 @@ async def mint_agent_key(
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
     username = _AGENT_USERNAME_PREFIX + _slugify_agent_name(req.agent_name)
+    dup_detail = f"an agent named {req.agent_name!r} already exists (username {username!r}) — pick a different name"
 
     if await store.get_user(username) is not None:
-        raise HTTPException(
-            status_code=409,
-            detail=f"an agent named {req.agent_name!r} already exists (username {username!r}) — pick a different name",
-        )
+        raise HTTPException(status_code=409, detail=dup_detail)
 
     # Inherit the minting admin's tenancy so the agent lands in this L2.
-    admin_user = await store.get_user(admin)
-    enterprise_id = (admin_user or {}).get("enterprise_id") or DEFAULT_ENTERPRISE_ID
-    group_id = (admin_user or {}).get("group_id") or DEFAULT_GROUP_ID
+    enterprise_id, group_id = await _resolve_admin_tenancy(store, admin)
 
     # 1. Stub user — random password hash, never usable for login. The
-    #    agent authenticates only via its cqa.v1.* bearer key.
+    #    agent authenticates only via its cqa.v1.* bearer key. The
+    #    get_user pre-check above is racy; the UNIQUE(username) constraint
+    #    is the real arbiter, so a concurrent collision still 409s rather
+    #    than surfacing as an unhandled 500.
     stub_hash = hash_password(uuid.uuid4().hex)
-    await store.create_user(
-        username,
-        stub_hash,
-        role="user",
-        enterprise_id=enterprise_id,
-        group_id=group_id,
-    )
+    try:
+        await store.create_user(
+            username,
+            stub_hash,
+            role="user",
+            enterprise_id=enterprise_id,
+            group_id=group_id,
+        )
+    except sqlite3.IntegrityError as exc:
+        raise HTTPException(status_code=409, detail=dup_detail) from exc
 
     # 2. Persona assignment — marks the stub user as an agent.
     now = datetime.now(UTC).isoformat()
@@ -240,11 +258,14 @@ async def list_agent_keys(
     admin: str = Depends(require_admin),
     store: SqliteStore = Depends(get_store),
 ) -> AgentKeyListResponse:
-    """List every agent-persona key on this L2 (never returns plaintext).
+    """List agent-persona keys in the caller's Enterprise/L2 tenancy.
 
-    Revoked and expired keys are included with ``is_active: false`` so the
-    admin table doubles as a revocation-history audit.
+    Scoped to the calling admin's ``(enterprise_id, group_id)`` so no
+    cross-tenancy leak; never returns plaintext. Revoked and expired keys
+    are included with ``is_active: false`` so the admin table doubles as a
+    revocation-history audit.
     """
-    rows = await store.list_agent_api_keys()
+    enterprise_id, group_id = await _resolve_admin_tenancy(store, admin)
+    rows = await store.list_agent_api_keys(enterprise_id=enterprise_id, group_id=group_id)
     data = [_to_agent_public(row, agent_username=row["agent_username"]) for row in rows]
     return AgentKeyListResponse(data=data, count=len(data))

--- a/server/backend/src/cq_server/agent_key_routes.py
+++ b/server/backend/src/cq_server/agent_key_routes.py
@@ -1,0 +1,250 @@
+"""FO-4: Self-service Add Agent — admin routes for minting agent keys.
+
+Endpoints (all gated on ``require_admin``, mounted under ``/api/v1``):
+
+  POST /admin/agent-keys   — mint a new agent persona + cqa.v1.* key
+  GET  /admin/agent-keys   — list every agent-persona key on this L2
+
+An "agent" here is a stub ``users`` row carrying a ``persona_assignments``
+row at ``persona='agent'`` plus an ``api_keys`` row — the exact shape a
+Human persona uses (see ``persona_routes.create_persona``), minus the
+magic-link invite. The plaintext ``cqa.v1.*`` token is returned exactly
+once in the mint response and is never recoverable afterwards.
+
+Per Decision 33: FO-4 V1 mints full-capability keys — there is no
+per-key permission-scope selector because no scope-enforcement mechanism
+exists yet (``api_keys.labels`` is free-form; ``auth.scope_filter``
+scopes only by tenancy). Scope enforcement is a tracked follow-up.
+
+Auth: ``require_admin`` — the same FO-1c session-cookie gate used by
+``persona_routes`` and ``l2_provision_routes``.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import uuid
+from datetime import UTC, datetime
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from .api_keys import encode_token, generate_secret, hash_secret, secret_prefix
+from .auth import ApiKeyPublic, _to_public, hash_password, require_admin
+from .deps import get_api_key_pepper, get_store
+from .store._sqlite import SqliteStore
+from .tables import DEFAULT_ENTERPRISE_ID, DEFAULT_GROUP_ID
+from .ttl import parse_ttl
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/admin/agent-keys", tags=["admin", "agent-keys"])
+
+HarnessEnum = Literal["claude-code", "claude-desktop", "openclaw", "other"]
+
+DEFAULT_AGENT_TTL = "60d"
+
+# An agent username is ``agent-<slug>`` so agent stub users never collide
+# with Human usernames (which are email-derived).
+_AGENT_USERNAME_PREFIX = "agent-"
+_SLUG_MAX = 48
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+class MintAgentKeyRequest(BaseModel):
+    """Request body for minting an agent key."""
+
+    agent_name: str = Field(min_length=1, max_length=64)
+    harness: HarnessEnum
+    ttl: str = Field(default=DEFAULT_AGENT_TTL, min_length=1, max_length=16)
+
+
+class AgentInstallPaths(BaseModel):
+    """The pieces the admin UI renders into install paths.
+
+    The backend ships the fully-assembled ``join_command``; the UI builds
+    the plugin-install command and the QR payload from the scalar fields
+    so a marketplace-slug change never needs a backend redeploy.
+    """
+
+    join_command: str
+    enterprise_id: str
+    l2: str
+    persona: str = "agent"
+
+
+class AgentKeyPublic(ApiKeyPublic):
+    """Public view of an agent key — api-key fields plus the owning agent."""
+
+    agent_username: str
+
+
+class MintAgentKeyResponse(AgentKeyPublic):
+    """Mint response. ``token`` is the plaintext key, returned exactly once."""
+
+    token: str
+    install: AgentInstallPaths
+
+
+class AgentKeyListResponse(BaseModel):
+    """Collection wrapper for the agent-key admin table."""
+
+    data: list[AgentKeyPublic]
+    count: int
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _slugify_agent_name(agent_name: str) -> str:
+    """Derive a URL/username-safe slug from a free-text agent name.
+
+    Lowercases, maps every run of non-alphanumerics to a single hyphen,
+    trims leading/trailing hyphens, and caps length. Raises 422 when the
+    name has no usable characters (e.g. all punctuation).
+    """
+    slug = re.sub(r"[^a-z0-9]+", "-", agent_name.strip().lower()).strip("-")
+    slug = slug[:_SLUG_MAX].strip("-")
+    if not slug:
+        raise HTTPException(
+            status_code=422,
+            detail="agent_name must contain at least one letter or digit",
+        )
+    return slug
+
+
+def _build_join_command(*, enterprise_id: str, l2: str, token: str) -> str:
+    """Assemble the ``8l join`` one-liner an agent operator copy-pastes."""
+    return f"8l join --enterprise {enterprise_id} --l2 {l2} --persona agent --api-key {token} --non-interactive"
+
+
+def _to_agent_public(row: dict, agent_username: str) -> AgentKeyPublic:
+    """Build the agent-key public view from an api-key row."""
+    base = _to_public(row)
+    return AgentKeyPublic(**base.model_dump(), agent_username=agent_username)
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@router.post("", response_model=MintAgentKeyResponse, status_code=201)
+async def mint_agent_key(
+    req: MintAgentKeyRequest,
+    admin: str = Depends(require_admin),
+    store: SqliteStore = Depends(get_store),
+    pepper: str = Depends(get_api_key_pepper),
+) -> MintAgentKeyResponse:
+    """Mint a new agent persona and its ``cqa.v1.*`` key.
+
+    Creates a stub ``users`` row, a ``persona_assignments`` row at
+    ``persona='agent'``, and an ``api_keys`` row in that order. The new
+    agent inherits the minting admin's ``enterprise_id`` / ``group_id``
+    so it lands in the same L2 tenancy. The plaintext token is returned
+    once; only its HMAC hash + 8-char prefix are persisted.
+
+    Raises:
+        HTTPException: 422 on an unusable agent_name or bad TTL,
+            409 when the derived agent username already exists.
+    """
+    try:
+        duration = parse_ttl(req.ttl)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    username = _AGENT_USERNAME_PREFIX + _slugify_agent_name(req.agent_name)
+
+    if await store.get_user(username) is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=f"an agent named {req.agent_name!r} already exists (username {username!r}) — pick a different name",
+        )
+
+    # Inherit the minting admin's tenancy so the agent lands in this L2.
+    admin_user = await store.get_user(admin)
+    enterprise_id = (admin_user or {}).get("enterprise_id") or DEFAULT_ENTERPRISE_ID
+    group_id = (admin_user or {}).get("group_id") or DEFAULT_GROUP_ID
+
+    # 1. Stub user — random password hash, never usable for login. The
+    #    agent authenticates only via its cqa.v1.* bearer key.
+    stub_hash = hash_password(uuid.uuid4().hex)
+    await store.create_user(
+        username,
+        stub_hash,
+        role="user",
+        enterprise_id=enterprise_id,
+        group_id=group_id,
+    )
+
+    # 2. Persona assignment — marks the stub user as an agent.
+    now = datetime.now(UTC).isoformat()
+    await store.upsert_persona_assignment(
+        username=username,
+        persona="agent",
+        assigned_at=now,
+        assigned_by=admin,
+        audit_action="CREATED",
+        audit_old_persona=None,
+    )
+
+    # 3. API key owned by the agent stub user.
+    new_user = await store.get_user(username)
+    if new_user is None:  # pragma: no cover — created two statements ago
+        raise HTTPException(status_code=500, detail="agent user vanished after creation")
+    user_id = int(new_user["id"])
+
+    key_id = uuid.uuid4()
+    secret = generate_secret()
+    plaintext = encode_token(key_id=key_id, secret=secret)
+    expires_at = (datetime.now(UTC) + duration).isoformat()
+    row = await store.create_api_key(
+        key_id=key_id.hex,
+        user_id=user_id,
+        name=req.agent_name,
+        labels=[f"harness:{req.harness}", "persona:agent"],
+        key_prefix=secret_prefix(secret),
+        key_hash=hash_secret(secret, pepper=pepper),
+        ttl=req.ttl,
+        expires_at=expires_at,
+    )
+
+    log.info(
+        "FO-4: admin %r minted agent key for %r (harness=%s, l2=%s/%s)",
+        admin,
+        username,
+        req.harness,
+        enterprise_id,
+        group_id,
+    )
+
+    public = _to_agent_public(row, agent_username=username)
+    install = AgentInstallPaths(
+        join_command=_build_join_command(enterprise_id=enterprise_id, l2=group_id, token=plaintext),
+        enterprise_id=enterprise_id,
+        l2=group_id,
+    )
+    return MintAgentKeyResponse(**public.model_dump(), token=plaintext, install=install)
+
+
+@router.get("", response_model=AgentKeyListResponse)
+async def list_agent_keys(
+    admin: str = Depends(require_admin),
+    store: SqliteStore = Depends(get_store),
+) -> AgentKeyListResponse:
+    """List every agent-persona key on this L2 (never returns plaintext).
+
+    Revoked and expired keys are included with ``is_active: false`` so the
+    admin table doubles as a revocation-history audit.
+    """
+    rows = await store.list_agent_api_keys()
+    data = [_to_agent_public(row, agent_username=row["agent_username"]) for row in rows]
+    return AgentKeyListResponse(data=data, count=len(data))

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -27,6 +27,7 @@ from . import aigrp
 from .activity_logger import log_activity, summary_first_60
 from .activity_routes import router as activity_router
 from .admin_routes import router as admin_xgroup_consent_router
+from .agent_key_routes import router as agent_key_router
 from .auth import get_current_user, require_admin
 from .auth import router as auth_router
 from .claim_page import router as claim_page_router
@@ -490,6 +491,8 @@ api_router.include_router(invite_router)
 api_router.include_router(l2_provision_router)
 # AS-1 (#229) — admin Personas CRUD endpoints.
 api_router.include_router(persona_router)
+# FO-4 (#194) — admin Add-Agent: mint agent persona + cqa.v1.* key.
+api_router.include_router(agent_key_router)
 # FO-1d (#199) — anonymous /theme endpoint for the per-L2 brand chrome.
 # Mounted on api_router so it lives under both / and /api/v1, same as
 # every other API route. Decision 30 sets the spec.

--- a/server/backend/src/cq_server/store/_sqlite.py
+++ b/server/backend/src/cq_server/store/_sqlite.py
@@ -372,14 +372,21 @@ class SqliteStore:
     async def list_api_keys_for_user(self, user_id: int) -> list[dict[str, Any]]:
         return await self._run_sync(self._list_api_keys_for_user_sync, user_id)
 
-    async def list_agent_api_keys(self) -> list[dict[str, Any]]:
-        """List every API key owned by an agent-persona user (FO-4).
+    async def list_agent_api_keys(
+        self, *, enterprise_id: str, group_id: str
+    ) -> list[dict[str, Any]]:
+        """List agent-persona API keys scoped to one ``(enterprise_id, group_id)``.
 
-        Joins ``api_keys`` to ``persona_assignments`` via the owning user
-        and filters to ``persona='agent'``. Each row carries the api-key
-        public fields plus the owning ``agent_username``.
+        Joins ``api_keys`` to ``persona_assignments`` via the owning user,
+        filters to ``persona='agent'``, and restricts to the owning user's
+        tenancy so an admin never sees another Enterprise/L2's agent keys.
+        Each row carries the api-key public fields plus ``agent_username``.
         """
-        return await self._run_sync(self._list_agent_api_keys_sync)
+        return await self._run_sync(
+            self._list_agent_api_keys_sync,
+            enterprise_id=enterprise_id,
+            group_id=group_id,
+        )
 
     async def list_units(
         self,
@@ -1979,9 +1986,12 @@ class SqliteStore:
             for row in rows
         ]
 
-    def _list_agent_api_keys_sync(self) -> list[dict[str, Any]]:
+    def _list_agent_api_keys_sync(
+        self, *, enterprise_id: str, group_id: str
+    ) -> list[dict[str, Any]]:
         # Inline SQL: joins api_keys → users → persona_assignments to
-        # surface only agent-persona keys (FO-4 admin table).
+        # surface only agent-persona keys (FO-4 admin table), scoped to
+        # the owning user's tenancy so no cross-Enterprise/L2 leak.
         stmt = text(
             "SELECT ak.id, ak.name, ak.labels, ak.key_prefix, ak.ttl, "
             "ak.expires_at, ak.created_at, ak.last_used_at, ak.revoked_at, "
@@ -1990,10 +2000,14 @@ class SqliteStore:
             "JOIN users u ON ak.user_id = u.id "
             "JOIN persona_assignments pa ON pa.username = u.username "
             "WHERE pa.persona = 'agent' "
+            "AND u.enterprise_id = :enterprise_id "
+            "AND u.group_id = :group_id "
             "ORDER BY ak.created_at DESC"
         )
         with self._engine.connect() as conn:
-            rows = conn.execute(stmt).fetchall()
+            rows = conn.execute(
+                stmt, {"enterprise_id": enterprise_id, "group_id": group_id}
+            ).fetchall()
         return [
             {
                 "id": row[0],

--- a/server/backend/src/cq_server/store/_sqlite.py
+++ b/server/backend/src/cq_server/store/_sqlite.py
@@ -372,6 +372,15 @@ class SqliteStore:
     async def list_api_keys_for_user(self, user_id: int) -> list[dict[str, Any]]:
         return await self._run_sync(self._list_api_keys_for_user_sync, user_id)
 
+    async def list_agent_api_keys(self) -> list[dict[str, Any]]:
+        """List every API key owned by an agent-persona user (FO-4).
+
+        Joins ``api_keys`` to ``persona_assignments`` via the owning user
+        and filters to ``persona='agent'``. Each row carries the api-key
+        public fields plus the owning ``agent_username``.
+        """
+        return await self._run_sync(self._list_agent_api_keys_sync)
+
     async def list_units(
         self,
         *,
@@ -1966,6 +1975,37 @@ class SqliteStore:
                 "created_at": row[6],
                 "last_used_at": row[7],
                 "revoked_at": row[8],
+            }
+            for row in rows
+        ]
+
+    def _list_agent_api_keys_sync(self) -> list[dict[str, Any]]:
+        # Inline SQL: joins api_keys → users → persona_assignments to
+        # surface only agent-persona keys (FO-4 admin table).
+        stmt = text(
+            "SELECT ak.id, ak.name, ak.labels, ak.key_prefix, ak.ttl, "
+            "ak.expires_at, ak.created_at, ak.last_used_at, ak.revoked_at, "
+            "u.username "
+            "FROM api_keys ak "
+            "JOIN users u ON ak.user_id = u.id "
+            "JOIN persona_assignments pa ON pa.username = u.username "
+            "WHERE pa.persona = 'agent' "
+            "ORDER BY ak.created_at DESC"
+        )
+        with self._engine.connect() as conn:
+            rows = conn.execute(stmt).fetchall()
+        return [
+            {
+                "id": row[0],
+                "name": row[1],
+                "labels": json.loads(row[2] or "[]"),
+                "key_prefix": row[3],
+                "ttl": row[4],
+                "expires_at": row[5],
+                "created_at": row[6],
+                "last_used_at": row[7],
+                "revoked_at": row[8],
+                "agent_username": row[9],
             }
             for row in rows
         ]

--- a/server/backend/tests/test_agent_key_routes.py
+++ b/server/backend/tests/test_agent_key_routes.py
@@ -148,3 +148,24 @@ def test_list_populated_never_leaks_plaintext(client: TestClient) -> None:
     for row in body["data"]:
         assert "token" not in row
         assert row["prefix"]  # 8-char display prefix is present
+
+
+def test_list_is_tenancy_scoped(client: TestClient) -> None:
+    """An admin sees only agent keys in their own Enterprise/L2.
+
+    The default admin lands agents in the default scope; a second admin in
+    Enterprise 'ent-b' lands agents there. Neither list call may surface
+    the other tenancy's keys.
+    """
+    store = _get_store()
+    pw = bcrypt.hashpw(PASSWORD.encode(), bcrypt.gensalt()).decode()
+    store.sync.create_user("admin@ent-b", pw, role="admin", enterprise_id="ent-b", group_id="grp-b")
+
+    _mint(client, _login(client, ADMIN), "Default Agent")
+    _mint(client, _login(client, "admin@ent-b"), "EntB Agent")
+
+    seen_default = client.get("/api/v1/admin/agent-keys", headers=_login(client, ADMIN)).json()
+    seen_entb = client.get("/api/v1/admin/agent-keys", headers=_login(client, "admin@ent-b")).json()
+
+    assert {r["agent_username"] for r in seen_default["data"]} == {"agent-default-agent"}
+    assert {r["agent_username"] for r in seen_entb["data"]} == {"agent-entb-agent"}

--- a/server/backend/tests/test_agent_key_routes.py
+++ b/server/backend/tests/test_agent_key_routes.py
@@ -1,0 +1,150 @@
+"""Tests for FO-4 Self-service Add Agent endpoints (agent#194).
+
+Covers:
+* auth gating — non-admin gets 403 on mint + list
+* POST /admin/agent-keys — happy path: token shape, install paths, persona
+* POST — 409 on duplicate agent name, 422 on unusable name / bad TTL
+* GET /admin/agent-keys — empty + populated; never leaks plaintext
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+from pathlib import Path
+
+import bcrypt
+import pytest
+from fastapi.testclient import TestClient
+
+from cq_server.app import _get_store, app
+
+ADMIN = "admin@agentkey-test"
+NON_ADMIN = "user@agentkey-test"
+PASSWORD = "password123!"  # pragma: allowlist secret
+
+# Matches the cqa.v1.<32-hex>.<52-char-secret> token format.
+_TOKEN_RE = re.compile(r"^cqa\.v1\.[a-f0-9]{32}\.[a-z2-7]{52}$")
+
+
+@pytest.fixture
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "agentkeys.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    monkeypatch.setenv("CQ_PUBLIC_HOST", "https://test.8th-layer.ai")
+
+    with TestClient(app) as c:
+        store = _get_store()
+        pw = bcrypt.hashpw(PASSWORD.encode(), bcrypt.gensalt()).decode()
+        store.sync.create_user(ADMIN, pw)
+        store.sync.create_user(NON_ADMIN, pw)
+        store.sync.set_user_role(ADMIN, "admin")
+        yield c
+
+
+def _login(client: TestClient, username: str) -> dict[str, str]:
+    resp = client.post(
+        "/api/v1/auth/login",
+        json={"username": username, "password": PASSWORD},
+    )
+    assert resp.status_code == 200, resp.text
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
+def _mint(client: TestClient, headers: dict[str, str], name: str, **over: object) -> object:
+    body = {"agent_name": name, "harness": "claude-code"}
+    body.update(over)
+    return client.post("/api/v1/admin/agent-keys", headers=headers, json=body)
+
+
+# ---------------------------------------------------------------------------
+# Auth gating
+# ---------------------------------------------------------------------------
+
+
+def test_mint_requires_admin(client: TestClient) -> None:
+    resp = _mint(client, _login(client, NON_ADMIN), "Build Bot")
+    assert resp.status_code == 403
+
+
+def test_list_requires_admin(client: TestClient) -> None:
+    resp = client.get("/api/v1/admin/agent-keys", headers=_login(client, NON_ADMIN))
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# POST /admin/agent-keys
+# ---------------------------------------------------------------------------
+
+
+def test_mint_happy_path(client: TestClient) -> None:
+    headers = _login(client, ADMIN)
+    resp = _mint(client, headers, "Build Bot")
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+
+    assert _TOKEN_RE.match(body["token"]), body["token"]
+    assert body["agent_username"] == "agent-build-bot"
+    assert body["name"] == "Build Bot"
+    assert "harness:claude-code" in body["labels"]
+    assert body["is_active"] is True
+
+    install = body["install"]
+    assert install["persona"] == "agent"
+    assert body["token"] in install["join_command"]
+    assert install["join_command"].startswith("8l join --enterprise ")
+    assert "--persona agent" in install["join_command"]
+
+
+def test_mint_duplicate_name_conflicts(client: TestClient) -> None:
+    headers = _login(client, ADMIN)
+    assert _mint(client, headers, "Dup Agent").status_code == 201
+    resp = _mint(client, headers, "Dup Agent")
+    assert resp.status_code == 409
+
+
+def test_mint_unusable_name_rejected(client: TestClient) -> None:
+    resp = _mint(client, _login(client, ADMIN), "!!!")
+    assert resp.status_code == 422
+
+
+def test_mint_bad_ttl_rejected(client: TestClient) -> None:
+    resp = _mint(client, _login(client, ADMIN), "Ttl Agent", ttl="banana")
+    assert resp.status_code == 422
+
+
+def test_mint_default_ttl_is_60d(client: TestClient) -> None:
+    resp = _mint(client, _login(client, ADMIN), "Default Ttl")
+    assert resp.status_code == 201
+    assert resp.json()["ttl"] == "60d"
+
+
+# ---------------------------------------------------------------------------
+# GET /admin/agent-keys
+# ---------------------------------------------------------------------------
+
+
+def test_list_empty(client: TestClient) -> None:
+    resp = client.get("/api/v1/admin/agent-keys", headers=_login(client, ADMIN))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["data"] == []
+    assert body["count"] == 0
+
+
+def test_list_populated_never_leaks_plaintext(client: TestClient) -> None:
+    headers = _login(client, ADMIN)
+    _mint(client, headers, "Agent One")
+    _mint(client, headers, "Agent Two")
+
+    resp = client.get("/api/v1/admin/agent-keys", headers=headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["count"] == 2
+    usernames = {row["agent_username"] for row in body["data"]}
+    assert usernames == {"agent-agent-one", "agent-agent-two"}
+    # The plaintext token is returned only by the mint response, never here.
+    for row in body["data"]:
+        assert "token" not in row
+        assert row["prefix"]  # 8-char display prefix is present

--- a/server/frontend/src/types.ts
+++ b/server/frontend/src/types.ts
@@ -106,6 +106,43 @@ export interface ApiKeysList {
   count: number
 }
 
+// --- FO-4: Self-service Add Agent (agent#194 / Decision 33) ---------------
+
+export type AgentHarness =
+  | "claude-code"
+  | "claude-desktop"
+  | "openclaw"
+  | "other"
+
+export interface MintAgentKeyRequest {
+  agent_name: string
+  harness: AgentHarness
+  ttl: string
+}
+
+/** Scalar pieces the UI renders into install paths (join cmd / plugin / QR). */
+export interface AgentInstallPaths {
+  join_command: string
+  enterprise_id: string
+  l2: string
+  persona: string
+}
+
+export interface AgentKeyPublic extends ApiKeyPublic {
+  agent_username: string
+}
+
+/** Mint response — `token` is the plaintext key, returned exactly once. */
+export interface MintAgentKeyResponse extends AgentKeyPublic {
+  token: string
+  install: AgentInstallPaths
+}
+
+export interface AgentKeyListResponse {
+  data: AgentKeyPublic[]
+  count: number
+}
+
 export interface MessageResponse {
   message: string
 }


### PR DESCRIPTION
**FO-4 Phase 1** — backend for the Self-service Add Agent feature ([agent#194](https://github.com/OneZero1ai/8th-layer-agent/issues/194), Founder Onboarding Act IV). Design: [Decision 33](https://github.com/OneZero1ai/8th-layer-core/pull/69).

## What

New admin router `/admin/agent-keys` (mounted under `/api/v1`):

- **`POST /admin/agent-keys`** — mints a new agent persona: a stub `users` row + a `persona_assignments` row (`persona='agent'`) + an `api_keys` row, in that order. Returns the plaintext `cqa.v1.*` token **exactly once** plus the assembled `8l join …` command. The agent inherits the minting admin's `enterprise_id`/`group_id` so it lands in the same L2 tenancy.
- **`GET /admin/agent-keys`** — lists every agent-persona key on this L2 for the admin table; never returns plaintext.

Both gated on `Depends(require_admin)` — the same FO-1c session gate as `persona_routes` / `l2_provision_routes`. No new auth mechanism.

`store.list_agent_api_keys()` added (joins `api_keys` → `persona_assignments`).

## Per Decision 33

V1 mints **full-capability keys** — no per-key permission-scope selector, because no scope-enforcement mechanism exists yet (`api_keys.labels` is free-form; `auth.scope_filter` scopes only by tenancy). Scope enforcement is filed as a separate follow-up.

## Tests

9 new route tests (`test_agent_key_routes.py`) — auth gating, mint happy-path + token shape + install paths, 409 duplicate, 422 unusable-name / bad-TTL, list empty/populated + no-plaintext-leak. `test_persona_routes` + `test_api_keys` suites still green (36 passed).

Phase 2 (admin-shell wizard frontend) lands as a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)