### PR TITLE
feat(admin): FO-4 Phase 2 — Add-Agent wizard frontend (agent#194)

### DIFF
--- a/server/frontend/package.json
+++ b/server/frontend/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "framer-motion": "^12.38.0",
     "lucide-react": "^1.14.0",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router": "^7.13.1",

--- a/server/frontend/pnpm-lock.yaml
+++ b/server/frontend/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       lucide-react:
         specifier: ^1.14.0
         version: 1.14.0(react@19.2.4)
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@19.2.4)
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -976,6 +979,11 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
@@ -2031,6 +2039,10 @@ snapshots:
 
   punycode@2.3.1:
     optional: true
+
+  qrcode.react@4.2.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:

--- a/server/frontend/src/App.tsx
+++ b/server/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Navigate, Route, Routes } from "react-router"
 import { AuthProvider, useAuth } from "./auth"
 import { Layout } from "./components/Layout"
 import { ProtectedRoute } from "./components/ProtectedRoute"
+import { AddAgentPage } from "./pages/AddAgentPage"
 import { ApiKeysPage } from "./pages/ApiKeysPage"
 import { CreateL2Page } from "./pages/CreateL2Page"
 import { CrosstalkPage } from "./pages/CrosstalkPage"
@@ -64,6 +65,7 @@ function AppRoutes() {
         <Route path="/admin/personas" element={<PersonasPage />} />
         <Route path="/admin/invites" element={<InvitesPage />} />
         <Route path="/admin/l2s/new" element={<CreateL2Page />} />
+        <Route path="/admin/agents/new" element={<AddAgentPage />} />
       </Route>
       <Route path="*" element={<Navigate to="/review" replace />} />
     </Routes>

--- a/server/frontend/src/api.ts
+++ b/server/frontend/src/api.ts
@@ -1,6 +1,7 @@
 import type { CreateL2Request, CreateL2Response } from "./l2wizard/types"
 import type {
   ActivityListResponse,
+  AgentKeyListResponse,
   ApiKeysList,
   ConsultInboxResponse,
   ConsultMessagesResponse,
@@ -14,6 +15,8 @@ import type {
   InviteStatus,
   InvitesPublic,
   MessageResponse,
+  MintAgentKeyRequest,
+  MintAgentKeyResponse,
   PatchPersonaRequest,
   PatchPersonaResponse,
   PersonaListResponse,
@@ -243,6 +246,20 @@ export const api = {
       method: "POST",
       body: JSON.stringify(body),
     }),
+
+  // FO-4 (agent#194): mint a new agent persona + cqa.v1.* key. The 201
+  // response carries the plaintext `token` exactly once plus the assembled
+  // `install` paths — the caller must surface it immediately and never
+  // re-fetch (the backend stores only the hash).
+  mintAgentKey: (body: MintAgentKeyRequest) =>
+    request<MintAgentKeyResponse>("/admin/agent-keys", {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+
+  // listAgentKeys returns the agent-persona keys in the caller's tenancy
+  // for the admin table; never includes plaintext.
+  listAgentKeys: () => request<AgentKeyListResponse>("/admin/agent-keys"),
 
   // checkL2SlugAvailable does a debounced live availability probe for the
   // wizard's name step. It hits the cq-server proxy's slug-availability

--- a/server/frontend/src/components/Layout.tsx
+++ b/server/frontend/src/components/Layout.tsx
@@ -71,6 +71,7 @@ export function Layout() {
             {navLink("/settings/api-keys", "API Keys", "api-keys")}
             {navLink("/admin/personas", "Personas", "personas")}
             {navLink("/admin/l2s/new", "Add L2", "add-l2")}
+            {navLink("/admin/agents/new", "Add Agent", "add-agent")}
           </div>
           <div className="flex items-center gap-4">
             <TourLauncher />

--- a/server/frontend/src/pages/AddAgentPage.test.tsx
+++ b/server/frontend/src/pages/AddAgentPage.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * FO-4 Phase 2 — tests for the Add-Agent page (agent#194 / Decision 33).
+ *
+ * Covers the single-request mint flow: the form renders, a successful mint
+ * replaces the form with the completion panel (token + all three install
+ * paths), and an error response (409 duplicate / 422 bad input) surfaces the
+ * backend message. `fetch` is stubbed per the PersonasPage test convention.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { MemoryRouter } from "react-router"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { AddAgentPage } from "./AddAgentPage"
+
+const originalFetch = globalThis.fetch
+
+type MockResponse = { ok: boolean; status: number; body: unknown }
+
+/**
+ * Route the fetch mock by request: the page fires a GET (listAgentKeys, on
+ * mount and after a successful mint) and a POST (mintAgentKey). `list`
+ * answers the GET; `mint` answers the POST.
+ */
+function mockApi(opts: { list?: MockResponse; mint?: MockResponse }) {
+  const list: MockResponse = opts.list ?? {
+    ok: true,
+    status: 200,
+    body: { data: [], count: 0 },
+  }
+  const mint: MockResponse = opts.mint ?? {
+    ok: true,
+    status: 201,
+    body: mintResponse,
+  }
+  globalThis.fetch = vi
+    .fn()
+    .mockImplementation((_url: string, init?: RequestInit) => {
+      const method = (init?.method ?? "GET").toUpperCase()
+      const resp = method === "POST" ? mint : list
+      return Promise.resolve({
+        ok: resp.ok,
+        status: resp.status,
+        json: () => Promise.resolve(resp.body),
+      })
+    }) as unknown as typeof fetch
+}
+
+const mintResponse = {
+  id: "key-1",
+  name: "campaign-researcher",
+  labels: [],
+  prefix: "cqa.v1.a",
+  ttl: "60d",
+  expires_at: "2026-07-18T10:00:00+00:00",
+  created_at: "2026-05-19T10:00:00+00:00",
+  last_used_at: null,
+  revoked_at: null,
+  is_expired: false,
+  is_active: true,
+  agent_username: "agent-campaign-researcher",
+  token: "cqa.v1.abcdef0123456789plaintexttokenvalue",
+  install: {
+    join_command: "8l join --token cqa.v1.abcdef0123456789plaintexttokenvalue",
+    enterprise_id: "acme",
+    l2: "acme/eng",
+    persona: "agent",
+  },
+}
+
+beforeEach(() => {
+  mockApi({})
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  vi.restoreAllMocks()
+})
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AddAgentPage />
+    </MemoryRouter>,
+  )
+}
+
+/** Fill the form with valid input. */
+function fillForm(name = "campaign-researcher") {
+  fireEvent.change(screen.getByPlaceholderText(/campaign-researcher/i), {
+    target: { value: name },
+  })
+}
+
+describe("AddAgentPage", () => {
+  it("renders the form with name, harness, and TTL fields", async () => {
+    renderPage()
+    expect(screen.getByText(/agent details/i)).toBeInTheDocument()
+    expect(
+      screen.getByPlaceholderText(/campaign-researcher/i),
+    ).toBeInTheDocument()
+    // Harness select defaults to Claude Code.
+    const harness = screen.getByRole("combobox")
+    expect(harness).toHaveValue("claude-code")
+    // TTL defaults to 60d.
+    expect(screen.getByPlaceholderText("60d")).toHaveValue("60d")
+    // List call resolved — the empty agent-key table renders.
+    expect(
+      await screen.findByText(/no agent keys minted yet/i),
+    ).toBeInTheDocument()
+  })
+
+  it("blocks Mint until the agent name is valid", () => {
+    renderPage()
+    const mintBtn = screen.getByRole("button", { name: /mint agent key/i })
+    expect(mintBtn).toBeDisabled()
+
+    fireEvent.change(screen.getByPlaceholderText(/campaign-researcher/i), {
+      target: { value: "x" }, // 1 char — below min
+    })
+    expect(mintBtn).toBeDisabled()
+
+    fillForm()
+    expect(mintBtn).not.toBeDisabled()
+  })
+
+  it("blocks Mint on an invalid TTL", () => {
+    renderPage()
+    fillForm()
+    const mintBtn = screen.getByRole("button", { name: /mint agent key/i })
+    expect(mintBtn).not.toBeDisabled()
+
+    fireEvent.change(screen.getByPlaceholderText("60d"), {
+      target: { value: "soon" }, // not <number><unit>
+    })
+    expect(mintBtn).toBeDisabled()
+  })
+
+  it("mint success shows the token and all three install paths", async () => {
+    renderPage()
+    fillForm()
+    fireEvent.click(screen.getByRole("button", { name: /mint agent key/i }))
+
+    // Completion panel replaces the form.
+    await waitFor(() =>
+      expect(screen.getByTestId("mint-complete")).toBeInTheDocument(),
+    )
+    expect(
+      screen.queryByRole("button", { name: /mint agent key/i }),
+    ).not.toBeInTheDocument()
+
+    // One-time token reveal.
+    expect(screen.getByTestId("agent-token").textContent).toBe(
+      mintResponse.token,
+    )
+    expect(screen.getByText(/will not be shown again/i)).toBeInTheDocument()
+
+    // (a) join command.
+    expect(screen.getByTestId("join-command").textContent).toBe(
+      mintResponse.install.join_command,
+    )
+    // (b) plugin-install command.
+    expect(screen.getByTestId("plugin-command").textContent).toMatch(
+      /plugin marketplace add/i,
+    )
+    // (c) QR code — rendered as an SVG.
+    const qrBlock = screen.getByTestId("install-qr")
+    expect(qrBlock.querySelector("svg")).not.toBeNull()
+  })
+
+  it("shows the backend message on a 409 duplicate name", async () => {
+    mockApi({
+      mint: {
+        ok: false,
+        status: 409,
+        body: { detail: "An agent named 'campaign-researcher' already exists" },
+      },
+    })
+    renderPage()
+    fillForm()
+    fireEvent.click(screen.getByRole("button", { name: /mint agent key/i }))
+
+    expect(await screen.findByTestId("mint-error")).toHaveTextContent(
+      /already exists/i,
+    )
+    // The form stays visible — no completion panel.
+    expect(screen.queryByTestId("mint-complete")).not.toBeInTheDocument()
+  })
+
+  it("shows the backend message on a 422 bad input", async () => {
+    mockApi({
+      mint: {
+        ok: false,
+        status: 422,
+        body: { detail: "ttl must be a positive duration" },
+      },
+    })
+    renderPage()
+    fillForm()
+    fireEvent.click(screen.getByRole("button", { name: /mint agent key/i }))
+
+    expect(await screen.findByTestId("mint-error")).toHaveTextContent(
+      /positive duration/i,
+    )
+  })
+
+  it("lists existing agent keys returned by the API", async () => {
+    mockApi({
+      list: {
+        ok: true,
+        status: 200,
+        body: {
+          data: [
+            {
+              ...mintResponse,
+              token: undefined,
+              install: undefined,
+              name: "existing-agent",
+              agent_username: "agent-existing-agent",
+            },
+          ],
+          count: 1,
+        },
+      },
+    })
+    renderPage()
+    expect(await screen.findByText("existing-agent")).toBeInTheDocument()
+    expect(screen.getByText("agent-existing-agent")).toBeInTheDocument()
+    expect(screen.getByTestId("agent-key-table")).toBeInTheDocument()
+  })
+})

--- a/server/frontend/src/pages/AddAgentPage.tsx
+++ b/server/frontend/src/pages/AddAgentPage.tsx
@@ -1,0 +1,496 @@
+/**
+ * FO-4 Phase 2 — Self-service Add-Agent page (agent#194 / Decision 33).
+ *
+ * A single-route admin-shell page at `/admin/agents/new`. Unlike FO-3's
+ * Create-L2 wizard, this is a single synchronous request/response — no SSE,
+ * no step machine. The operator names an agent, picks a harness, sets a TTL,
+ * and clicks Mint; the backend creates a stub user + `persona='agent'`
+ * assignment + an `api_keys` row and returns the plaintext `cqa.v1.*` token
+ * exactly once.
+ *
+ * Locked decisions (Decision 33, operator 2026-05-19):
+ *   1. No scope/permission selector — FO-4 mints full-capability keys; the
+ *      selector lands when per-key enforcement does (separate follow-up).
+ *   2. Three install paths on the completion panel: the `8l join …` one-liner,
+ *      a plugin-install command, and a QR code encoding the join command.
+ *
+ * The token reveal copies KeyRevealPanel's visual pattern (the
+ * `brand-surface-raised` card, the code box + Copy, the "won't be shown
+ * again" warning). KeyRevealPanel itself is typed to an L2 result, so this
+ * builds a local reveal block in the same style rather than importing it.
+ */
+
+import { QRCodeSVG } from "qrcode.react"
+import { useCallback, useEffect, useState } from "react"
+import { ApiError, api } from "../api"
+import type {
+  AgentHarness,
+  AgentKeyPublic,
+  MintAgentKeyResponse,
+} from "../types"
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Harness options — values are the wire enum `AgentHarness`. */
+const HARNESSES: readonly { value: AgentHarness; label: string }[] = [
+  { value: "claude-code", label: "Claude Code" },
+  { value: "claude-desktop", label: "Claude Desktop" },
+  { value: "openclaw", label: "OpenClaw" },
+  { value: "other", label: "Other" },
+] as const
+
+/** Default agent-key TTL. Decision 33 §Shape — 60 days. */
+const DEFAULT_TTL = "60d"
+
+/** Agent-name shape — a friendly slug; the backend derives the stub username. */
+const AGENT_NAME_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9 _-]{1,48}$/
+
+/**
+ * Plugin-install command for operators who do not yet have the `8l` CLI.
+ * NOTE: the marketplace slug `OneZero1ai/8th-layer-agent` and the plugin id
+ * `8l-cq` need verification once the plugin marketplace listing is published
+ * — confirm against the published marketplace manifest before GA.
+ */
+const PLUGIN_INSTALL_COMMAND =
+  "/plugin marketplace add OneZero1ai/8th-layer-agent\n" +
+  "/plugin install 8l-cq@8th-layer-agent"
+
+// ---------------------------------------------------------------------------
+// Shared brand classes (match CreateL2Page / PersonasPage conventions)
+// ---------------------------------------------------------------------------
+
+const primaryBtn =
+  "rounded-md bg-[color-mix(in_srgb,var(--brand-primary)_18%,transparent)] border border-[color-mix(in_srgb,var(--brand-primary)_45%,transparent)] px-4 py-2 font-mono-brand text-[11px] uppercase tracking-[0.2em] text-[var(--brand-primary)] hover:bg-[color-mix(in_srgb,var(--brand-primary)_28%,transparent)] disabled:opacity-50 transition-all"
+const ghostBtn =
+  "rounded-md border border-[var(--rule-strong)] bg-[var(--surface)] px-4 py-2 font-mono-brand text-[11px] uppercase tracking-[0.2em] text-[var(--ink-dim)] hover:bg-[var(--surface-hover)] disabled:opacity-50 transition-all"
+
+// ---------------------------------------------------------------------------
+// Copyable code block — the KeyRevealPanel copy pattern, reusable.
+// ---------------------------------------------------------------------------
+
+function CopyBlock({
+  value,
+  label,
+  testid,
+  mono = true,
+}: {
+  value: string
+  label?: string
+  testid?: string
+  mono?: boolean
+}) {
+  const [copied, setCopied] = useState(false)
+
+  const copy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(value)
+      setCopied(true)
+    } catch {
+      // Clipboard denied (insecure context / permissions) — leave the value
+      // visible so the operator can select it manually. No state change.
+    }
+  }, [value])
+
+  return (
+    <div>
+      {label && <p className="eyebrow mb-1.5">{label}</p>}
+      <div className="flex items-start gap-2 rounded-lg bg-[var(--bg-via)] border border-[var(--rule-strong)] p-3">
+        <code
+          className={`flex-1 break-all whitespace-pre-wrap text-sm text-[var(--brand-primary)] ${
+            mono ? "font-mono-brand" : ""
+          }`}
+          data-testid={testid}
+        >
+          {value}
+        </code>
+        <button type="button" onClick={copy} className={primaryBtn}>
+          {copied ? "Copied" : "Copy"}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Existing agent-keys table
+// ---------------------------------------------------------------------------
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "never"
+  return new Date(iso).toLocaleDateString()
+}
+
+function AgentKeyTable({ keys }: { keys: AgentKeyPublic[] }) {
+  if (keys.length === 0) {
+    return (
+      <p className="text-sm text-[var(--ink-mute)]">
+        No agent keys minted yet.
+      </p>
+    )
+  }
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-left text-sm" data-testid="agent-key-table">
+        <thead>
+          <tr className="border-b border-[var(--rule)]">
+            {["Name", "Agent username", "Prefix", "Expires", "Status"].map(
+              (h) => (
+                <th
+                  key={h}
+                  className="pb-2 eyebrow text-[var(--ink-mute)] font-normal"
+                >
+                  {h}
+                </th>
+              ),
+            )}
+          </tr>
+        </thead>
+        <tbody>
+          {keys.map((k) => (
+            <tr
+              key={k.id}
+              className="border-b border-[var(--rule)] last:border-0"
+            >
+              <td className="py-2 text-[var(--ink)]">{k.name}</td>
+              <td className="py-2 font-mono-brand text-[var(--ink-dim)]">
+                {k.agent_username}
+              </td>
+              <td className="py-2 font-mono-brand text-[var(--ink-dim)]">
+                {k.prefix}
+              </td>
+              <td className="py-2 text-[var(--ink-dim)]">
+                {formatDate(k.expires_at)}
+              </td>
+              <td className="py-2">
+                <span
+                  className={`inline-block rounded-full px-2 py-0.5 text-[10px] font-mono-brand ${
+                    k.is_active
+                      ? "bg-[color-mix(in_srgb,var(--emerald)_14%,transparent)] text-[var(--emerald)]"
+                      : "bg-[var(--surface-hover)] text-[var(--ink-mute)]"
+                  }`}
+                >
+                  {k.is_active ? "Active" : "Inactive"}
+                </span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Completion panel — one-time token reveal + three install paths.
+// ---------------------------------------------------------------------------
+
+function CompletionPanel({ result }: { result: MintAgentKeyResponse }) {
+  return (
+    <section className="brand-surface-raised p-6" data-testid="mint-complete">
+      <p className="eyebrow text-[var(--emerald)]">Agent minted</p>
+      <h2 className="font-display text-xl text-[var(--ink)] mt-1">
+        {result.name} is ready to join
+      </h2>
+      <p className="mt-2 text-sm text-[var(--ink-dim)] leading-relaxed">
+        Copy the agent token below now.{" "}
+        <strong className="text-[var(--ink)]">
+          It will not be shown again.
+        </strong>{" "}
+        Only its hash is stored — if you lose it, mint a new key.
+      </p>
+
+      <p className="mt-3 text-sm text-[var(--ink-mute)]">
+        Agent username:{" "}
+        <code className="font-mono-brand text-[var(--brand-primary)]">
+          {result.agent_username}
+        </code>
+      </p>
+
+      {/* ---- One-time token reveal ---- */}
+      <div className="mt-4">
+        <CopyBlock
+          label="Agent token"
+          value={result.token}
+          testid="agent-token"
+        />
+      </div>
+
+      {/* ---- Install paths ---- */}
+      <div className="mt-8 space-y-6">
+        <p className="eyebrow text-[var(--ink)]">Install paths</p>
+
+        {/* (a) — 8l join one-liner */}
+        <div data-testid="install-join">
+          <p className="text-sm text-[var(--ink-dim)] mb-1.5">
+            <strong className="text-[var(--ink)]">Join command.</strong> Run
+            this in the agent&rsquo;s harness with the <code>8l</code> CLI
+            installed.
+          </p>
+          <CopyBlock
+            value={result.install.join_command}
+            testid="join-command"
+          />
+        </div>
+
+        {/* (b) — plugin-install command */}
+        <div data-testid="install-plugin">
+          <p className="text-sm text-[var(--ink-dim)] mb-1.5">
+            <strong className="text-[var(--ink)]">Plugin install.</strong> For
+            operators who do not have the <code>8l</code> CLI yet — install the
+            plugin from the marketplace, then run the join command above.
+          </p>
+          <CopyBlock value={PLUGIN_INSTALL_COMMAND} testid="plugin-command" />
+        </div>
+
+        {/* (c) — QR code */}
+        <div data-testid="install-qr">
+          <p className="text-sm text-[var(--ink-dim)] mb-2.5">
+            <strong className="text-[var(--ink)]">Scan from a device.</strong>{" "}
+            This QR code encodes the join command.
+          </p>
+          <div className="inline-block rounded-lg bg-white p-3">
+            <QRCodeSVG
+              value={result.install.join_command}
+              size={160}
+              level="M"
+              data-testid="join-qr"
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export function AddAgentPage() {
+  // Form state.
+  const [agentName, setAgentName] = useState("")
+  const [harness, setHarness] = useState<AgentHarness>("claude-code")
+  const [ttl, setTtl] = useState(DEFAULT_TTL)
+
+  // Submission state.
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [result, setResult] = useState<MintAgentKeyResponse | null>(null)
+
+  // Existing agent keys (admin table).
+  const [agentKeys, setAgentKeys] = useState<AgentKeyPublic[]>([])
+
+  const loadKeys = useCallback(() => {
+    api
+      .listAgentKeys()
+      .then((resp) => setAgentKeys(resp.data))
+      .catch(() => {
+        // The table is informational — a list failure must not block minting.
+      })
+  }, [])
+
+  useEffect(() => {
+    loadKeys()
+  }, [loadKeys])
+
+  // ---- derived validation -------------------------------------------------
+
+  const nameValid = AGENT_NAME_PATTERN.test(agentName.trim())
+  const ttlValid = /^\d+[smhd]$/.test(ttl.trim())
+  const canSubmit = nameValid && ttlValid && !submitting
+
+  // ---- submit -------------------------------------------------------------
+
+  const handleMint = useCallback(async () => {
+    setSubmitting(true)
+    setSubmitError(null)
+    try {
+      const resp = await api.mintAgentKey({
+        agent_name: agentName.trim(),
+        harness,
+        ttl: ttl.trim(),
+      })
+      setResult(resp)
+      // Refresh the table so the new key shows when the operator scrolls.
+      loadKeys()
+    } catch (err) {
+      if (err instanceof ApiError) {
+        // 409 duplicate name, 422 bad name/ttl, 403 not-admin — the backend
+        // message is operator-facing; surface it verbatim.
+        setSubmitError(err.message)
+      } else {
+        setSubmitError(
+          err instanceof Error ? err.message : "Failed to mint agent key.",
+        )
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }, [agentName, harness, ttl, loadKeys])
+
+  // ---- render -------------------------------------------------------------
+
+  return (
+    <div className="space-y-8">
+      <section>
+        <p className="eyebrow">Admin</p>
+        <h1 className="font-display text-3xl text-[var(--ink)] mt-1">
+          Add an Agent
+        </h1>
+        <p className="mt-3 text-sm text-[var(--ink-dim)] leading-relaxed max-w-prose">
+          Mint a new agent key for this L2. Name the agent, pick its harness,
+          and set a token lifetime — you get a one-time token plus copy-paste
+          install paths. The agent joins as a stub identity with the{" "}
+          <code className="font-mono-brand">agent</code> persona.
+        </p>
+      </section>
+
+      {/* ---------- Form (replaced by the completion panel on success) ---------- */}
+      {!result && (
+        <section className="brand-surface-raised p-6">
+          <p className="eyebrow">New agent</p>
+          <h2 className="font-display text-xl text-[var(--ink)] mt-1">
+            Agent details
+          </h2>
+
+          <form
+            className="mt-5 space-y-5"
+            onSubmit={(e) => {
+              e.preventDefault()
+              if (canSubmit) void handleMint()
+            }}
+          >
+            {/* Agent name */}
+            <label className="flex flex-col text-sm">
+              <span className="eyebrow mb-1.5">Agent name</span>
+              <input
+                type="text"
+                value={agentName}
+                onChange={(e) => setAgentName(e.target.value)}
+                placeholder="e.g. campaign-researcher"
+                maxLength={48}
+                aria-invalid={agentName.length > 0 && !nameValid}
+                aria-describedby="agent-name-help"
+                className="brand-input font-mono-brand"
+              />
+              <span id="agent-name-help" className="mt-1.5 text-xs">
+                {agentName.length > 0 && !nameValid ? (
+                  <span className="text-[var(--rose)]">
+                    2–49 characters; letters, digits, spaces, hyphens, and
+                    underscores.
+                  </span>
+                ) : (
+                  <span className="text-[var(--ink-mute)]">
+                    A friendly label for the agent.
+                  </span>
+                )}
+              </span>
+            </label>
+
+            {/* Harness */}
+            <label className="flex flex-col text-sm">
+              <span className="eyebrow mb-1.5">Harness</span>
+              <select
+                value={harness}
+                onChange={(e) => setHarness(e.target.value as AgentHarness)}
+                className="brand-input font-mono-brand"
+              >
+                {HARNESSES.map((h) => (
+                  <option key={h.value} value={h.value}>
+                    {h.label}
+                  </option>
+                ))}
+              </select>
+              <span className="mt-1.5 text-xs text-[var(--ink-mute)]">
+                The agent runtime this key is for.
+              </span>
+            </label>
+
+            {/* TTL */}
+            <label className="flex flex-col text-sm">
+              <span className="eyebrow mb-1.5">Token lifetime (TTL)</span>
+              <input
+                type="text"
+                value={ttl}
+                onChange={(e) => setTtl(e.target.value)}
+                placeholder={DEFAULT_TTL}
+                aria-invalid={ttl.length > 0 && !ttlValid}
+                aria-describedby="ttl-help"
+                className="brand-input font-mono-brand"
+              />
+              <span id="ttl-help" className="mt-1.5 text-xs">
+                {ttl.length > 0 && !ttlValid ? (
+                  <span className="text-[var(--rose)]">
+                    Must be a number followed by{" "}
+                    <code className="font-mono-brand">s</code>,{" "}
+                    <code className="font-mono-brand">m</code>,{" "}
+                    <code className="font-mono-brand">h</code>, or{" "}
+                    <code className="font-mono-brand">d</code> (e.g.{" "}
+                    <code className="font-mono-brand">60d</code>).
+                  </span>
+                ) : (
+                  <span className="text-[var(--ink-mute)]">
+                    How long the token stays valid. Default 60 days.
+                  </span>
+                )}
+              </span>
+            </label>
+
+            {submitError && (
+              <p
+                className="text-sm text-[var(--rose)]"
+                data-testid="mint-error"
+              >
+                {submitError}
+              </p>
+            )}
+
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                disabled={!canSubmit}
+                className={primaryBtn}
+              >
+                {submitting ? "Minting…" : "Mint agent key"}
+              </button>
+            </div>
+          </form>
+        </section>
+      )}
+
+      {/* ---------- Completion panel ---------- */}
+      {result && <CompletionPanel result={result} />}
+
+      {result && (
+        <div className="flex justify-end">
+          <button
+            type="button"
+            className={ghostBtn}
+            onClick={() => {
+              // Reset to the form for a second mint. The token is dropped
+              // from state — it is never recoverable after this.
+              setResult(null)
+              setAgentName("")
+              setHarness("claude-code")
+              setTtl(DEFAULT_TTL)
+              setSubmitError(null)
+            }}
+          >
+            Mint another
+          </button>
+        </div>
+      )}
+
+      {/* ---------- Existing agent keys ---------- */}
+      <section className="brand-surface p-6">
+        <p className="eyebrow">Agent keys</p>
+        <h2 className="font-display text-lg text-[var(--ink)] mt-1 mb-4">
+          Existing agents in this L2
+        </h2>
+        <AgentKeyTable keys={agentKeys} />
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## FO-4 Phase 2 — Self-service Add-Agent UI (agent#194 / Decision 33)

The admin-shell frontend for self-service agent onboarding. Companion to FO-3's Create-L2 wizard; implements Phase 2 of the FO-4 build sequence in [Decision 33](https://github.com/OneZero1ai/crosstalk-enterprise/blob/main/docs/decisions/33-fo-4-add-agent-ui.md).

### Stacking

This PR is **stacked on #297 (FO-4 backend)** for the shared `types.ts` additions (`MintAgentKeyRequest`, `MintAgentKeyResponse`, `AgentInstallPaths`, `AgentKeyPublic`, `AgentHarness`) and the `api.mintAgentKey` / `api.listAgentKeys` clients — those are already committed on this branch. **Treat the base as #297 until it merges**, then this rebases onto `main`.

### What's in it

- **`pages/AddAgentPage.tsx`** — single-page form (NOT a multi-step wizard): agent name, harness select (Claude Code / Desktop / OpenClaw / Other), TTL (default `60d`). Submit → `POST /api/v1/admin/agent-keys`. On success the form is replaced by a completion panel.
- **Completion panel** — one-time token reveal in the `KeyRevealPanel` visual style (local block, not an import — `KeyRevealPanel` is typed to an L2 result) plus **three install paths**:
  - (a) the `8l join …` one-liner from `install.join_command`, with Copy
  - (b) a plugin marketplace-install command (frontend constant, flagged for marketplace-slug verification), with Copy
  - (c) a QR code (`QRCodeSVG`) encoding the join command
- **No scope/permission selector** — per the locked operator decision, FO-4 mints full-capability keys.
- Existing agent keys rendered in a small table from `listAgentKeys()`.
- 409 / 422 / 403 errors surface `ApiError.message` verbatim.
- Route `/admin/agents/new` + "Add Agent" nav link wired next to Add L2.
- `AddAgentPage.test.tsx` — form render, mint success (token + all three install paths), 409/422 error, existing-keys table.

### qrcode.react install note

Added `qrcode.react@^4` (exports `QRCodeSVG`). The repo's `server/frontend` uses **pnpm** (`pnpm-lock.yaml`). `npm install` fails with `EUNSUPPORTEDPROTOCOL workspace:*` because the existing node_modules tree carries pnpm's `workspace:*` protocol (e.g. in `@vitejs/plugin-react`), which npm cannot parse — `--no-workspaces` / `--omit=dev` do not help. Installed cleanly with `pnpm add`; `pnpm-lock.yaml` updated and consistent.

### Checks

- `pnpm run lint:check` — clean (93 files, no fixes)
- `pnpm run build` (`tsc -b && vite build`) — passes
- `pnpm run test` (vitest) — 85/85 passing across 14 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)