### PR TITLE
fix(marketplace-l2): carry real (enterprise_id, group_id) into provisioned L2 tenancy

### DIFF
--- a/deploy/aws/marketplace-l2.yaml
+++ b/deploy/aws/marketplace-l2.yaml
@@ -23,11 +23,40 @@ Parameters:
   EnterpriseSlug:
     Type: String
     Description: |
-      URL-safe enterprise slug — used as identifier + subdomain prefix
-      (e.g. "acme" → acme.8th-layer.ai). Must match the slug registered
-      with the 8th-Layer directory in phase 2.
+      URL-safe slug — used for resource naming + subdomain prefix
+      (e.g. "acme" → acme.8th-layer.ai) + CFN stack name. For an
+      FO-1 first-L2 deploy this equals the Enterprise slug. For an
+      FO-2 additional-L2 deploy this is the *L2's own* slug, which
+      differs from its parent Enterprise — so it must NOT be used as
+      the cq-server tenancy id. See CqEnterpriseId/CqGroupId below.
     AllowedPattern: "^[a-z0-9][a-z0-9-]{2,62}$"
     ConstraintDescription: 3-63 chars, lowercase alphanumeric + hyphen.
+
+  CqEnterpriseId:
+    Type: String
+    Default: ""
+    Description: |
+      The cq-server tenancy enterprise id — becomes CQ_ENTERPRISE on
+      the task, which stamps tenant_enterprise on every activity_log
+      row, KU, and agent. This is the *parent Enterprise* slug, which
+      for an FO-2 additional-L2 deploy is NOT the same as EnterpriseSlug
+      (the L2's own slug). Leave empty for FO-1 first-L2 deploys, where
+      the L2 slug IS the Enterprise — the template then falls back to
+      EnterpriseSlug. agent#303.
+    AllowedPattern: "^([a-z0-9][a-z0-9-]{2,62})?$"
+    ConstraintDescription: Empty, or 3-63 chars lowercase alphanumeric + hyphen.
+
+  CqGroupId:
+    Type: String
+    Default: default
+    Description: |
+      The cq-server tenancy group id within the Enterprise — becomes
+      CQ_GROUP on the task, stamping tenant_group on activity_log rows,
+      KUs, and agents. Defaults to "default" (single-group deployments);
+      provisioning passes the L2's real group when one is assigned.
+      agent#303.
+    AllowedPattern: "^[a-z0-9][a-z0-9-]{0,62}$"
+    ConstraintDescription: 1-63 chars, lowercase alphanumeric + hyphen.
 
   AwsRegion:
     Type: String
@@ -114,6 +143,10 @@ Parameters:
 Conditions:
   HasAdminPasswordParam: !Not [!Equals [!Ref AdminPasswordSsmParam, ""]]
   AutoApproveOn: !Equals [!Ref AutoApprovePropose, "true"]
+  # agent#303 — when CqEnterpriseId is left empty (FO-1 first-L2 deploy),
+  # the L2 slug IS the Enterprise, so CQ_ENTERPRISE falls back to
+  # EnterpriseSlug. FO-2 deploys pass the real parent Enterprise id.
+  HasCqEnterpriseId: !Not [!Equals [!Ref CqEnterpriseId, ""]]
 
 Resources:
   # =====================================================================
@@ -446,8 +479,15 @@ Resources:
           Environment:
             - { Name: CQ_PORT, Value: "3000" }
             - { Name: CQ_DB_PATH, Value: /data/cq.db }
-            - { Name: CQ_ENTERPRISE, Value: !Ref EnterpriseSlug }
-            - { Name: CQ_GROUP, Value: default }
+            # agent#303 — CQ_ENTERPRISE / CQ_GROUP drive tenancy stamping
+            # (tenant_enterprise / tenant_group on activity_log, KUs, agents).
+            # CQ_ENTERPRISE must be the *parent Enterprise* id, which for an
+            # FO-2 additional-L2 deploy is NOT EnterpriseSlug (the L2's own
+            # slug). Fall back to EnterpriseSlug only when CqEnterpriseId is
+            # unset (FO-1 first-L2, where the slug IS the Enterprise).
+            - Name: CQ_ENTERPRISE
+              Value: !If [HasCqEnterpriseId, !Ref CqEnterpriseId, !Ref EnterpriseSlug]
+            - { Name: CQ_GROUP, Value: !Ref CqGroupId }
             - { Name: CQ_DIRECTORY_URL, Value: !Ref DirectoryUrl }
             - { Name: CQ_ENTERPRISE_ROOT_PUBKEY, Value: !Ref RootPubkeyB64u }
             - { Name: CQ_DIRECTORY_ENABLED, Value: "true" }

--- a/server/backend/tests/test_l2_tenancy_scope.py
+++ b/server/backend/tests/test_l2_tenancy_scope.py
@@ -1,0 +1,79 @@
+"""agent#303 — an FO-2-provisioned L2 must run in its own tenancy scope.
+
+Regression pin for the bug where every FO-2-provisioned L2 silently
+stamped ``tenant_enterprise=default-enterprise`` / ``tenant_group=
+default-group`` on its ``activity_log`` rows, KUs, and agents — because
+the marketplace CFN template fed the L2's *own slug* into ``CQ_ENTERPRISE``
+instead of the parent Enterprise id, and hardcoded ``CQ_GROUP=default``.
+
+These tests assert the cq-server side of the contract: given the
+canonical ``CQ_ENTERPRISE`` / ``CQ_GROUP`` env vars, the runtime
+resolves a non-default ``(enterprise_id, group_id)`` rather than
+falling through to the ``tables.py`` defaults.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cq_server import aigrp
+from cq_server.aigrp import _legacy
+from cq_server.tables import DEFAULT_ENTERPRISE_ID, DEFAULT_GROUP_ID
+
+
+def test_canonical_env_vars_are_cq_enterprise_and_cq_group(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The runtime reads ``CQ_ENTERPRISE`` / ``CQ_GROUP`` — nothing else.
+
+    This pins the env-var contract the marketplace template + provisioning
+    service must target. If someone renames the env vars on the app side,
+    this test fails and forces the template to be updated in lockstep.
+    """
+    monkeypatch.setenv("CQ_ENTERPRISE", "acme-corp")
+    monkeypatch.setenv("CQ_GROUP", "platform")
+    assert _legacy.enterprise() == "acme-corp"
+    assert _legacy.group() == "platform"
+    # Re-exported on the package so callers use ``aigrp.enterprise()``.
+    assert aigrp.enterprise() == "acme-corp"
+    assert aigrp.group() == "platform"
+
+
+def test_fo2_provisioned_l2_resolves_non_default_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An L2 carrying its real Enterprise/Group env does NOT fall to default.
+
+    Simulates an FO-2 additional-L2 deploy: the L2's own slug differs from
+    its parent Enterprise, and the template now passes the parent Enterprise
+    id into ``CQ_ENTERPRISE``. The resolved scope must be the parent
+    Enterprise, never ``default-enterprise`` / ``default-group``.
+    """
+    # FO-2: parent Enterprise "globex", a non-default group, L2 slug would
+    # be something else entirely (e.g. "globex-eu-l2") — irrelevant here,
+    # because tenancy is driven by CQ_ENTERPRISE/CQ_GROUP, not the slug.
+    monkeypatch.setenv("CQ_ENTERPRISE", "globex")
+    monkeypatch.setenv("CQ_GROUP", "research")
+
+    resolved_enterprise = _legacy.enterprise()
+    resolved_group = _legacy.group()
+
+    assert resolved_enterprise == "globex"
+    assert resolved_group == "research"
+    assert resolved_enterprise != DEFAULT_ENTERPRISE_ID
+    assert resolved_group != DEFAULT_GROUP_ID
+
+
+def test_unset_env_falls_through_to_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no env set, the runtime falls to the documented defaults.
+
+    This is the *pre-fix* failure mode — kept as a guard so the fallback
+    behaviour stays explicit. ``group()`` defaults to bare ``"default"``
+    (not ``DEFAULT_GROUP_ID``); both are accepted as "unscoped".
+    """
+    monkeypatch.delenv("CQ_ENTERPRISE", raising=False)
+    monkeypatch.delenv("CQ_GROUP", raising=False)
+    assert _legacy.enterprise() == DEFAULT_ENTERPRISE_ID
+    assert _legacy.group() == "default"


### PR DESCRIPTION
## Problem

FO-2/FO-3-provisioned L2s silently run in **default tenancy scope**. Every `activity_log` row, KU, and agent on a provisioned L2 is stamped `tenant_enterprise=default-enterprise` / `tenant_group=default-group`, regardless of which Enterprise the L2 belongs to.

## Root cause

The `marketplace-l2.yaml` template reused a single `EnterpriseSlug` parameter for **two unrelated purposes**:

1. Resource naming / subdomain prefix / CFN stack name — must be the L2's *own* unique slug.
2. The cq-server `CQ_ENTERPRISE` tenancy id — must be the *parent Enterprise*.

For an additional-L2 deploy the L2 slug differs from its Enterprise, so `CQ_ENTERPRISE` got the L2 slug instead of the Enterprise. `CQ_GROUP` was hardcoded to `default`.

The cq-server side was never wrong: it reads `CQ_ENTERPRISE` / `CQ_GROUP` via `aigrp._legacy.enterprise()` / `group()`, which feed `activity_logger` tenancy stamping. The template just fed those env vars the wrong source value.

## Fix (this PR — template side)

- New `CqEnterpriseId` parameter → `CQ_ENTERPRISE` env. Empty default; a new `HasCqEnterpriseId` condition falls back to `EnterpriseSlug` when empty (FO-1 first-L2 deploy, where the L2 slug *is* the Enterprise — backward compatible).
- New `CqGroupId` parameter (default `default`) → `CQ_GROUP` env.
- `EnterpriseSlug` keeps its resource-naming / subdomain / stack-name role only.
- New `test_l2_tenancy_scope.py` pins the canonical env-var contract (`CQ_ENTERPRISE` / `CQ_GROUP`) and asserts a provisioned L2 resolves a non-default `(enterprise_id, group_id)`.

The provisioning-service side (passing `CqEnterpriseId` / `CqGroupId` as stack params) is fixed in a companion PR on `OneZero1ai/8th-layer-directory`.

## Canonical env var names

`CQ_ENTERPRISE` and `CQ_GROUP` — already what the cq-server reads; not renamed.

## Test results

`912 passed, 5 skipped` (full backend suite); ruff clean on changed files; cfn-lint clean (no new warnings).

## Scope

New provisions come up correctly scoped. Retro-fixing the already-running `mvp-s1` L2's `default-*` data is a separate migration concern, deliberately out of scope.

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)