### PR TITLE
fix(cq-plugin): resolve AIGRP ambient-pull endpoint from profile, not bare CQ_ADDR (#279 Gap 1)

### DIFF
--- a/plugins/cq/commands/status.md
+++ b/plugins/cq/commands/status.md
@@ -11,6 +11,12 @@ Display a summary of the cq knowledge store.
 
 1. Call the `status` MCP tool (no arguments needed).
 2. Format the response as a readable summary using the sections below.
+3. Run the ambient-hook liveness check:
+   `python3 "${CLAUDE_PLUGIN_ROOT}/hooks/claude_code/cq_aigrp_pull.py" --mode status`
+   and append its single output line under an **Ambient Pull** section. This
+   tells the operator whether the `UserPromptSubmit` AIGRP hook can actually
+   reach the L2 — a `LIVE` line means ambient retrieval is working; an
+   `INACTIVE` line means it is silently no-op'ing (see issue #279).
 
 ## Output Format
 
@@ -36,6 +42,9 @@ local: {count} | private: {count} | public: {count}
 ■ 0.5-0.7: {count} units
 ■ 0.3-0.5: {count} units
 ■ 0.0-0.3: {count} units
+
+### Ambient Pull
+{liveness line from cq_aigrp_pull.py --mode status}
 ```
 
 The `tier_counts` field contains the tier breakdown. Display all tiers present in the response. Omit tiers with a count of 0.

--- a/plugins/cq/hooks/claude_code/cq_aigrp_pull.py
+++ b/plugins/cq/hooks/claude_code/cq_aigrp_pull.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Claude Code ``UserPromptSubmit`` hook for 8l-cq AIGRP ambient pull.
+
+On every prompt this hook asks the tenant L2 for knowledge units relevant to
+what the operator just typed and injects the hits as a ``<system-reminder>``
+block — the "seamless ambient query" half of the cq experience (the other
+half being the model proposing KUs back).
+
+Modes (``--mode``):
+
+  pull     The ``UserPromptSubmit`` path. Read Claude Code's hook JSON on
+           stdin, resolve the L2 endpoint, POST the prompt to
+           ``/api/v1/aigrp/lookup``, and emit any hits as injected context.
+
+  status   Operator-facing liveness check. Resolve the endpoint and print a
+           one-line human-readable summary of whether the ambient hook can
+           reach the L2 — independent of ``AIGRP_DEBUG``. Invoked by the
+           ``/cq:status`` command (or directly).
+
+Design contract (matches the cursor / cc hooks in this directory):
+
+  * **stdlib-only** — runs on every prompt, so import + startup must be cheap.
+  * **best-effort** — in ``pull`` mode *any* failure exits 0 with empty
+    stdout. A broken hook must never block prompt submission.
+  * **quiet on the happy path** — ``pull`` emits a reminder block only when
+    the L2 returns hits; zero hits / errors produce no output.
+
+The #279 fix
+------------
+The original ``8l-cq-aigrp-pull.sh`` bailed at its first guard whenever
+``$CQ_ADDR`` was unset and gave the operator *no signal*. In a claude-mux
+session ``CQ_ADDR`` lives in the MCP server's config block, not the shell —
+so the hook was permanently dead while the cq MCP server worked fine.
+
+Two changes close the gap:
+
+  1. Endpoint resolution is delegated to :mod:`cq_endpoint`, which falls back
+     to the claude-mux profile JSON (the same config the MCP server block is
+     generated from) when ``$CQ_ADDR`` is absent. The hook now finds the L2
+     whenever the MCP server can.
+  2. The ``status`` mode + a one-line stderr breadcrumb make "the ambient
+     hook is off / can't reach the L2" detectable without enabling
+     ``AIGRP_DEBUG``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime
+from pathlib import Path
+
+# Resolve the sibling endpoint module whether the hook is launched as a script
+# (``python3 .../cq_aigrp_pull.py``) or imported by the test suite.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import cq_endpoint  # noqa: E402
+
+# --- Tunables (env-overridable, mirroring the original shell hook) ----------
+#
+# Read at call time, not import time: the hook module is loaded once and
+# reused, so a frozen import-time snapshot would ignore per-invocation env.
+
+# Default values; the env var name is checked live by the accessors below.
+_DEFAULTS = {
+    "AIGRP_TIMEOUT_S": "1.5",
+    "AIGRP_MIN_PROMPT": "10",
+    "AIGRP_MAX_HITS": "5",
+    "AIGRP_MIN_CONF": "0.5",
+    "AIGRP_MIN_SIM": "0.3",
+}
+
+
+def _tunable(name: str, cast):
+    """Read an env-overridable tunable, falling back to its default."""
+    return cast(os.environ.get(name, _DEFAULTS[name]))
+
+
+def _heartbeat_path() -> Path:
+    """Path of the liveness breadcrumb the hook stamps on every run.
+
+    ``--mode status`` reads it back so the operator can see when the hook last
+    fired and what happened — the AIGRP_DEBUG-independent signal.
+    """
+    return Path(
+        os.environ.get(
+            "AIGRP_HEARTBEAT_PATH",
+            str(Path.home() / ".cache" / "cq" / "aigrp-heartbeat.json"),
+        )
+    )
+
+
+def _log(message: str) -> None:
+    """Append a debug line to ``~/.claude-mux/aigrp.log`` when AIGRP_DEBUG is set."""
+    if not os.environ.get("AIGRP_DEBUG"):
+        return
+    try:
+        log_path = Path.home() / ".claude-mux" / "aigrp.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        stamp = datetime.now(UTC).strftime("%H:%M:%S")
+        with log_path.open("a") as fh:
+            fh.write(f"[{stamp}] {message}\n")
+    except OSError:
+        pass
+
+
+def _write_heartbeat(outcome: str, detail: dict | None = None) -> None:
+    """Record the most recent hook run so ``--mode status`` can report liveness.
+
+    Best-effort: a heartbeat write must never break the hook. ``outcome`` is a
+    short tag (``hits`` / ``no_hits`` / ``unresolved`` / ``error`` / ...);
+    ``detail`` carries extra fields surfaced by the status line.
+    """
+    record = {
+        "ts": datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "outcome": outcome,
+    }
+    if detail:
+        record.update(detail)
+    path = _heartbeat_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(record))
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# pull mode
+# ---------------------------------------------------------------------------
+
+
+def run_pull(payload: dict) -> int:
+    """UserPromptSubmit handler. Always returns 0 — the hook is best-effort."""
+    prompt = (payload.get("prompt") or "").strip()
+    if not prompt:
+        _log("skip: empty prompt")
+        return 0
+    if len(prompt) < _tunable("AIGRP_MIN_PROMPT", int):
+        _log(f"skip: prompt too short ({len(prompt)})")
+        return 0
+
+    endpoint = cq_endpoint.resolve()
+    if not endpoint.addr:
+        # This is the #279 failure mode. It is no longer SILENT: a stderr
+        # breadcrumb surfaces in `claude --debug` and the heartbeat lets
+        # `/cq:status` report it. Still exits 0 so prompt submission proceeds.
+        _write_heartbeat("unresolved", {"source": endpoint.source})
+        msg = (
+            "[8l-cq] ambient AIGRP pull inactive: could not resolve the L2 "
+            "endpoint (CQ_ADDR unset and no claude-mux profile carried it). "
+            "Run the /cq:status command for details."
+        )
+        print(msg, file=sys.stderr)
+        _log("skip: endpoint unresolved")
+        return 0
+    if not endpoint.api_key:
+        _write_heartbeat("no_api_key", {"source": endpoint.source})
+        print(
+            "[8l-cq] ambient AIGRP pull inactive: L2 endpoint resolved but "
+            "CQ_API_KEY is missing. Run the /cq:status command for details.",
+            file=sys.stderr,
+        )
+        _log("skip: api key missing")
+        return 0
+
+    persona = os.environ.get("CLAUDE_PERSONA") or os.environ.get("CLAUDE_PROFILE") or os.environ.get("CQ_SESSION") or ""
+    session_id = payload.get("session_id") or payload.get("sessionId") or "unknown"
+
+    body = json.dumps(
+        {
+            "context": prompt,
+            "trigger": "user_prompt",
+            "session_id": session_id,
+            "persona": persona,
+            "max_results": _tunable("AIGRP_MAX_HITS", int),
+            "min_confidence": _tunable("AIGRP_MIN_CONF", float),
+            "min_similarity": _tunable("AIGRP_MIN_SIM", float),
+            "exclude_self": persona != "",
+        }
+    ).encode("utf-8")
+
+    started = time.monotonic()
+    try:
+        resp = _post_lookup(endpoint.addr, endpoint.api_key, body)
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        _write_heartbeat("error", {"source": endpoint.source, "error": str(exc)[:120]})
+        _log(f"skip: lookup failed ({exc})")
+        return 0
+    except json.JSONDecodeError as exc:
+        _write_heartbeat("error", {"source": endpoint.source, "error": f"bad JSON: {exc}"})
+        _log(f"skip: lookup returned non-JSON ({exc})")
+        return 0
+
+    elapsed_ms = int((time.monotonic() - started) * 1000)
+    results = resp.get("results") or []
+    if not results:
+        _write_heartbeat("no_hits", {"source": endpoint.source, "hits": 0, "elapsed_ms": elapsed_ms})
+        _log(f"skip: zero hits ({elapsed_ms}ms)")
+        return 0
+
+    server_ms = resp.get("elapsed_ms", elapsed_ms)
+    _write_heartbeat(
+        "hits",
+        {"source": endpoint.source, "hits": len(results), "elapsed_ms": elapsed_ms},
+    )
+    _emit_reminder(results, server_ms)
+    _log(f"fired {len(results)} hits, {server_ms}ms, persona={persona}")
+    return 0
+
+
+def _post_lookup(addr: str, api_key: str, body: bytes) -> dict:
+    """POST the AIGRP lookup and return the parsed JSON body."""
+    req = urllib.request.Request(  # noqa: S310 — addr comes from operator config
+        url=addr.rstrip("/") + "/api/v1/aigrp/lookup",
+        data=body,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        },
+    )
+    timeout = _tunable("AIGRP_TIMEOUT_S", float)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+        raw = resp.read().decode("utf-8")
+    return json.loads(raw)
+
+
+def _emit_reminder(results: list, server_ms: object) -> None:
+    """Write the ``<system-reminder>`` block Claude Code injects into the prompt."""
+    lines = [
+        "<system-reminder>",
+        f"[8L AIGRP] Relevant prior knowledge for this prompt (server {server_ms}ms, {len(results)} hits):",
+        "",
+    ]
+    for i, hit in enumerate(results, start=1):
+        sim = hit.get("similarity")
+        sim_str = f"{round(sim, 2)}" if isinstance(sim, (int, float)) else "?"
+        lines.append(f"{i}. (sim {sim_str}) {hit.get('summary', '')}")
+        lines.append(f"   Action: {hit.get('action', '')}")
+        lines.append(
+            f"   {hit.get('ku_id', '?')} (created_by {hit.get('created_by', '?')}, "
+            f"confidence {hit.get('confidence', '?')})"
+        )
+    lines.append("</system-reminder>")
+    sys.stdout.write("\n".join(lines) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# status mode
+# ---------------------------------------------------------------------------
+
+
+def run_status() -> int:
+    """Print a one-line operator-facing liveness summary. Returns 0 if live."""
+    endpoint = cq_endpoint.resolve()
+
+    if not endpoint.addr:
+        print(
+            "[8l-cq] ambient AIGRP pull: INACTIVE — no L2 endpoint. "
+            "CQ_ADDR is unset and no claude-mux profile under "
+            f"{cq_endpoint.profiles_dir()} carried a cq address. "
+            "The UserPromptSubmit hook cannot reach the L2."
+        )
+        return 1
+    if not endpoint.api_key:
+        print(
+            f"[8l-cq] ambient AIGRP pull: INACTIVE — endpoint {endpoint.addr} "
+            f"resolved (via {endpoint.source}) but CQ_API_KEY is missing."
+        )
+        return 1
+
+    masked = _mask(endpoint.api_key)
+    last = _format_heartbeat()
+    print(
+        f"[8l-cq] ambient AIGRP pull: LIVE — endpoint {endpoint.addr} "
+        f"(resolved via {endpoint.source}, key {masked}). {last}"
+    )
+    return 0
+
+
+def _format_heartbeat() -> str:
+    """Render the last-run breadcrumb for the status line, if one exists."""
+    path = _heartbeat_path()
+    if not path.is_file():
+        return "Hook has not fired yet this install (no heartbeat recorded)."
+    try:
+        record = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return "Heartbeat file present but unreadable."
+    ts = record.get("ts", "?")
+    outcome = record.get("outcome", "?")
+    detail = ""
+    if "hits" in record:
+        detail = f", {record['hits']} hits, {record.get('elapsed_ms', '?')}ms"
+    return f"Last fired {ts} ({outcome}{detail})."
+
+
+def _mask(api_key: str) -> str:
+    """Mask an API key for display — keep the recognisable prefix + suffix."""
+    if len(api_key) <= 12:
+        return "****"
+    return f"{api_key[:8]}...{api_key[-4:]}"
+
+
+# ---------------------------------------------------------------------------
+# entrypoint
+# ---------------------------------------------------------------------------
+
+
+def _read_payload() -> dict:
+    """Parse the hook JSON from stdin; return {} on empty/garbage input."""
+    try:
+        raw = sys.stdin.read().strip()
+    except OSError:
+        return {}
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Dispatch to the requested mode. ``pull`` always returns 0."""
+    parser = argparse.ArgumentParser(prog="cq_aigrp_pull")
+    parser.add_argument("--mode", required=True, choices=["pull", "status"])
+    args = parser.parse_args(argv if argv is not None else sys.argv[1:])
+
+    if args.mode == "status":
+        return run_status()
+
+    # pull mode — wrap everything so an unexpected error still exits 0.
+    try:
+        payload = _read_payload()
+        return run_pull(payload)
+    except Exception as exc:  # noqa: BLE001 — best-effort hook, never block the prompt
+        _log(f"unexpected error: {exc}")
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/cq/hooks/claude_code/cq_endpoint.py
+++ b/plugins/cq/hooks/claude_code/cq_endpoint.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Resolve the cq L2 endpoint (CQ_ADDR + CQ_API_KEY) for shell-launched hooks.
+
+Why this module exists
+----------------------
+The cq **MCP server** and the cq **lifecycle hooks** reach the L2 by two
+different paths, and only the hook path was fragile:
+
+* The MCP server (``cq mcp``) is launched *by Claude Code* from the plugin's
+  ``mcpServers.cq`` config block. Claude Code injects that block's ``env``
+  into the subprocess, so ``CQ_ADDR`` lands in the server's environment even
+  though it is never exported to the operator's shell. ``CQ_API_KEY`` is
+  merged into the same block from the profile's ``secrets:`` map.
+
+* A ``UserPromptSubmit`` / ``PostToolUse`` hook is launched as a plain shell
+  command. It sees the *shell* environment, not the MCP block's ``env``. In a
+  claude-mux session ``CQ_ADDR`` lives only in ``mcpServers.cq.env`` — so the
+  hook observed ``CQ_ADDR`` unset and silently no-op'd (issue #279, Gap 1).
+  The flagship ambient-retrieval feature was dead with zero operator signal.
+
+The fix: hooks must resolve the endpoint the *same way the binary's config is
+sourced* — from the claude-mux profile JSON that the MCP block was generated
+from — instead of trusting a bare ``$CQ_ADDR`` env var.
+
+Resolution order
+----------------
+1. ``$CQ_ADDR`` / ``$CQ_API_KEY`` from the environment (fast path; honoured
+   when a session *does* export them, e.g. the ``dw-l2`` profile shape).
+2. The active claude-mux profile JSON under ``~/.claude-mux/profiles/``.
+   Three on-disk shapes are supported, checked in order:
+     a. ``mcpServers.cq.env.CQ_ADDR``         — the 8l-cq plugin profile shape
+        (``secrets.CQ_API_KEY`` for the key — already resolved into the env,
+        so step 1 normally covers the key).
+     b. ``env.CQ_ADDR``                       — the dw-l2 profile shape.
+     c. top-level ``cq_addr`` / ``cq_api_key`` — the ``8l join`` CLI profile
+        shape written to ``~/.claude-mux/profiles/<persona>@<ent>-<l2>.json``.
+
+The active profile is chosen by ``$CLAUDE_PROFILE`` (claude-mux exports it),
+falling back to ``$CQ_SESSION`` then ``$CLAUDE_SESSION_DISPLAY_NAME``. If none
+is set, every profile file is scanned and the first that yields a CQ_ADDR
+*and* whose name matches a cq/8l profile is used; this keeps single-profile
+installs working without any env wiring.
+
+Stdlib-only by design — this module is imported by hooks that run on every
+prompt, so it must stay dependency-free and cheap to import.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import NamedTuple
+
+# Default location claude-mux writes session profiles to. Overridable via
+# CQ_PROFILES_DIR so tests (and non-standard installs) can redirect it.
+DEFAULT_PROFILES_DIR = Path.home() / ".claude-mux" / "profiles"
+
+
+class Endpoint(NamedTuple):
+    """A resolved L2 endpoint plus where it came from (for the liveness line)."""
+
+    addr: str | None
+    api_key: str | None
+    source: str  # "env", "profile:<name>", or "unresolved"
+
+    @property
+    def ok(self) -> bool:
+        """True when both an address and a key are present."""
+        return bool(self.addr) and bool(self.api_key)
+
+
+def profiles_dir() -> Path:
+    """Return the claude-mux profiles directory, honouring ``$CQ_PROFILES_DIR``."""
+    override = os.environ.get("CQ_PROFILES_DIR")
+    if override:
+        return Path(override)
+    return DEFAULT_PROFILES_DIR
+
+
+def _addr_key_from_profile(data: dict) -> tuple[str | None, str | None]:
+    """Pull (CQ_ADDR, CQ_API_KEY) out of one parsed profile JSON.
+
+    Tries the three known on-disk shapes (see module docstring) in order.
+    A secret reference such as ``ssm://...`` is *not* a usable key; only a
+    literal value is returned. Returning ``None`` for the key is fine — the
+    key almost always arrives via the environment (claude-mux merges
+    ``secrets:`` into the live env), so address resolution is the load-bearing
+    part here.
+    """
+    addr: str | None = None
+    api_key: str | None = None
+
+    # Shape (a): 8l-cq plugin profile — CQ_ADDR lives in the MCP server block.
+    mcp_env = (data.get("mcpServers") or {}).get("cq", {}).get("env") or {}
+    if isinstance(mcp_env, dict):
+        addr = addr or mcp_env.get("CQ_ADDR")
+        api_key = api_key or _literal(mcp_env.get("CQ_API_KEY"))
+
+    # Shape (b): dw-l2 profile — CQ_ADDR in top-level env.
+    top_env = data.get("env") or {}
+    if isinstance(top_env, dict):
+        addr = addr or top_env.get("CQ_ADDR")
+        api_key = api_key or _literal(top_env.get("CQ_API_KEY"))
+
+    # Shape (c): `8l join` CLI profile — flat cq_addr / cq_api_key.
+    addr = addr or data.get("cq_addr")
+    api_key = api_key or _literal(data.get("cq_api_key"))
+
+    return addr, api_key
+
+
+def _literal(value: object) -> str | None:
+    """Return ``value`` only if it is a usable literal, not a secret reference.
+
+    Profile ``secrets:`` entries hold URIs like ``ssm://8l-cq/foo/api-key`` or
+    ``keychain://...`` — placeholders claude-mux resolves at launch. Those are
+    not bearer tokens; treat them as absent so the caller falls back to the
+    environment (where the resolved key actually lives).
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    if "://" in value or value.startswith("${"):
+        return None
+    return value
+
+
+def _load_profile(path: Path) -> dict | None:
+    """Parse one profile JSON file, returning ``None`` on any read/parse error."""
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _active_profile_names() -> list[str]:
+    """Return candidate profile names from the environment, most-specific first."""
+    names: list[str] = []
+    for var in ("CLAUDE_PROFILE", "CQ_SESSION", "CLAUDE_SESSION_DISPLAY_NAME"):
+        value = os.environ.get(var)
+        if value and value not in names:
+            names.append(value)
+    return names
+
+
+def resolve(env: dict | None = None) -> Endpoint:
+    """Resolve the cq L2 endpoint for a shell-launched hook.
+
+    See the module docstring for the full resolution order. ``env`` defaults
+    to ``os.environ`` and is injectable for tests.
+    """
+    env = os.environ if env is None else env
+
+    # Step 1 — environment fast path.
+    env_addr = env.get("CQ_ADDR")
+    env_key = env.get("CQ_API_KEY")
+    if env_addr:
+        return Endpoint(addr=env_addr, api_key=env_key, source="env")
+
+    # Step 2 — claude-mux profile JSON.
+    pdir = profiles_dir()
+    if not pdir.is_dir():
+        return Endpoint(addr=None, api_key=env_key, source="unresolved")
+
+    # 2a — try the explicitly-named active profile(s) first.
+    for name in _active_profile_names():
+        path = pdir / f"{name}.json"
+        if not path.is_file():
+            continue
+        data = _load_profile(path)
+        if data is None:
+            continue
+        addr, api_key = _addr_key_from_profile(data)
+        if addr:
+            return Endpoint(addr=addr, api_key=api_key or env_key, source=f"profile:{name}")
+
+    # 2b — no env hint (or it didn't carry CQ_ADDR): scan for the first
+    # cq/8l profile that yields an address. Sorted for deterministic pick.
+    for path in sorted(pdir.glob("*.json")):
+        name = path.stem
+        if "cq" not in name and not name.startswith("8l") and "l2" not in name:
+            continue
+        data = _load_profile(path)
+        if data is None:
+            continue
+        addr, api_key = _addr_key_from_profile(data)
+        if addr:
+            return Endpoint(addr=addr, api_key=api_key or env_key, source=f"profile:{name}")
+
+    return Endpoint(addr=None, api_key=env_key, source="unresolved")

--- a/plugins/cq/hooks/hooks.json
+++ b/plugins/cq/hooks/hooks.json
@@ -1,6 +1,18 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/claude_code/cq_aigrp_pull.py\" --mode pull"
+          }
+        ],
+        "description": "8l-cq AIGRP ambient pull: query the tenant L2 for KUs relevant to the prompt and inject them as context"
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "*",

--- a/plugins/cq/tests/conftest.py
+++ b/plugins/cq/tests/conftest.py
@@ -11,6 +11,19 @@ import pytest
 
 HOOK_PATH = Path(__file__).resolve().parent.parent / "hooks" / "cursor" / "cq_cursor_hook.py"
 CC_HOOK_PATH = Path(__file__).resolve().parent.parent / "hooks" / "claude_code" / "cq_cc_hook.py"
+CLAUDE_CODE_HOOK_DIR = Path(__file__).resolve().parent.parent / "hooks" / "claude_code"
+AIGRP_HOOK_PATH = CLAUDE_CODE_HOOK_DIR / "cq_aigrp_pull.py"
+ENDPOINT_PATH = CLAUDE_CODE_HOOK_DIR / "cq_endpoint.py"
+
+
+def _load_module(name: str, path: Path) -> ModuleType:
+    """Load a hook script as a module by path (hooks aren't a package)."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 @pytest.fixture(scope="session")
@@ -39,3 +52,19 @@ def cc_hook() -> ModuleType:
     sys.modules["cq_cc_hook"] = module
     spec.loader.exec_module(module)
     return module
+
+
+@pytest.fixture(scope="session")
+def cq_endpoint() -> ModuleType:
+    """Load cq_endpoint.py (shared L2 endpoint resolver) as a module."""
+    return _load_module("cq_endpoint", ENDPOINT_PATH)
+
+
+@pytest.fixture(scope="session")
+def aigrp_hook() -> ModuleType:
+    """Load cq_aigrp_pull.py (AIGRP ambient-pull hook) as a module.
+
+    The hook inserts its own directory onto ``sys.path`` so its
+    ``import cq_endpoint`` resolves; that runs at import time here too.
+    """
+    return _load_module("cq_aigrp_pull", AIGRP_HOOK_PATH)

--- a/plugins/cq/tests/test_aigrp_pull.py
+++ b/plugins/cq/tests/test_aigrp_pull.py
@@ -1,0 +1,301 @@
+"""Tests for the AIGRP ambient-pull hook + its endpoint resolver.
+
+Covers issue #279 Gap 1: the hook must resolve the L2 endpoint the same way
+the cq binary's config is sourced (claude-mux profile JSON) instead of dying
+silently when ``$CQ_ADDR`` is unset, and must surface an operator-visible
+liveness signal independent of ``AIGRP_DEBUG``.
+
+  * cq_endpoint.resolve — env fast path + the three profile-file shapes
+  * cq_endpoint.resolve — graceful "unresolved" when nothing carries CQ_ADDR
+  * pull mode — best-effort: empty/short prompt, unresolved endpoint → exit 0
+  * pull mode — reminder emitted only when the L2 returns hits
+  * status mode — LIVE vs INACTIVE lines + exit codes
+  * heartbeat — written on every run, read back by status mode
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from io import StringIO
+
+# ---------------------------------------------------------------------------
+# cq_endpoint.resolve
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_env_fast_path(cq_endpoint):
+    """CQ_ADDR/CQ_API_KEY in the environment is used verbatim, source=env."""
+    ep = cq_endpoint.resolve(env={"CQ_ADDR": "https://l2.example", "CQ_API_KEY": "k"})
+    assert ep.addr == "https://l2.example"
+    assert ep.api_key == "k"
+    assert ep.source == "env"
+    assert ep.ok
+
+
+def test_resolve_from_8lcq_profile_shape(cq_endpoint, tmp_path, monkeypatch):
+    """The 8l-cq profile carries CQ_ADDR in mcpServers.cq.env — the #279 case.
+
+    CQ_ADDR is NOT in the shell env (that is the whole bug); the resolver must
+    still find it in the profile JSON. The key arrives via the env, as it does
+    in a live session where claude-mux merges secrets: into the environment.
+    """
+    profile = {
+        "name": "8l-cq",
+        "mcpServers": {"cq": {"env": {"CQ_ADDR": "https://eng.l2.example"}}},
+        "secrets": {"CQ_API_KEY": "ssm://8l-cq/8l-cq/api-key"},  # pragma: allowlist secret
+    }
+    (tmp_path / "8l-cq.json").write_text(json.dumps(profile))
+    monkeypatch.setenv("CQ_PROFILES_DIR", str(tmp_path))
+    monkeypatch.setenv("CLAUDE_PROFILE", "8l-cq")
+
+    ep = cq_endpoint.resolve(
+        env={"CQ_API_KEY": "live-key", "CLAUDE_PROFILE": "8l-cq"}  # pragma: allowlist secret
+    )
+    assert ep.addr == "https://eng.l2.example"
+    assert ep.api_key == "live-key"  # pragma: allowlist secret
+    assert ep.source == "profile:8l-cq"
+    assert ep.ok
+
+
+def test_resolve_ignores_secret_reference_as_key(cq_endpoint, tmp_path, monkeypatch):
+    """An ``ssm://`` placeholder is not a usable bearer token — treated absent."""
+    profile = {
+        "mcpServers": {
+            "cq": {
+                "env": {
+                    "CQ_ADDR": "https://l2.example",
+                    "CQ_API_KEY": "ssm://x/y/z",  # pragma: allowlist secret
+                }
+            }
+        }
+    }
+    (tmp_path / "cq.json").write_text(json.dumps(profile))
+    monkeypatch.setenv("CQ_PROFILES_DIR", str(tmp_path))
+    ep = cq_endpoint.resolve(env={"CLAUDE_PROFILE": "cq"})
+    assert ep.addr == "https://l2.example"
+    assert ep.api_key is None  # ssm:// reference rejected
+
+
+def test_resolve_from_dwl2_profile_shape(cq_endpoint, tmp_path, monkeypatch):
+    """The dw-l2 profile carries CQ_ADDR in top-level env."""
+    profile = {"name": "dw-l2", "env": {"CQ_ADDR": "http://team-dw.example"}}
+    (tmp_path / "dw-l2.json").write_text(json.dumps(profile))
+    monkeypatch.setenv("CQ_PROFILES_DIR", str(tmp_path))
+    monkeypatch.setenv("CLAUDE_PROFILE", "dw-l2")
+    ep = cq_endpoint.resolve(env={"CLAUDE_PROFILE": "dw-l2"})
+    assert ep.addr == "http://team-dw.example"
+    assert ep.source == "profile:dw-l2"
+
+
+def test_resolve_from_8ljoin_profile_shape(cq_endpoint, tmp_path, monkeypatch):
+    """The `8l join` CLI profile carries flat cq_addr / cq_api_key keys."""
+    profile = {
+        "persona": "david",
+        "cq_addr": "https://joined.l2.example",
+        "cq_api_key": "joined-key",  # pragma: allowlist secret
+    }
+    (tmp_path / "david@ent-eng.json").write_text(json.dumps(profile))
+    monkeypatch.setenv("CQ_PROFILES_DIR", str(tmp_path))
+    monkeypatch.setenv("CLAUDE_PROFILE", "david@ent-eng")
+    ep = cq_endpoint.resolve(env={"CLAUDE_PROFILE": "david@ent-eng"})
+    assert ep.addr == "https://joined.l2.example"
+    assert ep.api_key == "joined-key"  # pragma: allowlist secret
+
+
+def test_resolve_scan_fallback_no_env_hint(cq_endpoint, tmp_path, monkeypatch):
+    """With no env hint at all, the resolver scans for a cq/8l profile."""
+    (tmp_path / "unrelated.json").write_text(json.dumps({"env": {"FOO": "bar"}}))
+    (tmp_path / "8l-cq.json").write_text(
+        json.dumps({"mcpServers": {"cq": {"env": {"CQ_ADDR": "https://scanned.example"}}}})
+    )
+    monkeypatch.setenv("CQ_PROFILES_DIR", str(tmp_path))
+    ep = cq_endpoint.resolve(env={})
+    assert ep.addr == "https://scanned.example"
+    assert ep.source == "profile:8l-cq"
+
+
+def test_resolve_unresolved_when_nothing_carries_addr(cq_endpoint, tmp_path, monkeypatch):
+    """No env var, no matching profile → unresolved (not a crash)."""
+    monkeypatch.setenv("CQ_PROFILES_DIR", str(tmp_path))  # empty dir
+    ep = cq_endpoint.resolve(env={})
+    assert ep.addr is None
+    assert ep.source == "unresolved"
+    assert not ep.ok
+
+
+def test_resolve_unresolved_when_profiles_dir_missing(cq_endpoint, monkeypatch):
+    """A non-existent profiles dir resolves to unresolved, no exception."""
+    monkeypatch.setenv("CQ_PROFILES_DIR", "/no/such/dir/279")
+    ep = cq_endpoint.resolve(env={})
+    assert ep.source == "unresolved"
+
+
+# ---------------------------------------------------------------------------
+# pull mode — best-effort behaviour
+# ---------------------------------------------------------------------------
+
+
+def _run(aigrp_hook, monkeypatch, argv, stdin_payload, capsys):
+    monkeypatch.setattr(sys, "argv", ["cq_aigrp_pull.py", *argv])
+    monkeypatch.setattr("sys.stdin", StringIO(json.dumps(stdin_payload)))
+    rc = aigrp_hook.main()
+    return rc, capsys.readouterr()
+
+
+def test_pull_empty_prompt_is_noop(aigrp_hook, monkeypatch, capsys):
+    """An empty prompt exits 0 with no stdout."""
+    rc, captured = _run(aigrp_hook, monkeypatch, ["--mode", "pull"], {"prompt": ""}, capsys)
+    assert rc == 0
+    assert captured.out == ""
+
+
+def test_pull_short_prompt_is_noop(aigrp_hook, monkeypatch, capsys):
+    """A sub-threshold-length prompt exits 0 with no stdout."""
+    rc, captured = _run(aigrp_hook, monkeypatch, ["--mode", "pull"], {"prompt": "hi"}, capsys)
+    assert rc == 0
+    assert captured.out == ""
+
+
+def test_pull_unresolved_endpoint_exits_zero_with_stderr(aigrp_hook, monkeypatch, capsys, tmp_path):
+    """The #279 fix: an unresolved endpoint no longer dies SILENTLY.
+
+    The hook still exits 0 (best-effort, never block the prompt) and writes
+    nothing to stdout, but it DOES emit a one-line stderr breadcrumb so the
+    failure is detectable in `claude --debug` instead of being invisible.
+    """
+    monkeypatch.setenv("CQ_PROFILES_DIR", str(tmp_path))  # empty → unresolved
+    monkeypatch.delenv("CQ_ADDR", raising=False)
+    monkeypatch.setenv("AIGRP_HEARTBEAT_PATH", str(tmp_path / "hb.json"))
+    rc, captured = _run(
+        aigrp_hook,
+        monkeypatch,
+        ["--mode", "pull"],
+        {"prompt": "a reasonably long prompt about terraform state"},
+        capsys,
+    )
+    assert rc == 0
+    assert captured.out == ""  # no injected context
+    assert "inactive" in captured.err.lower()
+    assert "cq_addr" in captured.err.lower() or "endpoint" in captured.err.lower()
+    # Heartbeat records the unresolved outcome for /cq:status to surface.
+    record = json.loads((tmp_path / "hb.json").read_text())
+    assert record["outcome"] == "unresolved"
+
+
+def test_pull_emits_reminder_on_hits(aigrp_hook, monkeypatch, capsys, tmp_path):
+    """When the L2 returns hits, pull injects a <system-reminder> block."""
+    monkeypatch.setenv("CQ_ADDR", "https://l2.example")
+    monkeypatch.setenv("CQ_API_KEY", "cqa.v1.test")
+    monkeypatch.setenv("AIGRP_HEARTBEAT_PATH", str(tmp_path / "hb.json"))
+
+    fake_resp = {
+        "elapsed_ms": 42,
+        "results": [
+            {
+                "summary": "Use workload identity federation, not key files.",
+                "action": "Set CQ_GCP_WIF=1.",
+                "ku_id": "ku-123",
+                "created_by": "probe-agent",
+                "confidence": 0.9,
+                "similarity": 0.812,
+            }
+        ],
+    }
+    monkeypatch.setattr(aigrp_hook, "_post_lookup", lambda *a, **k: fake_resp)
+
+    rc, captured = _run(
+        aigrp_hook,
+        monkeypatch,
+        ["--mode", "pull"],
+        {"prompt": "how do I authenticate to gcp without a service account key"},
+        capsys,
+    )
+    assert rc == 0
+    assert "<system-reminder>" in captured.out
+    assert "[8L AIGRP]" in captured.out
+    assert "ku-123" in captured.out
+    assert "workload identity federation" in captured.out
+    record = json.loads((tmp_path / "hb.json").read_text())
+    assert record["outcome"] == "hits"
+    assert record["hits"] == 1
+
+
+def test_pull_quiet_on_zero_hits(aigrp_hook, monkeypatch, capsys, tmp_path):
+    """Zero hits → no stdout (the hook stays quiet on the happy path)."""
+    monkeypatch.setenv("CQ_ADDR", "https://l2.example")
+    monkeypatch.setenv("CQ_API_KEY", "cqa.v1.test")
+    monkeypatch.setenv("AIGRP_HEARTBEAT_PATH", str(tmp_path / "hb.json"))
+    monkeypatch.setattr(aigrp_hook, "_post_lookup", lambda *a, **k: {"results": []})
+    rc, captured = _run(
+        aigrp_hook,
+        monkeypatch,
+        ["--mode", "pull"],
+        {"prompt": "a prompt the commons knows nothing about"},
+        capsys,
+    )
+    assert rc == 0
+    assert captured.out == ""
+    assert json.loads((tmp_path / "hb.json").read_text())["outcome"] == "no_hits"
+
+
+def test_pull_network_error_exits_zero(aigrp_hook, monkeypatch, capsys, tmp_path):
+    """A network failure during lookup must not block the prompt — exit 0."""
+    monkeypatch.setenv("CQ_ADDR", "https://l2.example")
+    monkeypatch.setenv("CQ_API_KEY", "cqa.v1.test")
+    monkeypatch.setenv("AIGRP_HEARTBEAT_PATH", str(tmp_path / "hb.json"))
+
+    def _boom(*_a, **_k):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(aigrp_hook, "_post_lookup", _boom)
+    rc, captured = _run(
+        aigrp_hook,
+        monkeypatch,
+        ["--mode", "pull"],
+        {"prompt": "a long enough prompt to pass the length guard"},
+        capsys,
+    )
+    assert rc == 0
+    assert captured.out == ""
+    assert json.loads((tmp_path / "hb.json").read_text())["outcome"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# status mode
+# ---------------------------------------------------------------------------
+
+
+def test_status_live_when_endpoint_resolves(aigrp_hook, monkeypatch, capsys, tmp_path):
+    """status prints a LIVE line and exits 0 when the endpoint resolves."""
+    monkeypatch.setenv("CQ_ADDR", "https://l2.example")
+    monkeypatch.setenv("CQ_API_KEY", "cqa.v1.0123456789abcdef")
+    monkeypatch.setenv("AIGRP_HEARTBEAT_PATH", str(tmp_path / "hb.json"))
+    rc, captured = _run(aigrp_hook, monkeypatch, ["--mode", "status"], {}, capsys)
+    assert rc == 0
+    assert "LIVE" in captured.out
+    assert "https://l2.example" in captured.out
+    # The key is masked, never printed in full.
+    assert "cqa.v1.0123456789abcdef" not in captured.out
+
+
+def test_status_inactive_when_unresolved(aigrp_hook, monkeypatch, capsys, tmp_path):
+    """status prints an INACTIVE line and exits 1 when nothing resolves."""
+    monkeypatch.delenv("CQ_ADDR", raising=False)
+    monkeypatch.setenv("CQ_PROFILES_DIR", str(tmp_path))  # empty dir
+    rc, captured = _run(aigrp_hook, monkeypatch, ["--mode", "status"], {}, capsys)
+    assert rc == 1
+    assert "INACTIVE" in captured.out
+
+
+def test_status_reports_last_heartbeat(aigrp_hook, monkeypatch, capsys, tmp_path):
+    """status surfaces the most recent hook run from the heartbeat file."""
+    hb = tmp_path / "hb.json"
+    hb.write_text(json.dumps({"ts": "2026-05-19T10:00:00Z", "outcome": "hits", "hits": 3}))
+    monkeypatch.setenv("CQ_ADDR", "https://l2.example")
+    monkeypatch.setenv("CQ_API_KEY", "cqa.v1.0123456789abcdef")
+    monkeypatch.setenv("AIGRP_HEARTBEAT_PATH", str(hb))
+    rc, captured = _run(aigrp_hook, monkeypatch, ["--mode", "status"], {}, capsys)
+    assert rc == 0
+    assert "2026-05-19T10:00:00Z" in captured.out
+    assert "3 hits" in captured.out


### PR DESCRIPTION
## Gap 1 of #279 — the ambient-pull hook silently no-op'd

The "seamless ambient query" — the harness pulling relevant KUs from the L2 on every prompt — is a `UserPromptSubmit` hook calling `POST /api/v1/aigrp/lookup`. It bailed at its first guard whenever `$CQ_ADDR` was unset, giving the operator **no signal**.

### Root cause

`CQ_ADDR` and the cq endpoint are resolved two different ways:

- The **cq MCP server** (`cq mcp`) is launched *by Claude Code* from the plugin's `mcpServers.cq` config block. Claude Code injects that block's `env` into the subprocess, so `CQ_ADDR` reaches the server even though it is never exported to the operator's shell.
- A **`UserPromptSubmit` hook** runs as a plain shell command — it sees the *shell* environment, not the MCP block's `env`. In a claude-mux session `CQ_ADDR` lives only in `mcpServers.cq.env`, so the hook observed `CQ_ADDR` unset and silently exited.

Net effect: `propose`/`query` via MCP worked while the flagship ambient-retrieval feature was dead, invisibly.

## The fix

**Endpoint resolution** — new `cq_endpoint.py` resolver: environment fast path, then fall back to the claude-mux profile JSON under `~/.claude-mux/profiles/` — the same config the MCP server block is generated from. Handles all three on-disk shapes:
- 8l-cq plugin profile — `mcpServers.cq.env.CQ_ADDR`
- dw-l2 profile — top-level `env.CQ_ADDR`
- `8l join` CLI profile — flat `cq_addr` / `cq_api_key`

`ssm://` / `${...}` secret references are rejected as non-literal, so the resolved key from the live environment is used. The hook now finds the L2 whenever the MCP server can.

**The hook itself** — new `cq_aigrp_pull.py`, productized from the `8l-cq-aigrp-pull.sh` reference as stdlib-only Python matching the existing `cq_cc_hook.py` conventions; registered as `UserPromptSubmit` in `hooks.json`. Best-effort: any failure exits 0 so prompt submission is never blocked, and it stays quiet on the happy path (emits an injected `<system-reminder>` only when the L2 returns hits).

**Operator-visible liveness, independent of `AIGRP_DEBUG`:**
- A `--mode status` prints a one-line `LIVE` / `INACTIVE` summary (endpoint, resolution source, masked key, last-fire). Wired into `/cq:status` as an "Ambient Pull" section.
- Every hook run stamps a heartbeat file the status line reads back.
- An unresolved endpoint now also emits a one-line stderr breadcrumb (visible under `claude --debug`) instead of dying silently.

## Verification

With `CQ_ADDR` unset (simulating the live failure case):
- `--mode status` resolves the endpoint from the `8l-cq` profile and reports `LIVE`.
- `--mode pull` reaches the live engineering L2 (`200` in ~0.3s) and records a heartbeat.
- An unresolved endpoint reports `INACTIVE` (exit 1) and the pull path emits the stderr breadcrumb.

17 new tests cover endpoint resolution (all three profile shapes + env fast path + scan fallback + unresolved), best-effort behaviour, the reminder block, and status/heartbeat. Full plugin suite green (127 passed). `pre-commit` clean on all changed files.

## Scope

This addresses **Gap 1** of #279 (the `CQ_ADDR` wiring). **Gap 2** — read-path `activity_log` instrumentation — is tracked separately as #284 and is not touched here; the L2 server is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)