### PR TITLE
fix(docker): cq-server base images from ECR Public mirror — unblock image build

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -4,8 +4,13 @@
 #   docker build -t cq-server server/
 
 # --- Stage 1: build the frontend static assets. ---
+#
+# Base images come from AWS's ECR Public Docker Hub mirror, not docker.io
+# directly: anonymous docker.io pulls from shared CodeBuild IPs hit HTTP
+# 429 rate limits, which had been silently failing every cq-server-image
+# build. The mirror is rate-limit-free and needs no credentials.
 
-FROM node:22-slim AS frontend
+FROM public.ecr.aws/docker/library/node:22-slim AS frontend
 
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
@@ -19,7 +24,7 @@ RUN pnpm build
 
 # --- Stage 2: Python backend with embedded frontend. ---
 
-FROM python:3.12.11-slim
+FROM public.ecr.aws/docker/library/python:3.12.11-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends sqlite3 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Problem

The `cq-server-image` CodeBuild project has **failed on every build since FO-3** — #297, #298, and #299's merge-triggered image builds all failed in the BUILD phase:

```
ERROR: failed to solve: python:3.12.11-slim: 429 Too Many Requests — registry-1.docker.io
```

`server/Dockerfile` pulls `node:22-slim` + `python:3.12.11-slim` from docker.io directly; the multi-arch buildx build from shared CodeBuild IPs is rate-limited. **Net effect: no new cq-server image has shipped since 2026-05-18** — FO-4, the #284 read-path logging, and everything since are merged to `main` but not in any image.

## Fix

Point both `FROM` lines at AWS's ECR Public Docker Hub mirror (`public.ecr.aws/docker/library/*`) — rate-limit-free, no credentials. Identical fix to cq-directory #23.

Unblocks the S1 MVP-scenario substrate (needs a current image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)