### PR TITLE
Instrument the L2 read path — log aigrp/lookup + query to activity_log (agent#284)

### DIFF
--- a/server/backend/alembic/versions/0025_activity_log_aigrp_lookup_event.py
+++ b/server/backend/alembic/versions/0025_activity_log_aigrp_lookup_event.py
@@ -1,0 +1,160 @@
+r"""Extend the activity_log event-type enum with ``aigrp_lookup`` (agent#284).
+
+Revision ID: 0025_activity_log_aigrp_lookup_event
+Revises: 0024_user_tour_state
+Create Date: 2026-05-19
+
+# Why
+
+The L2 ``activity_log`` records *write* events (``propose``,
+``review_resolve``, ``crosstalk_send`` …) but no *read* events. The
+ambient-query path — ``POST /api/v1/aigrp/lookup``, fired by the harness
+on every ``UserPromptSubmit`` — is the highest-volume read in the fleet
+and is entirely unlogged today. Instrumenting it (agent#284) means the
+L2 becomes a record of what agents *consult*, not only what they
+*contribute* — the other half of the "L2 is the activity log of record"
+positioning, and a hard requirement of the MVP acceptance gate (R4).
+
+The KU-query endpoint (``GET /query`` / cross-L2 ``aigrp/forward-query``)
+already reuses the existing ``query`` event value — no enum change
+needed there. Only the AIGRP ambient-lookup needs a *new* value so it
+can be filtered apart from explicit KU queries on the read endpoint.
+
+# What this migration does
+
+``activity_log.event_type`` is gated by the ``ck_activity_log_event_type``
+CHECK constraint created in ``0011_activity_log``. SQLite cannot
+``ALTER TABLE ... DROP CONSTRAINT``; the locked-enum docstring in 0011
+explicitly says adding a value "requires a new migration that uses
+Alembic batch recreate to swap the CHECK constraint". This migration
+does exactly that: ``batch_alter_table(recreate="always")`` rebuilds the
+table with the new constraint clause, copying every existing row.
+
+The new enum (must stay in sync with ``cq_server.activity.EVENT_TYPES``):
+
+    query, propose, confirm, flag,
+    review_start, review_resolve,
+    crosstalk_send, crosstalk_reply, crosstalk_close,
+    consult_open, consult_reply, consult_close,
+    aigrp_lookup            <-- added here
+
+# Index re-creation
+
+``batch_alter_table`` with ``recreate="always"`` drops and rebuilds the
+table; Alembic's batch context reflects and re-applies the four indexes
+(``idx_activity_log_tenant_ts`` …) automatically as part of the copy, so
+no explicit index DDL is needed here.
+
+# Idempotency
+
+``_constraint_allows`` inspects the live CHECK clause; if ``aigrp_lookup``
+is already permitted (re-run, or a DB stamped past this revision) the
+upgrade is a no-op. Downgrade rebuilds the table with the original
+12-value clause — only used by tests; never run in production against a
+table that already holds ``aigrp_lookup`` rows (the copy would violate
+the narrowed constraint).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0025_activity_log_aigrp_lookup_event"
+down_revision: str | Sequence[str] | None = "0024_user_tour_state"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# Original 12-value enum from 0011_activity_log.
+_EVENT_TYPES_BASE = (
+    "query",
+    "propose",
+    "confirm",
+    "flag",
+    "review_start",
+    "review_resolve",
+    "crosstalk_send",
+    "crosstalk_reply",
+    "crosstalk_close",
+    "consult_open",
+    "consult_reply",
+    "consult_close",
+)
+
+# agent#284 adds the read-path ambient-lookup event.
+_EVENT_TYPES_WITH_LOOKUP = (*_EVENT_TYPES_BASE, "aigrp_lookup")
+
+
+def _table_exists(bind: sa.engine.Connection, table_name: str) -> bool:
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def _check_clause(event_types: Sequence[str]) -> str:
+    quoted = ", ".join(f"'{e}'" for e in event_types)
+    return f"event_type IN ({quoted})"
+
+
+def _constraint_allows(bind: sa.engine.Connection, value: str) -> bool:
+    """Return True if the live activity_log CHECK clause permits ``value``.
+
+    SQLite stores the CHECK clause verbatim in ``sqlite_master.sql``;
+    a substring test on the quoted value is sufficient and avoids a
+    fragile clause re-parse.
+    """
+    row = bind.exec_driver_sql("SELECT sql FROM sqlite_master WHERE type='table' AND name='activity_log'").fetchone()
+    if row is None or row[0] is None:
+        return False
+    return f"'{value}'" in row[0]
+
+
+def _swap_constraint(event_types: Sequence[str]) -> None:
+    """Recreate ``activity_log`` with a fresh ``event_type`` CHECK clause.
+
+    On ``recreate="always"`` Alembic's batch context *reflects* the
+    table — including the existing ``ck_activity_log_event_type`` CHECK.
+    Passing a new ``CheckConstraint`` via ``table_args`` would *add* a
+    second constraint of the same name rather than replace it (SQLite
+    permits duplicate constraint names), and the row copy would then
+    have to satisfy both — the old, narrower clause would reject any new
+    value. So the swap is two explicit ops inside the batch block:
+    drop the reflected constraint, then create the new one. Both run
+    against the temp table before the row copy.
+    """
+    with op.batch_alter_table("activity_log", recreate="always") as batch:
+        batch.drop_constraint("ck_activity_log_event_type", type_="check")
+        batch.create_check_constraint(
+            "ck_activity_log_event_type",
+            _check_clause(event_types),
+        )
+
+
+def upgrade() -> None:
+    """Recreate activity_log with ``aigrp_lookup`` added to the CHECK enum."""
+    bind = op.get_bind()
+    if not _table_exists(bind, "activity_log"):
+        # activity_log is created by 0011; this migration runs on a
+        # stamped DB that already has it. Skip rather than error if the
+        # chain is somehow incomplete (mirrors 0012's defensive guard).
+        return
+    if _constraint_allows(bind, "aigrp_lookup"):
+        # Already extended (re-run / DB stamped past this revision).
+        return
+    _swap_constraint(_EVENT_TYPES_WITH_LOOKUP)
+
+
+def downgrade() -> None:
+    """Recreate activity_log with the original 12-value CHECK enum.
+
+    Used by tests only. Never run in production against a table that
+    already holds ``aigrp_lookup`` rows — the row copy would violate the
+    narrowed constraint.
+    """
+    bind = op.get_bind()
+    if not _table_exists(bind, "activity_log"):
+        return
+    if not _constraint_allows(bind, "aigrp_lookup"):
+        # Already at the base enum.
+        return
+    _swap_constraint(_EVENT_TYPES_BASE)

--- a/server/backend/src/cq_server/activity.py
+++ b/server/backend/src/cq_server/activity.py
@@ -34,9 +34,16 @@ __all__ = [
 
 
 # Locked enum — must stay in sync with the CHECK constraint in
-# ``alembic/versions/0011_activity_log.py`` and with the schema
+# ``alembic/versions/0011_activity_log.py`` (extended by
+# ``0025_activity_log_aigrp_lookup_event.py``) and with the schema
 # sketch in issue #108. Adding a new value requires a new Alembic
 # migration that swaps the constraint via batch-recreate.
+#
+# ``aigrp_lookup`` (agent#284) is the read-path ambient-query event —
+# fired by ``POST /api/v1/aigrp/lookup`` on every harness prompt. It is
+# distinct from ``query`` (explicit KU search via ``GET /query`` /
+# cross-L2 ``aigrp/forward-query``) so the read endpoint can filter
+# ambient lookups apart from deliberate searches.
 EVENT_TYPES: frozenset[str] = frozenset(
     {
         "query",
@@ -51,6 +58,7 @@ EVENT_TYPES: frozenset[str] = frozenset(
         "consult_open",
         "consult_reply",
         "consult_close",
+        "aigrp_lookup",
     }
 )
 

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -560,13 +560,23 @@ class AigrpLookupResponse(BaseModel):
 @api_router.post("/aigrp/lookup")
 async def aigrp_lookup(
     request: AigrpLookupRequest,
-    _username: str = Depends(get_current_user),
+    background_tasks: BackgroundTasks,
+    username: str = Depends(get_current_user),
 ) -> AigrpLookupResponse:
     """Automatic-trigger lookup for AIGRP-pull (Phase 2).
 
     Fired by the harness on every prompt / session-start / tool-failure.
     Embeds the freeform context, runs semantic search, filters by
     confidence + similarity + exclude_self, returns ranked hits.
+
+    Activity log (agent#284): every lookup schedules a non-blocking
+    ``aigrp_lookup`` ``activity_log`` row — the read-path counterpart to
+    the write-path instrumentation. ``payload`` carries the trigger and
+    request filters; ``result_summary`` carries the matched ``ku_id``s
+    with similarity scores and the hit/filtered counts. The audit write
+    runs after the response is sealed via ``BackgroundTasks``; a logging
+    failure never affects the lookup — critical on this path, which is
+    the highest-volume read in the fleet.
     """
     import time
 
@@ -576,6 +586,25 @@ async def aigrp_lookup(
     if payload is None:
         # Don't 503 here — the hook is best-effort and a 503 would
         # log loudly on every prompt if Bedrock is briefly slow.
+        # Still log the lookup: a zero-result event with no embedding
+        # is a real fleet-analytics signal (Bedrock degraded → empty
+        # ambient context). cache/embed miss is recorded in payload.
+        background_tasks.add_task(
+            log_activity,
+            store,
+            username=username,
+            event_type="aigrp_lookup",
+            payload={
+                "trigger": request.trigger,
+                "session_id": request.session_id,
+                "max_results": request.max_results,
+                "min_confidence": request.min_confidence,
+                "min_similarity": request.min_similarity,
+                "embed_unavailable": True,
+            },
+            result_summary={"ku_ids": [], "hits": 0, "filtered_count": 0, "elapsed_ms": 0},
+            thread_or_chain_id=request.session_id or None,
+        )
         return AigrpLookupResponse(trigger=request.trigger, results=[], elapsed_ms=0, filtered_count=0)
     from .embed import unpack
 
@@ -612,6 +641,30 @@ async def aigrp_lookup(
             break
 
     elapsed_ms = int((time.monotonic() - t0) * 1000)
+    background_tasks.add_task(
+        log_activity,
+        store,
+        username=username,
+        event_type="aigrp_lookup",
+        payload={
+            "trigger": request.trigger,
+            "session_id": request.session_id,
+            "max_results": request.max_results,
+            "min_confidence": request.min_confidence,
+            "min_similarity": request.min_similarity,
+            "embed_unavailable": False,
+        },
+        result_summary={
+            # Matched KU ids + their similarity scores — the feedback
+            # signal for "which KUs actually get consulted" (#284).
+            "ku_ids": [h.ku_id for h in filtered],
+            "matches": [{"ku_id": h.ku_id, "similarity": h.similarity} for h in filtered],
+            "hits": len(filtered),
+            "filtered_count": dropped,
+            "elapsed_ms": elapsed_ms,
+        },
+        thread_or_chain_id=request.session_id or None,
+    )
     return AigrpLookupResponse(
         trigger=request.trigger,
         results=filtered,
@@ -984,6 +1037,7 @@ def _decide_policy_for_ku(
 async def aigrp_forward_query(
     body: AigrpForwardQueryRequest,
     request: Request,
+    background_tasks: BackgroundTasks,
     _peer: None = Depends(aigrp.require_peer_key),
 ) -> AigrpForwardQueryResponse:
     """Cross-L2 forward-query — Phase 6 step 2.
@@ -1004,6 +1058,16 @@ async def aigrp_forward_query(
     receiver pins it to ``body.requester_l2_id`` and to its own Enterprise.
     Closes cross-Enterprise impersonation; sibling-L2 spoof inside an
     Enterprise is the residual gap (sprint 4 / Ed25519).
+
+    Activity log (agent#284): in addition to the existing
+    ``cross_l2_audit`` row (the security audit of cross-L2 access), a
+    non-blocking ``query`` ``activity_log`` row is scheduled — the
+    read-path counterpart to ``GET /query``'s instrumentation. It is a
+    *system* event (``persona=None``) filed under this L2's own
+    Enterprise/Group: the requesting persona belongs to a different L2,
+    so the local activity log records "this L2 served a forward-query"
+    with the requester identity in ``payload``. A logging failure never
+    affects the response.
     """
     import uuid
 
@@ -1050,6 +1114,22 @@ async def aigrp_forward_query(
                 policy_applied="denied",
                 result_count=0,
                 consent_id=None,
+            )
+            background_tasks.add_task(
+                log_activity,
+                _get_store(),
+                username=None,
+                event_type="query",
+                payload={
+                    "source": "forward_query",
+                    "requester_l2_id": body.requester_l2_id,
+                    "requester_enterprise": body.requester_enterprise,
+                    "requester_group": body.requester_group,
+                    "requester_persona": body.requester_persona or None,
+                    "max_results": body.max_results,
+                    "policy_applied": "denied",
+                },
+                result_summary={"ku_ids": [], "result_count": 0, "cache_hit": False},
             )
             return AigrpForwardQueryResponse(
                 responder_l2_id=responder_l2_id,
@@ -1128,6 +1208,26 @@ async def aigrp_forward_query(
         consent_id=consent_id,
     )
 
+    background_tasks.add_task(
+        log_activity,
+        store,
+        username=None,
+        event_type="query",
+        payload={
+            "source": "forward_query",
+            "requester_l2_id": body.requester_l2_id,
+            "requester_enterprise": body.requester_enterprise,
+            "requester_group": body.requester_group,
+            "requester_persona": body.requester_persona or None,
+            "max_results": body.max_results,
+            "policy_applied": response_policy,
+        },
+        result_summary={
+            "ku_ids": [h.ku_id for h in results],
+            "result_count": len(results),
+            "cache_hit": False,
+        },
+    )
     return AigrpForwardQueryResponse(
         responder_l2_id=responder_l2_id,
         responder_enterprise=responder_enterprise,

--- a/server/backend/src/cq_server/migrations.py
+++ b/server/backend/src/cq_server/migrations.py
@@ -36,7 +36,7 @@ BASELINE_REVISION = "0001"
 # Phase 2 (task #100) — chain head after porting fork-delta tables to
 # Alembic. Update this string when adding a new migration so test
 # assertions and ops scripts stay in sync with the actual chain head.
-HEAD_REVISION = "0024_user_tour_state"
+HEAD_REVISION = "0025_activity_log_aigrp_lookup_event"
 
 
 def _find_alembic_ini() -> Path:

--- a/server/backend/tests/test_activity_log_read_path.py
+++ b/server/backend/tests/test_activity_log_read_path.py
@@ -1,0 +1,354 @@
+"""Activity-log read-path instrumentation — agent#284.
+
+The L2 ``activity_log`` records *write* events (``propose``,
+``review_resolve`` …) but historically recorded zero *read* events.
+This suite pins the read-path instrumentation added by agent#284:
+
+* ``POST /api/v1/aigrp/lookup`` → an ``aigrp_lookup`` event carrying the
+  trigger + request filters in ``payload`` and the matched ``ku_id``s
+  with similarity scores in ``result_summary``.
+* ``POST /api/v1/aigrp/forward-query`` → a ``query`` event (system row,
+  ``persona=None``) recording that this L2 served a cross-L2 query.
+
+Plus the hard requirement: a forced ``append_activity`` failure must
+never fail the lookup/query — the audit write is fire-and-forget via
+``BackgroundTasks`` and the ``log_activity`` helper swallows the error.
+
+Mirrors the write-path style in ``test_activity_log_instrumentation.py``:
+rows are read directly off-disk and asserted by ``event_type``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+import struct
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+import cq_server.app as app_module
+from cq_server.app import _get_store, app
+from cq_server.auth import hash_password
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "activity.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")  # pragma: allowlist secret
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")  # pragma: allowlist secret
+    with TestClient(app) as c:
+        yield c
+
+
+def _seed_user(
+    *,
+    username: str,
+    password: str,
+    enterprise_id: str = "acme",
+    group_id: str = "engineering",
+) -> None:
+    store = _get_store()
+    store.sync.create_user(username, hash_password(password))
+    with store._engine.begin() as conn:
+        conn.exec_driver_sql(
+            "UPDATE users SET enterprise_id = ?, group_id = ? WHERE username = ?",
+            (enterprise_id, group_id, username),
+        )
+
+
+def _login_jwt(client: TestClient, username: str, password: str) -> str:
+    resp = client.post("/auth/login", json={"username": username, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _mint_api_key(client: TestClient, jwt_token: str) -> str:
+    resp = client.post(
+        "/auth/api-keys",
+        headers={"Authorization": f"Bearer {jwt_token}"},
+        json={"name": "read-path-test", "ttl": "30d"},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["token"]
+
+
+def _activity_rows(db_path: Path) -> list[dict]:
+    """Read all activity_log rows directly off-disk, ordered by ts."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        rows = conn.execute(
+            "SELECT id, ts, tenant_enterprise, tenant_group, persona, human, "
+            "event_type, payload, result_summary, thread_or_chain_id "
+            "FROM activity_log ORDER BY ts"
+        ).fetchall()
+    finally:
+        conn.close()
+    return [
+        {
+            "id": r[0],
+            "ts": r[1],
+            "tenant_enterprise": r[2],
+            "tenant_group": r[3],
+            "persona": r[4],
+            "human": r[5],
+            "event_type": r[6],
+            "payload": r[7],
+            "result_summary": r[8],
+            "thread_or_chain_id": r[9],
+        }
+        for r in rows
+    ]
+
+
+def _propose_one(
+    client: TestClient,
+    api_key: str,
+    summary: str = "Read-path instrumentation coverage pin for agent#284",
+) -> str:
+    resp = client.post(
+        "/propose",
+        json={
+            "domains": ["test-fleet"],
+            "insight": {
+                "summary": summary,
+                "detail": "A KU used to back the aigrp_lookup instrumentation test.",
+                "action": "Read tests/test_activity_log_read_path.py for coverage.",
+            },
+        },
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _stub_embed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ``embed_text`` deterministic and Bedrock-free.
+
+    The handler only needs ``embed_text`` to return a non-None
+    ``(packed_bytes, model_id)`` tuple — the actual vector is irrelevant
+    because ``semantic_query`` is stubbed separately in the tests that
+    need a hit.
+    """
+    vec = [1.0] + [0.0] * 7
+    packed = struct.pack(f"<{len(vec)}f", *vec)
+
+    def _fake(_text: str):
+        return packed, "stub-model"
+
+    monkeypatch.setattr(app_module, "embed_text", _fake)
+
+
+# ---------------------------------------------------------------------------
+# aigrp/lookup → aigrp_lookup event
+# ---------------------------------------------------------------------------
+
+
+class TestAigrpLookupLogs:
+    def test_lookup_writes_aigrp_lookup_row_with_matches(
+        self,
+        client: TestClient,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _seed_user(username="looker", password="pw")  # pragma: allowlist secret
+        api_key = _mint_api_key(client, _login_jwt(client, "looker", "pw"))  # pragma: allowlist secret
+        ku_id = _propose_one(client, api_key)
+        store = _get_store()
+        store.sync.set_review_status(ku_id, "approved", "looker")
+
+        _stub_embed(monkeypatch)
+        # Force one deterministic hit so the row carries a ku_id +
+        # similarity score regardless of the embedding backend.
+        unit = asyncio.run(store.get(ku_id))
+        assert unit is not None
+
+        async def _fake_semantic_query(_vec, *, limit: int = 10):  # noqa: ANN001
+            return [(unit, 0.91)]
+
+        monkeypatch.setattr(store, "semantic_query", _fake_semantic_query)
+
+        resp = client.post(
+            "/api/v1/aigrp/lookup",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={
+                "context": "how do I rotate an IAM key",
+                "trigger": "user_prompt",
+                "session_id": "sess-abc",
+                "persona": "looker",
+                "min_confidence": 0.0,
+                "min_similarity": 0.0,
+                # The seeded KU was proposed by ``looker``; without
+                # this the exclude_self filter would drop the only hit.
+                "exclude_self": False,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+
+        rows = _activity_rows(tmp_path / "activity.db")
+        lookup_rows = [r for r in rows if r["event_type"] == "aigrp_lookup"]
+        assert len(lookup_rows) == 1
+        row = lookup_rows[0]
+        assert row["persona"] == "looker"
+        assert row["tenant_enterprise"] == "acme"
+        assert row["tenant_group"] == "engineering"
+        assert row["thread_or_chain_id"] == "sess-abc"
+
+        payload = json.loads(row["payload"])
+        assert payload["trigger"] == "user_prompt"
+        assert payload["session_id"] == "sess-abc"
+        assert payload["embed_unavailable"] is False
+
+        summary = json.loads(row["result_summary"])
+        assert ku_id in summary["ku_ids"]
+        assert summary["hits"] == 1
+        assert "elapsed_ms" in summary
+        assert summary["matches"][0]["ku_id"] == ku_id
+        assert summary["matches"][0]["similarity"] == pytest.approx(0.91)
+
+    def test_lookup_logs_when_embedding_unavailable(
+        self,
+        client: TestClient,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A Bedrock-down lookup still logs a zero-result row.
+
+        ``embed_text`` returning None is the degraded path; the handler
+        returns empty results but the lookup is still a real
+        fleet-analytics event and must be recorded.
+        """
+        _seed_user(username="degraded", password="pw")  # pragma: allowlist secret
+        api_key = _mint_api_key(client, _login_jwt(client, "degraded", "pw"))
+
+        monkeypatch.setattr(app_module, "embed_text", lambda _t: None)
+
+        resp = client.post(
+            "/api/v1/aigrp/lookup",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={"context": "anything", "trigger": "session_start"},
+        )
+        assert resp.status_code == 200, resp.text
+
+        rows = _activity_rows(tmp_path / "activity.db")
+        lookup_rows = [r for r in rows if r["event_type"] == "aigrp_lookup"]
+        assert len(lookup_rows) == 1
+        payload = json.loads(lookup_rows[0]["payload"])
+        assert payload["embed_unavailable"] is True
+        assert payload["trigger"] == "session_start"
+        summary = json.loads(lookup_rows[0]["result_summary"])
+        assert summary["hits"] == 0
+        assert summary["ku_ids"] == []
+
+    def test_lookup_succeeds_when_append_activity_raises(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """A logging failure must never fail the lookup (agent#284).
+
+        ``aigrp/lookup`` is the highest-volume read path — a DB hiccup
+        in the audit append must be swallowed by ``log_activity`` and
+        leave the lookup response intact.
+        """
+        _seed_user(username="resilient-look", password="pw")  # pragma: allowlist secret
+        api_key = _mint_api_key(client, _login_jwt(client, "resilient-look", "pw"))
+
+        _stub_embed(monkeypatch)
+        store = _get_store()
+
+        async def _empty_semantic_query(_vec, *, limit: int = 10):  # noqa: ANN001
+            return []
+
+        monkeypatch.setattr(store, "semantic_query", _empty_semantic_query)
+
+        original = store.append_activity
+
+        async def _raises(*_args: object, **_kwargs: object) -> None:
+            raise RuntimeError("simulated DB failure during audit append")
+
+        monkeypatch.setattr(store, "append_activity", _raises)
+        try:
+            resp = client.post(
+                "/api/v1/aigrp/lookup",
+                headers={"Authorization": f"Bearer {api_key}"},
+                json={"context": "still works", "trigger": "user_prompt"},
+            )
+            assert resp.status_code == 200, resp.text
+
+            rows = _activity_rows(tmp_path / "activity.db")
+            assert all(r["event_type"] != "aigrp_lookup" for r in rows)
+        finally:
+            monkeypatch.setattr(store, "append_activity", original)
+
+
+# ---------------------------------------------------------------------------
+# aigrp/forward-query → query event
+# ---------------------------------------------------------------------------
+
+
+class TestForwardQueryLogs:
+    def test_forward_query_writes_query_row(
+        self,
+        client: TestClient,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A served same-Enterprise forward-query logs a system query row."""
+        from cq_server import aigrp
+
+        # Bypass the peer-key + forwarder-identity gates — those are
+        # exercised by test_forward_query.py; here we pin the activity
+        # row, not the auth surface.
+        app.dependency_overrides[aigrp.require_peer_key] = lambda: None
+
+        async def _noop_identity(*_a: object, **_k: object) -> None:
+            return None
+
+        monkeypatch.setattr(aigrp, "require_forwarder_identity", _noop_identity)
+
+        store = _get_store()
+
+        async def _empty_scope_query(_vec, *, limit: int = 10):  # noqa: ANN001
+            return []
+
+        monkeypatch.setattr(store, "semantic_query_with_scope", _empty_scope_query)
+
+        try:
+            resp = client.post(
+                "/api/v1/aigrp/forward-query",
+                headers={"X-8L-Forwarder-L2-Id": "peer-l2"},
+                json={
+                    "query_vec": [0.1] * 8,
+                    "requester_l2_id": "peer-l2",
+                    "requester_enterprise": aigrp.enterprise(),
+                    "requester_group": "remote-group",
+                    "requester_persona": "remote-persona",
+                    "max_results": 5,
+                },
+            )
+            assert resp.status_code == 200, resp.text
+        finally:
+            app.dependency_overrides.pop(aigrp.require_peer_key, None)
+
+        rows = _activity_rows(tmp_path / "activity.db")
+        query_rows = [r for r in rows if r["event_type"] == "query"]
+        assert len(query_rows) == 1
+        row = query_rows[0]
+        # Forward-query is a system event — no local persona.
+        assert row["persona"] is None
+        # Filed under this L2's own Enterprise/Group.
+        assert row["tenant_enterprise"] == aigrp.enterprise()
+
+        payload = json.loads(row["payload"])
+        assert payload["source"] == "forward_query"
+        assert payload["requester_l2_id"] == "peer-l2"
+        assert payload["requester_persona"] == "remote-persona"
+
+        summary = json.loads(row["result_summary"])
+        assert summary["ku_ids"] == []
+        assert summary["result_count"] == 0

--- a/server/backend/tests/test_default_enterprise_backfill.py
+++ b/server/backend/tests/test_default_enterprise_backfill.py
@@ -409,4 +409,4 @@ class TestIdempotencyAndChain:
         """
         # The current chain head. Update this whenever a new migration
         # lands — this test failing IS the reminder to bump HEAD_REVISION.
-        assert HEAD_REVISION == "0024_user_tour_state"
+        assert HEAD_REVISION == "0025_activity_log_aigrp_lookup_event"

--- a/server/backend/tests/test_migration_0011_activity_log.py
+++ b/server/backend/tests/test_migration_0011_activity_log.py
@@ -475,7 +475,7 @@ class TestHeadRevisionAndHistory:
 
         # The current chain head. Each new migration MUST move this
         # constant; this test failing is the reminder.
-        assert HEAD_REVISION == "0024_user_tour_state"
+        assert HEAD_REVISION == "0025_activity_log_aigrp_lookup_event"
 
     @pytest.mark.parametrize("invalid_dir", [None])
     def test_alembic_history_includes_0011(self, invalid_dir: object) -> None:

--- a/server/backend/tests/test_migration_0015_aigrp_peers_pair_secret_ref.py
+++ b/server/backend/tests/test_migration_0015_aigrp_peers_pair_secret_ref.py
@@ -271,7 +271,7 @@ class TestHeadRevisionAndHistory:
     def test_head_revision_constant_was_bumped(self) -> None:
         from cq_server.migrations import HEAD_REVISION
 
-        assert HEAD_REVISION == "0024_user_tour_state"
+        assert HEAD_REVISION == "0025_activity_log_aigrp_lookup_event"
 
     def test_alembic_history_includes_0015(self) -> None:
         repo_root = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Problem

The L2 `activity_log` records **write** events (`propose`, `review_resolve`, `crosstalk_*`, …) but recorded **zero read events**. The L2 was a record of what agents *contribute* to the commons, not what they *consult* from it — only half of the "L2 is the activity log of record for the fleet" positioning, and a gap on the MVP acceptance gate (requirement R4 — "L2 logs everything").

The highest-volume read — `aigrp/lookup`, fired by the harness on every `UserPromptSubmit` — was entirely unlogged.

## What this PR does

Mirrors the existing write-path instrumentation (`log_activity` via FastAPI `BackgroundTasks`) on the read path.

### `POST /api/v1/aigrp/lookup` → `aigrp_lookup` event (new event type)
- `payload`: `trigger`, `session_id`, `max_results`, `min_confidence`, `min_similarity`, `embed_unavailable`
- `result_summary`: matched `ku_ids`, `matches` (ku_id + similarity score per hit), `hits`, `filtered_count`, `elapsed_ms`
- `thread_or_chain_id`: the lookup's `session_id`, so ambient lookups correlate into a session workflow
- Tenant scope (`tenant_enterprise` / `tenant_group`) + `persona` resolved from the caller's user row by the existing `log_activity` helper
- The degraded path (Bedrock embedding unavailable → empty results, no 503) still logs a zero-result row with `embed_unavailable: true` — a real fleet-analytics signal

### `POST /api/v1/aigrp/forward-query` → `query` event
- Cross-L2 forward-query is a **system event** (`persona=None`), filed under this L2's own Enterprise/Group: the requesting persona belongs to a *different* L2, so the local activity log records "this L2 served a forward-query" with the requester identity (`requester_l2_id` / `requester_enterprise` / `requester_group` / `requester_persona`) in `payload`.
- Both the served path and the silent cross-Enterprise deny path log a row.
- This is *in addition to* the existing `cross_l2_audit` row (the security audit of cross-L2 access) — the `activity_log` row is the fleet-analytics counterpart.

`GET /query` was already instrumented in #108 Stage 2 — no change there. The KU-query path reuses the existing `query` event value; only the AIGRP ambient-lookup needed a new value.

## Schema change — migration 0025

`activity_log.event_type` is gated by the `ck_activity_log_event_type` CHECK constraint. SQLite has no `ALTER TABLE ... DROP CONSTRAINT`, so `0025_activity_log_aigrp_lookup_event` uses Alembic `batch_alter_table(recreate="always")` to rebuild the table with `aigrp_lookup` added to the enum.

Note: on recreate, Alembic *reflects* the existing CHECK constraint; passing a new constraint via `table_args` would leave **two** CHECK clauses of the same name and the row copy would have to satisfy both (the old, narrower clause rejecting `aigrp_lookup`). The migration therefore explicitly `drop_constraint` + `create_check_constraint` inside the batch block. `cq_server.activity.EVENT_TYPES` is updated to match.

Idempotent (re-runnable), downgrade-safe. The four indexes survive the recreate (Alembic re-applies them on copy).

## Non-blocking guarantee

Every write is scheduled via `BackgroundTasks` and swallowed by the `log_activity` helper's try/except — a logging failure NEVER fails the lookup/query. Critical on `aigrp/lookup`, the highest-volume read path. Read-endpoint latency is unchanged: the audit write runs after the response is sealed.

## Tests

`server/backend/tests/test_activity_log_read_path.py` (4 tests), mirroring `test_activity_log_instrumentation.py`:
- `aigrp_lookup` row appears after a lookup with correct tenant scope, matched ku_ids + similarity scores
- degraded (embed-unavailable) lookup still logs a zero-result row
- a forced `append_activity` failure leaves the lookup response 200
- `forward-query` logs a system `query` row (`persona=None`, this L2's tenancy) with requester identity in `payload`

### Verification
- `.venv/bin/python -m pytest tests/test_activity_log_read_path.py tests/test_activity_log_instrumentation.py tests/test_activity_read_endpoint.py tests/test_migration_0011_activity_log.py tests/test_forward_query.py tests/test_demo_scenarios.py` → **56 passed**
- Migration tested against a fresh DB and an existing-DB snapshot seeded with pre-0025 activity rows — rows survive, `aigrp_lookup` inserts succeed afterward; downgrade + re-upgrade verified
- `ruff check`, `ruff format`, `pre-commit` (incl. detect-secrets) → all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #284