### PR TITLE
fix(activity): mark API responses no-store so a CDN can't hide read-path logs (agent#306)

### DIFF
--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -1933,6 +1933,63 @@ if _CORS_ORIGINS:
         allow_credentials=False,
     )
 
+# --- API responses must never be cached by an intermediary. ---
+#
+# agent#306 — root cause. The L2 sits behind a CDN in some deployments
+# (``mvp-s1.8th-layer.ai`` fronts the ALB with Cloudflare -> CloudFront).
+# Dynamic API responses left the L2 with NO ``Cache-Control`` header, so
+# the CDN was free to apply its default caching to GET responses. The
+# observable symptom: ``GET /api/v1/activity`` served a STALE cached page
+# that never showed the ``aigrp_lookup`` rows the L2 had since written —
+# read-path instrumentation looked "not firing" when it was firing fine,
+# the audit read was just cached. A cache that ignores the
+# ``Authorization`` header can also leak one caller's response to
+# another, or serve an unauthenticated 200 in place of a live 401.
+#
+# The activity log is the audit record of record; it — and every other
+# dynamic API response — must always be live. Stamp ``no-store`` on all
+# API responses so no CDN, proxy, or browser cache can ever hold them.
+# Static assets (mounted below under ``/assets``) keep their own
+# long-lived caching headers from ``StaticFiles`` and are unaffected:
+# the guard only touches the API route trees.
+_API_PREFIXES = ("/api/v1/", "/api/v1")
+
+
+@app.middleware("http")
+async def _no_store_api_responses(request: Request, call_next):  # type: ignore[no-untyped-def]
+    """Default dynamic API responses to ``Cache-Control: no-store``.
+
+    Applies to the ``/api/v1`` route tree and to the root-mounted API
+    routes (the SDK-compat mount). The static SPA assets served from
+    ``/assets`` are intentionally excluded so their immutable-hashed
+    filenames keep CDN caching. ``no-store`` (not merely ``no-cache``)
+    is deliberate: it forbids storing the response at all, which is the
+    correct contract for an audit log and for auth-scoped data.
+
+    A route that has *already* set its own ``Cache-Control`` is left
+    untouched — e.g. ``GET /theme`` deliberately sends
+    ``public, max-age=300`` for its near-static branding payload. This
+    middleware only supplies the safe default for the routes that said
+    nothing; it never overrides a deliberate per-route caching policy.
+    """
+    response = await call_next(request)
+    if "cache-control" in response.headers:
+        # Route opted into an explicit policy — respect it.
+        return response
+    path = request.url.path
+    is_api = path.startswith(_API_PREFIXES) or path in {"/health", "/stats"}
+    if not is_api and not path.startswith("/assets"):
+        # Root-mounted API routes (SDK compat) — anything that is not a
+        # static asset and not the SPA HTML shell is a dynamic API
+        # response. The SPA fallback sets its own headers; an explicit
+        # no-store on a JSON API response is always safe.
+        ctype = response.headers.get("content-type", "")
+        is_api = ctype.startswith("application/json")
+    if is_api:
+        response.headers["Cache-Control"] = "no-store"
+    return response
+
+
 # Mount API routes at root (SDK compatibility) and at /api (frontend).
 app.include_router(api_router)
 app.include_router(api_router, prefix="/api/v1")

--- a/server/backend/tests/test_activity_log_read_path.py
+++ b/server/backend/tests/test_activity_log_read_path.py
@@ -243,6 +243,52 @@ class TestAigrpLookupLogs:
         assert summary["hits"] == 0
         assert summary["ku_ids"] == []
 
+    def test_lookup_writes_row_on_zero_result_lookup(
+        self,
+        client: TestClient,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A lookup that embeds fine but matches nothing still logs (agent#306).
+
+        The S1 acceptance smoke pinned this explicitly: even a
+        no-result lookup must be auditable. This is distinct from the
+        embedding-unavailable path — here ``embed_text`` succeeds and
+        the handler runs the full filter loop; ``semantic_query`` just
+        returns an empty candidate set. The ``aigrp_lookup`` row must
+        still be written, with ``embed_unavailable: False`` and an
+        empty ``ku_ids``.
+        """
+        _seed_user(username="empty-look", password="pw")  # pragma: allowlist secret
+        api_key = _mint_api_key(client, _login_jwt(client, "empty-look", "pw"))
+
+        _stub_embed(monkeypatch)
+        store = _get_store()
+
+        async def _no_hits(_vec, *, limit: int = 10):  # noqa: ANN001
+            return []
+
+        monkeypatch.setattr(store, "semantic_query", _no_hits)
+
+        resp = client.post(
+            "/api/v1/aigrp/lookup",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={"context": "nothing will match this", "trigger": "tool_failure"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["results"] == []
+
+        rows = _activity_rows(tmp_path / "activity.db")
+        lookup_rows = [r for r in rows if r["event_type"] == "aigrp_lookup"]
+        assert len(lookup_rows) == 1
+        payload = json.loads(lookup_rows[0]["payload"])
+        assert payload["embed_unavailable"] is False
+        assert payload["trigger"] == "tool_failure"
+        summary = json.loads(lookup_rows[0]["result_summary"])
+        assert summary["hits"] == 0
+        assert summary["ku_ids"] == []
+        assert "elapsed_ms" in summary
+
     def test_lookup_succeeds_when_append_activity_raises(
         self,
         client: TestClient,
@@ -352,3 +398,70 @@ class TestForwardQueryLogs:
         summary = json.loads(row["result_summary"])
         assert summary["ku_ids"] == []
         assert summary["result_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# CDN-cacheability guard — agent#306 root cause
+# ---------------------------------------------------------------------------
+
+
+class TestApiResponsesAreNotCacheable:
+    """API responses must carry ``Cache-Control: no-store`` (agent#306).
+
+    The L2 sits behind a CDN in some deployments. Without an explicit
+    no-store header the CDN cached ``GET /api/v1/activity`` and served a
+    stale page that never reflected freshly-written ``aigrp_lookup``
+    rows — the false "read-path instrumentation not firing" symptom #306
+    was filed for. The audit log, and every dynamic API response, must
+    always be live.
+    """
+
+    def test_activity_read_sends_no_store(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _seed_user(username="cache-look", password="pw")  # pragma: allowlist secret
+        api_key = _mint_api_key(client, _login_jwt(client, "cache-look", "pw"))
+        resp = client.get(
+            "/api/v1/activity",
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.headers.get("cache-control") == "no-store"
+
+    def test_aigrp_lookup_response_sends_no_store(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _seed_user(username="cache-look2", password="pw")  # pragma: allowlist secret
+        api_key = _mint_api_key(client, _login_jwt(client, "cache-look2", "pw"))
+        monkeypatch.setattr(app_module, "embed_text", lambda _t: None)
+        resp = client.post(
+            "/api/v1/aigrp/lookup",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={"context": "x", "trigger": "user_prompt"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.headers.get("cache-control") == "no-store"
+
+    def test_root_mounted_api_route_sends_no_store(
+        self,
+        client: TestClient,
+    ) -> None:
+        """The SDK-compat root mount (no ``/api/v1`` prefix) is covered too."""
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        assert resp.headers.get("cache-control") == "no-store"
+
+    def test_unauthenticated_401_is_not_cacheable(
+        self,
+        client: TestClient,
+    ) -> None:
+        """An auth failure must not be cacheable either — a cached 401
+        (or a cached 200 in its place) is how the CDN leaked stale auth
+        state in agent#306."""
+        resp = client.get("/api/v1/activity")
+        assert resp.status_code == 401
+        assert resp.headers.get("cache-control") == "no-store"


### PR DESCRIPTION
## Problem

agent#306: the read-path `aigrp_lookup` activity-log instrumentation (#284, merged via #299) appeared "not firing" on the live `mvp-s1` L2 — `GET /api/v1/activity` showed only write events (`propose`, `review_resolve`), never `aigrp_lookup`, even for full-work lookups that returned a semantic hit.

## Root cause — it is not a code or schema bug

I reproduced every theory in #306 and ruled them all out:

- **Migration 0025 / CHECK constraint** — applies cleanly on fresh DBs, on existing populated DBs, and via the production `run_migrations` single-transaction wrapper. The resulting `activity_log.event_type` CHECK constraint includes `aigrp_lookup`. A direct `aigrp_lookup` INSERT succeeds.
- **The handler / `log_activity`** — `BackgroundTasks` is wired into the route signature; the task is scheduled on every path including the zero-result and embed-unavailable short-circuits. Proven end-to-end in-process by minting a real agent-key persona through `POST /admin/agent-keys` and firing a lookup: an `aigrp_lookup` row **is** written.
- **The deployed image** — pulled `git-8e8db3f5aaaa` and inspected it: `cq_server` resolves to fresh `/app/src`, `EVENT_TYPES` contains `aigrp_lookup`, and the handlers carry their auth dependencies. The image is current.

The actual cause surfaced from the live response headers: `mvp-s1.8th-layer.ai` fronts the L2's ALB with a CDN (`server: cloudflare`, `via: ...cloudfront.net`). The L2 sent **dynamic API responses with no `Cache-Control` header at all**, so the CDN was free to cache them.

- `GET /api/v1/activity` against the **ALB directly** → live data, and `401` when unauthenticated.
- The **same path via the CDN** → a stale cached page (and a cached `200` where the live origin returns `401`).

The S1 acceptance smoke read `/api/v1/activity` through the CDN and got a cached page that never reflected the `aigrp_lookup` rows the L2 had since written. The instrumentation was firing the whole time; the audit read was simply being served stale by an intermediary.

## Fix

A middleware defaults every dynamic API response to `Cache-Control: no-store`. The activity log is the audit record of record, and all auth-scoped API data must never be cached by any CDN, proxy, or browser. A route that sets its own `Cache-Control` (e.g. `GET /theme`'s `public, max-age=300` near-static branding payload) is left untouched — the middleware only supplies the safe default where a route said nothing. Static `/assets` keep their own long-lived caching.

## Tests

- `test_lookup_writes_row_on_zero_result_lookup` — a lookup that embeds fine but matches nothing still writes an `aigrp_lookup` row (S1 explicitly required no-result lookups be auditable).
- `TestApiResponsesAreNotCacheable` — `no-store` on `/api/v1/activity`, on `/api/v1/aigrp/lookup`, on the root-mounted `/health` (SDK-compat mount), and on the unauthenticated `401`.
- Existing read-path + theme + app suites pass; theme's deliberate `public, max-age=300` is preserved.

## Follow-up (outside this repo)

The CDN in front of `mvp-s1.8th-layer.ai` should also be configured not to cache `/api/*` regardless of origin headers — defence in depth. This PR fixes the origin contract; the CDN config is a separate infra change.

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)