### PR TITLE
feat(aigrp): cross-L2 forward-query fan-out for intra-Enterprise federation (#316)

### DIFF
--- a/server/backend/src/cq_server/aigrp/__init__.py
+++ b/server/backend/src/cq_server/aigrp/__init__.py
@@ -36,6 +36,12 @@ from ._legacy import (
     self_l2_id,
     self_url,
 )
+from .federation import (
+    RemoteHit,
+    fan_out_forward_query,
+    forward_query_peer,
+    select_peers_for_query,
+)
 from .runtime import (
     bootstrap_root_if_needed,
     derive_bearer_token,
@@ -55,8 +61,12 @@ __all__ = [
     "bootstrap_root_if_needed",
     "compute_centroid",
     "compute_domain_bloom",
+    "RemoteHit",
     "derive_bearer_token",
     "enterprise",
+    "fan_out_forward_query",
+    "forward_query_peer",
+    "select_peers_for_query",
     "group",
     "invalidate_pair_cache",
     "is_first_deploy",

--- a/server/backend/src/cq_server/aigrp/federation.py
+++ b/server/backend/src/cq_server/aigrp/federation.py
@@ -37,6 +37,7 @@ from typing import Any
 import httpx
 
 from . import _legacy
+from .. import forward_sign
 
 log = logging.getLogger("aigrp.federation")
 
@@ -46,6 +47,35 @@ log = logging.getLogger("aigrp.federation")
 # breach degrades to local-only, never an error.
 _CONNECT_TIMEOUT_SEC = 3.0
 _READ_TIMEOUT_SEC = 8.0
+
+
+def _endpoint_is_safe(endpoint_url: str) -> bool:
+    """Minimal SSRF guard for a peer ``endpoint_url`` used as a POST target.
+
+    Rejects an endpoint when its scheme is not ``https://`` or its host
+    string is loopback / link-local / RFC1918 private space. This is a
+    deliberately small defensive check — full receiver-side hardening
+    (DNS-resolution pinning, redirect clamping) is tracked as a separate
+    issue. A string-level host check cannot catch a hostname that
+    *resolves* to a private address, but it cheaply blocks the obvious
+    ``http://`` and literal-private-IP foot-guns.
+    """
+    url = (endpoint_url or "").strip().lower()
+    if not url.startswith("https://"):
+        return False
+    host = url[len("https://") :].split("/", 1)[0].split("@")[-1].split(":", 1)[0]
+    if host in ("localhost", "") or host.endswith(".localhost"):
+        return False
+    if host.startswith(("127.", "10.", "192.168.", "169.254.", "0.")):
+        return False
+    if host == "::1" or host.startswith("[::1]"):
+        return False
+    # RFC1918 172.16.0.0/12 — second octet 16..31.
+    if host.startswith("172."):
+        parts = host.split(".")
+        if len(parts) >= 2 and parts[1].isdigit() and 16 <= int(parts[1]) <= 31:
+            return False
+    return True
 
 
 class RemoteHit:
@@ -109,6 +139,9 @@ def select_peers_for_query(
     - this L2 itself (``l2_id == self_l2_id``),
     - stub peers with no ``endpoint_url`` (consumer-only, can't be
       queried),
+    - peers whose ``endpoint_url`` fails the minimal SSRF guard
+      (:func:`_endpoint_is_safe` — non-https scheme or private/loopback
+      host),
     - peers whose ``domain_bloom`` matches none of ``query_domains``
       (Bloom prefilter — their corpus can't hold a relevant KU).
 
@@ -122,7 +155,16 @@ def select_peers_for_query(
     for peer in peers:
         if peer.get("l2_id") == self_id:
             continue
-        if not peer.get("endpoint_url"):
+        endpoint_url = peer.get("endpoint_url")
+        if not endpoint_url:
+            continue
+        if not _endpoint_is_safe(str(endpoint_url)):
+            log.warning(
+                "aigrp federation: skipping peer %s — endpoint_url %r failed the "
+                "SSRF guard (non-https scheme or private/loopback host)",
+                peer.get("l2_id"),
+                endpoint_url,
+            )
             continue
         bloom = peer.get("domain_bloom")
         if domains and bloom and not _legacy.bloom_matches_any(bloom, domains):
@@ -181,6 +223,20 @@ async def forward_query_peer(
         "authorization": f"Bearer {bearer_resolver(peer_l2_id)}",
         _legacy.FORWARDER_HEADER: requester_l2_id,
     }
+    # Sprint-4 forward signing (#44): the receiver's
+    # ``require_forwarder_identity`` verifies an Ed25519 signature over
+    # ``JCS(body) || forwarder_l2_id`` whenever it has the peer's pubkey
+    # on file — and a converged mesh always does (pubkeys land on the
+    # first /aigrp/hello and every poll). Without this header the
+    # receiver hard-403s and federation degrades to local-only forever.
+    # The signing input must be the exact dict POSTed as JSON: the
+    # receiver verifies against ``body.model_dump(mode="json")``, whose
+    # fields match ``body`` 1:1. ``sign_forward_request`` returns ``None``
+    # when no L2 keypair is on disk — omit the header then (mirrors
+    # consults.py; the receiver's legacy code path accepts unsigned).
+    sig = forward_sign.sign_forward_request(body, requester_l2_id)
+    if sig:
+        headers[forward_sign.SIGNATURE_HEADER] = sig
     timeout = httpx.Timeout(_READ_TIMEOUT_SEC, connect=_CONNECT_TIMEOUT_SEC)
 
     try:

--- a/server/backend/src/cq_server/aigrp/federation.py
+++ b/server/backend/src/cq_server/aigrp/federation.py
@@ -1,0 +1,290 @@
+"""Cross-L2 AIGRP federation — outbound forward-query client (agent#316).
+
+The receiving side of cross-L2 federation (``POST /aigrp/forward-query``)
+has existed since Phase 6 step 2. What was missing is the *outbound* leg:
+nothing actually issued a forward-query to a sibling L2. This module is
+that leg.
+
+``aigrp_lookup`` (app.py) calls :func:`fan_out_forward_query` after its
+local ``semantic_query``: it fans the signed forward-query at every
+sibling peer in the same Enterprise concurrently, merges the remote hits
+into the local result set, and re-ranks the union by similarity.
+
+Design constraints (from the issue):
+
+- **Non-blocking.** A peer that errors or times out must never fail the
+  whole lookup — it is logged and skipped. The lookup degrades to
+  local-only results.
+- **Pair-secret auth intact.** Every outbound call carries the per-pair
+  HKDF bearer (``_aigrp_outbound_bearer``) and the
+  ``X-8L-Forwarder-L2-Id`` identity header, exactly what the receiver's
+  ``require_peer_key`` / ``require_forwarder_identity`` expect.
+- **Intra-Enterprise only.** The caller passes only same-Enterprise
+  peers; the receiver's existing cross-Enterprise consent gate is
+  untouched.
+- **Bloom prefilter.** Peers whose ``domain_bloom`` matches none of the
+  query's domain tags are skipped before the HTTP call — their corpus
+  provably cannot hold a relevant KU. A query with no domain tags
+  queries all peers.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable
+from typing import Any
+
+import httpx
+
+from . import _legacy
+
+log = logging.getLogger("aigrp.federation")
+
+# Bounded timeouts. A connect failure is fast; a slow read is the more
+# common degradation, so it gets the larger budget. Either way the
+# fan-out caller wraps every call in ``return_exceptions=True`` so a
+# breach degrades to local-only, never an error.
+_CONNECT_TIMEOUT_SEC = 3.0
+_READ_TIMEOUT_SEC = 8.0
+
+
+class RemoteHit:
+    """One KU returned by a sibling L2's forward-query.
+
+    Mirrors the fields ``aigrp_lookup`` needs to merge a remote hit into
+    its local result set and apply the ``min_similarity`` /
+    ``min_confidence`` filters. ``detail`` / ``action`` are ``None`` when
+    the peer applied ``summary_only`` policy (cross-group); ``summary``
+    and ``confidence`` are always present.
+    """
+
+    __slots__ = (
+        "ku_id",
+        "summary",
+        "detail",
+        "action",
+        "domains",
+        "similarity",
+        "confidence",
+        "created_by",
+        "peer_l2_id",
+        "policy_applied",
+    )
+
+    def __init__(
+        self,
+        *,
+        ku_id: str,
+        summary: str,
+        detail: str | None,
+        action: str | None,
+        domains: list[str],
+        similarity: float,
+        confidence: float,
+        created_by: str,
+        peer_l2_id: str,
+        policy_applied: str,
+    ) -> None:
+        """Build a RemoteHit from a peer's parsed forward-query result."""
+        self.ku_id = ku_id
+        self.summary = summary
+        self.detail = detail
+        self.action = action
+        self.domains = domains
+        self.similarity = similarity
+        self.confidence = confidence
+        self.created_by = created_by
+        self.peer_l2_id = peer_l2_id
+        self.policy_applied = policy_applied
+
+
+def select_peers_for_query(
+    peers: Iterable[dict[str, Any]],
+    query_domains: Iterable[str],
+) -> list[dict[str, Any]]:
+    """Filter the peer list down to the ones worth a forward-query.
+
+    Drops:
+
+    - this L2 itself (``l2_id == self_l2_id``),
+    - stub peers with no ``endpoint_url`` (consumer-only, can't be
+      queried),
+    - peers whose ``domain_bloom`` matches none of ``query_domains``
+      (Bloom prefilter — their corpus can't hold a relevant KU).
+
+    The Bloom prefilter is skipped — every non-stub peer is kept — when
+    ``query_domains`` is empty: with no domain tags there is nothing to
+    test the Bloom against, so fanning at all peers is correct.
+    """
+    self_id = _legacy.self_l2_id()
+    domains = [d for d in (query_domains or []) if d]
+    selected: list[dict[str, Any]] = []
+    for peer in peers:
+        if peer.get("l2_id") == self_id:
+            continue
+        if not peer.get("endpoint_url"):
+            continue
+        bloom = peer.get("domain_bloom")
+        if domains and bloom and not _legacy.bloom_matches_any(bloom, domains):
+            log.debug(
+                "aigrp federation: Bloom prefilter skipped peer %s (no domain overlap)",
+                peer.get("l2_id"),
+            )
+            continue
+        selected.append(peer)
+    return selected
+
+
+async def forward_query_peer(
+    peer: dict[str, Any],
+    *,
+    query_vec: list[float],
+    query_text: str,
+    requester_l2_id: str,
+    requester_enterprise: str,
+    requester_group: str,
+    requester_persona: str,
+    max_results: int,
+    bearer_resolver: Callable[[str | None], str],
+    client: httpx.AsyncClient | None = None,
+) -> list[RemoteHit]:
+    """Issue a single ``POST /aigrp/forward-query`` to one sibling peer.
+
+    ``peer`` is one row from ``store.list_aigrp_peers``. ``bearer_resolver``
+    is ``app._aigrp_outbound_bearer`` — given the peer's ``l2_id`` it
+    returns the per-pair HKDF bearer (or the legacy env bearer as
+    fallback). Injected rather than imported to keep this module free of
+    an ``app`` import cycle.
+
+    Returns the peer's hits as :class:`RemoteHit` objects. On any error —
+    timeout, connection failure, non-200, malformed body — logs a warning
+    and returns ``[]`` so the caller's fan-out degrades to local-only for
+    this peer rather than failing.
+    """
+    peer_l2_id = peer.get("l2_id") or ""
+    endpoint = (peer.get("endpoint_url") or "").rstrip("/")
+    if not endpoint:
+        return []
+
+    url = f"{endpoint}/api/v1/aigrp/forward-query"
+    body = {
+        "query_vec": query_vec,
+        "query_text": query_text,
+        "requester_l2_id": requester_l2_id,
+        "requester_enterprise": requester_enterprise,
+        "requester_group": requester_group,
+        "requester_persona": requester_persona,
+        "max_results": max_results,
+    }
+    headers = {
+        "content-type": "application/json",
+        "authorization": f"Bearer {bearer_resolver(peer_l2_id)}",
+        _legacy.FORWARDER_HEADER: requester_l2_id,
+    }
+    timeout = httpx.Timeout(_READ_TIMEOUT_SEC, connect=_CONNECT_TIMEOUT_SEC)
+
+    try:
+        if client is not None:
+            resp = await client.post(url, json=body, headers=headers, timeout=timeout)
+        else:
+            async with httpx.AsyncClient(timeout=timeout) as owned:
+                resp = await owned.post(url, json=body, headers=headers)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:  # noqa: BLE001 — best-effort: degrade to local-only.
+        log.warning(
+            "aigrp federation: forward-query to peer %s (%s) failed: %s",
+            peer_l2_id,
+            url,
+            exc,
+        )
+        return []
+
+    policy = str(data.get("policy_applied") or "")
+    hits: list[RemoteHit] = []
+    for raw in data.get("results", []) or []:
+        try:
+            hits.append(
+                RemoteHit(
+                    ku_id=str(raw["ku_id"]),
+                    summary=str(raw.get("summary") or ""),
+                    detail=raw.get("detail"),
+                    action=raw.get("action"),
+                    domains=list(raw.get("domains") or []),
+                    similarity=float(raw.get("sim_score") or 0.0),
+                    # confidence is agent#316 — older peers omit it; a
+                    # missing value defaults to 0.0 and will be dropped
+                    # by any non-zero min_confidence filter, which is the
+                    # safe direction (don't surface unscored remote KUs).
+                    confidence=float(raw.get("confidence") or 0.0),
+                    created_by=str(raw.get("created_by") or ""),
+                    peer_l2_id=peer_l2_id,
+                    policy_applied=policy,
+                )
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            log.warning(
+                "aigrp federation: skipping malformed hit from peer %s: %s",
+                peer_l2_id,
+                exc,
+            )
+    return hits
+
+
+async def fan_out_forward_query(
+    peers: Iterable[dict[str, Any]],
+    *,
+    query_vec: list[float],
+    query_text: str,
+    query_domains: Iterable[str],
+    requester_l2_id: str,
+    requester_enterprise: str,
+    requester_group: str,
+    requester_persona: str,
+    max_results: int,
+    bearer_resolver: Callable[[str | None], str],
+) -> list[RemoteHit]:
+    """Fan a forward-query at every eligible sibling peer concurrently.
+
+    Applies the Bloom prefilter (:func:`select_peers_for_query`), then
+    issues all forward-queries in parallel with ``asyncio.gather`` /
+    ``return_exceptions=True``. A peer that raises is logged and
+    contributes no hits; the merged list from the survivors is returned
+    flat (caller re-ranks + filters).
+    """
+    import asyncio
+
+    selected = select_peers_for_query(peers, query_domains)
+    if not selected:
+        return []
+
+    timeout = httpx.Timeout(_READ_TIMEOUT_SEC, connect=_CONNECT_TIMEOUT_SEC)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        tasks = [
+            forward_query_peer(
+                peer,
+                query_vec=query_vec,
+                query_text=query_text,
+                requester_l2_id=requester_l2_id,
+                requester_enterprise=requester_enterprise,
+                requester_group=requester_group,
+                requester_persona=requester_persona,
+                max_results=max_results,
+                bearer_resolver=bearer_resolver,
+                client=client,
+            )
+            for peer in selected
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    merged: list[RemoteHit] = []
+    for peer, result in zip(selected, results, strict=True):
+        if isinstance(result, BaseException):
+            log.warning(
+                "aigrp federation: peer %s fan-out task raised: %s",
+                peer.get("l2_id"),
+                result,
+            )
+            continue
+        merged.extend(result)
+    return merged

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -614,29 +614,100 @@ async def aigrp_lookup(
         limit=request.max_results * 3,  # over-fetch so filters have headroom
     )
 
+    # --- Cross-L2 fan-out (agent#316) ----------------------------------
+    # After the local semantic query, also fan a signed forward-query at
+    # every sibling L2 in the same Enterprise, merge the remote hits with
+    # the local ones, and re-rank the union by similarity. The receiver's
+    # existing policy (_decide_policy_for_ku) returns summary_only for
+    # cross-group KUs and keeps cross-Enterprise consent-gated — this path
+    # only adds intra-Enterprise fan-out, it does not touch that boundary.
+    #
+    # Non-blocking: fan_out_forward_query wraps every peer call in
+    # return_exceptions=True; a slow/dead peer contributes zero hits and
+    # the lookup degrades to local-only. Local-only behaviour is byte-for-
+    # byte unchanged when there are no peers.
+    #
+    # Bloom prefilter: the lookup request carries only freeform context,
+    # no domain tags — so the query's domain set is taken from the local
+    # hits' domains (the corpus's own answer to "what is this query
+    # about"). Peers whose domain_bloom matches none of those are skipped
+    # before the HTTP call. With no local hits there are no domains, so
+    # the prefilter is a no-op and all peers are queried.
+    remote_hits: list[aigrp.RemoteHit] = []
+    try:
+        peers = await store.list_aigrp_peers(aigrp.enterprise())
+    except Exception:  # noqa: BLE001 — peer table read must never fail the lookup.
+        peers = []
+    if peers:
+        query_domains: set[str] = set()
+        for unit, _sim in raw_hits:
+            query_domains.update(unit.domains)
+        remote_hits = await aigrp.fan_out_forward_query(
+            peers,
+            query_vec=list(query_vec),
+            query_text=request.context,
+            query_domains=query_domains,
+            requester_l2_id=aigrp.self_l2_id(),
+            requester_enterprise=aigrp.enterprise(),
+            requester_group=aigrp.group(),
+            requester_persona=request.persona,
+            max_results=request.max_results,
+            bearer_resolver=_aigrp_outbound_bearer,
+        )
+
+    # Merge local + remote into one candidate list, then re-rank by
+    # similarity. Each candidate is (ku_id, summary, action, domains,
+    # similarity, confidence, created_by) — the AigrpLookupHit shape.
+    candidates: list[AigrpLookupHit] = [
+        AigrpLookupHit(
+            ku_id=unit.id,
+            summary=unit.insight.summary,
+            action=unit.insight.action,
+            domains=list(unit.domains),
+            similarity=sim,
+            confidence=unit.evidence.confidence,
+            created_by=unit.created_by,
+        )
+        for unit, sim in raw_hits
+    ]
+    candidates.extend(
+        AigrpLookupHit(
+            ku_id=rh.ku_id,
+            # summary_only remote hits omit action — fall back to empty.
+            summary=rh.summary,
+            action=rh.action or "",
+            domains=rh.domains,
+            similarity=rh.similarity,
+            confidence=rh.confidence,
+            created_by=rh.created_by,
+        )
+        for rh in remote_hits
+    )
+    # De-dup by ku_id (a KU could surface both locally and via a peer
+    # that mirrored it); keep the higher-similarity copy.
+    by_id: dict[str, AigrpLookupHit] = {}
+    for cand in candidates:
+        existing = by_id.get(cand.ku_id)
+        if existing is None or cand.similarity > existing.similarity:
+            by_id[cand.ku_id] = cand
+    merged = sorted(by_id.values(), key=lambda h: h.similarity, reverse=True)
+
+    # Apply min_similarity / min_confidence / exclude_self over the merged
+    # set, then cap at max_results — identical filter semantics to the
+    # former local-only loop, just over local+remote candidates.
     filtered: list[AigrpLookupHit] = []
     dropped = 0
-    for unit, sim in raw_hits:
-        if sim < request.min_similarity:
+    for cand in merged:
+        if cand.similarity < request.min_similarity:
             dropped += 1
             continue
-        if unit.evidence.confidence < request.min_confidence:
+        if cand.confidence < request.min_confidence:
             dropped += 1
             continue
-        if request.exclude_self and request.persona and unit.created_by == request.persona:
+        if request.exclude_self and request.persona and cand.created_by == request.persona:
             dropped += 1
             continue
-        filtered.append(
-            AigrpLookupHit(
-                ku_id=unit.id,
-                summary=unit.insight.summary,
-                action=unit.insight.action,
-                domains=list(unit.domains),
-                similarity=sim,
-                confidence=unit.evidence.confidence,
-                created_by=unit.created_by,
-            )
-        )
+        filtered.append(cand)
         if len(filtered) >= request.max_results:
             break
 
@@ -971,6 +1042,12 @@ class AigrpForwardQueryHit(BaseModel):
     and omitted (None) under ``summary_only``. ``redacted_fields`` lists
     the field names that were withheld so the requester knows what to
     ask for via a higher-trust channel if they need it.
+
+    ``confidence`` (agent#316) carries the KU's evidence confidence so a
+    forwarding L2 can apply ``aigrp/lookup``'s ``min_confidence`` filter
+    consistently across local and remote hits. It is *not* redacted
+    under ``summary_only`` — confidence is a scalar quality signal, not
+    KU body content, so the cross-group policy leaves it intact.
     """
 
     ku_id: str
@@ -979,6 +1056,7 @@ class AigrpForwardQueryHit(BaseModel):
     action: str | None = None
     domains: list[str]
     sim_score: float
+    confidence: float = 0.0
     redacted_fields: list[str] = Field(default_factory=list)
 
 
@@ -1174,6 +1252,7 @@ async def aigrp_forward_query(
                     action=None,
                     domains=list(unit.domains),
                     sim_score=hit["similarity"],
+                    confidence=unit.evidence.confidence,
                     redacted_fields=redacted,
                 )
             )
@@ -1186,6 +1265,7 @@ async def aigrp_forward_query(
                     action=unit.insight.action,
                     domains=list(unit.domains),
                     sim_score=hit["similarity"],
+                    confidence=unit.evidence.confidence,
                     redacted_fields=[],
                 )
             )

--- a/server/backend/tests/test_aigrp_federation.py
+++ b/server/backend/tests/test_aigrp_federation.py
@@ -244,6 +244,163 @@ class TestForwardQueryClient:
 
 
 # ---------------------------------------------------------------------------
+# 1b. Forward signing — the request carries a valid Ed25519 signature
+#     that the receiver's verification path accepts.
+# ---------------------------------------------------------------------------
+
+
+class TestForwardQuerySigning:
+    def test_request_carries_signature_the_receiver_accepts(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A converged-mesh receiver has the peer's pubkey on file and
+        hard-403s a forward-query with a missing/invalid signature
+        (see _legacy.require_forwarder_identity). This pins that
+        forward_query_peer emits a SIGNATURE_HEADER whose bytes verify
+        against the matching pubkey — i.e. exactly what the receiver
+        checks via verify_forward_signature."""
+        from cq_server import forward_sign
+
+        # Give this L2 a real Ed25519 keypair on disk.
+        monkeypatch.setenv("CQ_AIGRP_L2_PRIVKEY_PATH", str(tmp_path / "l2_key.bin"))
+        forward_sign.reload_l2_privkey()
+        pubkey_b64u = forward_sign.self_public_key_b64u()
+        assert pubkey_b64u is not None  # signing must be enabled
+
+        captured: dict = {}
+
+        def _handler(request: httpx.Request) -> httpx.Response:
+            import json as _json
+
+            captured["sig"] = request.headers.get(forward_sign.SIGNATURE_HEADER)
+            captured["forwarder"] = request.headers.get("x-8l-forwarder-l2-id")
+            captured["body"] = _json.loads(request.content)
+            return httpx.Response(
+                200,
+                json={"policy_applied": "full_body", "result_count": 0, "results": []},
+            )
+
+        async def _run() -> None:
+            transport = httpx.MockTransport(_handler)
+            async with httpx.AsyncClient(transport=transport) as mock_client:
+                await federation.forward_query_peer(
+                    _peer_row(l2_id="acme/group-b", domains=["iam"]),
+                    query_vec=[1.0, 0.0],
+                    query_text="iam key rotation",
+                    requester_l2_id="acme/group-a",
+                    requester_enterprise="acme",
+                    requester_group="group-a",
+                    requester_persona="agent-a1",
+                    max_results=5,
+                    bearer_resolver=lambda _l2: "derived-bearer",
+                    client=mock_client,
+                )
+
+        asyncio.run(_run())
+
+        # The header is present...
+        assert captured["sig"], "forward-query must carry an Ed25519 signature header"
+        # ...and verifies exactly the way the receiver verifies it:
+        # JCS(body_for_sig) || forwarder_l2_id, body_for_sig being the
+        # posted JSON body 1:1.
+        assert forward_sign.verify_forward_signature(
+            pubkey_b64u,
+            captured["body"],
+            captured["forwarder"],
+            captured["sig"],
+        ), "signature must verify against the matching pubkey"
+
+        # A signature over a different forwarder id must NOT verify —
+        # confirms the forwarder id is bound into the signed input.
+        assert not forward_sign.verify_forward_signature(
+            pubkey_b64u,
+            captured["body"],
+            "acme/group-evil",
+            captured["sig"],
+        )
+
+        forward_sign.reload_l2_privkey()  # reset cache for other tests
+
+    def test_no_signature_header_when_signing_disabled(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When no L2 keypair is available, sign_forward_request returns
+        None and the header is omitted (legacy receivers still accept)."""
+        from cq_server import forward_sign
+
+        monkeypatch.setenv("CQ_AIGRP_L2_PRIVKEY_PATH", str(tmp_path / "missing_key.bin"))
+        monkeypatch.setattr(forward_sign, "load_or_create_l2_privkey", lambda: None)
+        forward_sign.reload_l2_privkey()
+        assert forward_sign.get_l2_privkey() is None
+
+        captured: dict = {}
+
+        def _handler(request: httpx.Request) -> httpx.Response:
+            captured["sig"] = request.headers.get(forward_sign.SIGNATURE_HEADER)
+            return httpx.Response(
+                200,
+                json={"policy_applied": "full_body", "result_count": 0, "results": []},
+            )
+
+        async def _run() -> None:
+            transport = httpx.MockTransport(_handler)
+            async with httpx.AsyncClient(transport=transport) as mock_client:
+                await federation.forward_query_peer(
+                    _peer_row(l2_id="acme/group-b", domains=["iam"]),
+                    query_vec=[1.0],
+                    query_text="x",
+                    requester_l2_id="acme/group-a",
+                    requester_enterprise="acme",
+                    requester_group="group-a",
+                    requester_persona="agent-a1",
+                    max_results=5,
+                    bearer_resolver=lambda _l2: "b",
+                    client=mock_client,
+                )
+
+        asyncio.run(_run())
+        assert captured["sig"] is None
+
+        forward_sign.reload_l2_privkey()  # reset cache for other tests
+
+
+# ---------------------------------------------------------------------------
+# SSRF guard — peers with unsafe endpoint_url are skipped
+# ---------------------------------------------------------------------------
+
+
+class TestEndpointSsrfGuard:
+    def test_non_https_and_private_hosts_skipped(self) -> None:
+        unsafe_endpoints = [
+            "http://peer.example/",  # non-https scheme
+            "https://localhost/",
+            "https://127.0.0.1:8080/",
+            "https://10.1.2.3/",
+            "https://192.168.1.5/",
+            "https://169.254.169.254/",  # cloud metadata endpoint
+            "https://172.16.0.1/",
+            "https://172.31.255.1/",
+        ]
+        peers = [
+            _peer_row(l2_id=f"acme/group-{i}", domains=["iam"], endpoint=ep)
+            for i, ep in enumerate(unsafe_endpoints)
+        ]
+        selected = federation.select_peers_for_query(peers, query_domains=["iam"])
+        assert selected == [], f"unsafe endpoints were not all skipped: {selected}"
+
+    def test_public_https_peer_kept(self) -> None:
+        # 172.32.x is outside RFC1918 172.16/12 — must NOT be skipped.
+        for ep in ("https://peer.example/", "https://172.32.0.1/"):
+            peer = _peer_row(l2_id="acme/group-b", domains=["iam"], endpoint=ep)
+            selected = federation.select_peers_for_query([peer], query_domains=["iam"])
+            assert [p["l2_id"] for p in selected] == ["acme/group-b"], ep
+
+
+# ---------------------------------------------------------------------------
 # 2. Fan-out in aigrp_lookup — local + remote merge and re-rank
 # ---------------------------------------------------------------------------
 

--- a/server/backend/tests/test_aigrp_federation.py
+++ b/server/backend/tests/test_aigrp_federation.py
@@ -1,0 +1,471 @@
+"""Cross-L2 AIGRP federation — outbound forward-query fan-out (agent#316).
+
+Covers the four pieces built for issue #316:
+
+  1. Outbound forward-query client — issues a signed POST to a peer's
+     ``/aigrp/forward-query`` and parses the response into RemoteHits.
+  2. Fan-out in ``aigrp_lookup`` — local + remote hits merge and re-rank
+     by similarity; local-only behaviour unchanged when there are no
+     peers.
+  3. Bloom prefilter — peers whose ``domain_bloom`` claims none of the
+     query's domain tags are skipped before the HTTP call.
+  4. ``confidence`` on the forward-query response hit — the field
+     round-trips so a forwarder's ``min_confidence`` filter applies
+     consistently to remote hits.
+
+The peer-timeout invariant — a slow/dead peer degrades to local-only,
+never errors the lookup — is pinned in ``TestPeerTimeout``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import struct
+from collections.abc import Iterator
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+import cq_server.app as app_module
+from cq_server.aigrp import federation
+from cq_server.aigrp._legacy import compute_domain_bloom
+from cq_server.app import _get_store, app
+from cq_server.auth import hash_password
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "federation.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")  # pragma: allowlist secret
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")  # pragma: allowlist secret
+    monkeypatch.setenv("CQ_ENTERPRISE", "acme")
+    monkeypatch.setenv("CQ_GROUP", "group-a")
+    monkeypatch.setenv("CQ_AIGRP_PEER_KEY", "test-peer-key")  # pragma: allowlist secret
+    with TestClient(app) as c:
+        yield c
+
+
+def _seed_user(*, username: str, password: str) -> None:
+    store = _get_store()
+    store.sync.create_user(username, hash_password(password))
+    with store._engine.begin() as conn:
+        conn.exec_driver_sql(
+            "UPDATE users SET enterprise_id = ?, group_id = ? WHERE username = ?",
+            ("acme", "group-a", username),
+        )
+
+
+def _login_jwt(client: TestClient, username: str, password: str) -> str:
+    resp = client.post("/auth/login", json={"username": username, "password": password})
+    assert resp.status_code == 200, resp.text
+    return resp.json()["token"]
+
+
+def _mint_api_key(client: TestClient, jwt_token: str) -> str:
+    resp = client.post(
+        "/auth/api-keys",
+        headers={"Authorization": f"Bearer {jwt_token}"},
+        json={"name": "federation-test", "ttl": "30d"},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["token"]
+
+
+def _propose_one(client: TestClient, api_key: str, summary: str) -> str:
+    resp = client.post(
+        "/propose",
+        json={
+            "domains": ["test-fleet", "iam"],
+            "insight": {
+                "summary": summary,
+                "detail": "Local KU body for federation merge test.",
+                "action": "See tests/test_aigrp_federation.py.",
+            },
+        },
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _stub_embed(monkeypatch: pytest.MonkeyPatch) -> None:
+    vec = [1.0] + [0.0] * 7
+    packed = struct.pack(f"<{len(vec)}f", *vec)
+
+    def _fake(_text: str):
+        return packed, "stub-model"
+
+    monkeypatch.setattr(app_module, "embed_text", _fake)
+
+
+def _peer_row(*, l2_id: str, domains: list[str] | None, endpoint: str = "https://peer.example/") -> dict:
+    """Build an ``aigrp_peers``-shaped dict. ``domains=None`` => no Bloom."""
+    bloom = compute_domain_bloom(domains) if domains is not None else None
+    return {
+        "l2_id": l2_id,
+        "enterprise": "acme",
+        "group": l2_id.split("/", 1)[-1],
+        "endpoint_url": endpoint,
+        "embedding_centroid": None,
+        "domain_bloom": bloom,
+        "ku_count": 1,
+        "domain_count": len(domains or []),
+        "embedding_model": "stub-model",
+        "first_seen_at": "2026-05-19T00:00:00Z",
+        "last_seen_at": "2026-05-19T00:00:00Z",
+        "last_signature_at": None,
+        "public_key_ed25519": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 3. Bloom prefilter
+# ---------------------------------------------------------------------------
+
+
+class TestBloomPrefilter:
+    def test_peer_with_no_domain_overlap_skipped(self) -> None:
+        peer_match = _peer_row(l2_id="acme/group-b", domains=["iam", "aws"])
+        peer_miss = _peer_row(l2_id="acme/group-c", domains=["frontend", "css"])
+        selected = federation.select_peers_for_query(
+            [peer_match, peer_miss],
+            query_domains=["iam"],
+        )
+        assert [p["l2_id"] for p in selected] == ["acme/group-b"]
+
+    def test_empty_query_domains_keeps_all_peers(self) -> None:
+        peer_a = _peer_row(l2_id="acme/group-b", domains=["iam"])
+        peer_b = _peer_row(l2_id="acme/group-c", domains=["frontend"])
+        selected = federation.select_peers_for_query([peer_a, peer_b], query_domains=[])
+        assert {p["l2_id"] for p in selected} == {"acme/group-b", "acme/group-c"}
+
+    def test_stub_peer_without_endpoint_skipped(self) -> None:
+        stub = _peer_row(l2_id="acme/group-b", domains=["iam"], endpoint="")
+        selected = federation.select_peers_for_query([stub], query_domains=["iam"])
+        assert selected == []
+
+    def test_peer_without_bloom_is_kept(self) -> None:
+        """A peer that hasn't reported a signature yet (domain_bloom NULL)
+        cannot be prefiltered — keep it so a fresh peer is still reachable."""
+        peer = _peer_row(l2_id="acme/group-b", domains=None)
+        selected = federation.select_peers_for_query([peer], query_domains=["iam"])
+        assert [p["l2_id"] for p in selected] == ["acme/group-b"]
+
+
+# ---------------------------------------------------------------------------
+# 1. Outbound forward-query client
+# ---------------------------------------------------------------------------
+
+
+class TestForwardQueryClient:
+    def test_client_posts_signed_request_and_parses_hits(self) -> None:
+        captured: dict = {}
+
+        def _handler(request: httpx.Request) -> httpx.Response:
+            captured["url"] = str(request.url)
+            captured["auth"] = request.headers.get("authorization")
+            captured["forwarder"] = request.headers.get("x-8l-forwarder-l2-id")
+            return httpx.Response(
+                200,
+                json={
+                    "responder_l2_id": "acme/group-b",
+                    "responder_enterprise": "acme",
+                    "responder_group": "group-b",
+                    "policy_applied": "summary_only",
+                    "result_count": 1,
+                    "results": [
+                        {
+                            "ku_id": "ku-remote-1",
+                            "summary": "Remote KU from sibling L2",
+                            "detail": None,
+                            "action": None,
+                            "domains": ["iam"],
+                            "sim_score": 0.74,
+                            "confidence": 0.82,
+                            "redacted_fields": ["detail", "action"],
+                        }
+                    ],
+                },
+            )
+
+        async def _run() -> list[federation.RemoteHit]:
+            transport = httpx.MockTransport(_handler)
+            async with httpx.AsyncClient(transport=transport) as mock_client:
+                return await federation.forward_query_peer(
+                    _peer_row(l2_id="acme/group-b", domains=["iam"]),
+                    query_vec=[1.0, 0.0],
+                    query_text="iam key rotation",
+                    requester_l2_id="acme/group-a",
+                    requester_enterprise="acme",
+                    requester_group="group-a",
+                    requester_persona="agent-a1",
+                    max_results=5,
+                    bearer_resolver=lambda _l2: "derived-bearer",
+                    client=mock_client,
+                )
+
+        hits = asyncio.run(_run())
+        assert captured["url"] == "https://peer.example/api/v1/aigrp/forward-query"
+        assert captured["auth"] == "Bearer derived-bearer"
+        assert captured["forwarder"] == "acme/group-a"
+        assert len(hits) == 1
+        assert hits[0].ku_id == "ku-remote-1"
+        assert hits[0].confidence == pytest.approx(0.82)
+        assert hits[0].similarity == pytest.approx(0.74)
+        assert hits[0].policy_applied == "summary_only"
+
+    def test_client_returns_empty_on_peer_error(self) -> None:
+        def _handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, text="boom")
+
+        async def _run() -> list[federation.RemoteHit]:
+            transport = httpx.MockTransport(_handler)
+            async with httpx.AsyncClient(transport=transport) as mock_client:
+                return await federation.forward_query_peer(
+                    _peer_row(l2_id="acme/group-b", domains=["iam"]),
+                    query_vec=[1.0],
+                    query_text="x",
+                    requester_l2_id="acme/group-a",
+                    requester_enterprise="acme",
+                    requester_group="group-a",
+                    requester_persona="agent-a1",
+                    max_results=5,
+                    bearer_resolver=lambda _l2: "b",
+                    client=mock_client,
+                )
+
+        assert asyncio.run(_run()) == []
+
+
+# ---------------------------------------------------------------------------
+# 2. Fan-out in aigrp_lookup — local + remote merge and re-rank
+# ---------------------------------------------------------------------------
+
+
+class TestLookupFanOut:
+    def test_remote_hits_merge_and_rerank_with_local(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _seed_user(username="a1", password="pw")  # pragma: allowlist secret
+        api_key = _mint_api_key(client, _login_jwt(client, "a1", "pw"))
+        local_ku = _propose_one(client, api_key, "Local IAM key rotation knowledge unit for federation merge")
+        store = _get_store()
+        store.sync.set_review_status(local_ku, "approved", "a1")
+        _stub_embed(monkeypatch)
+
+        unit = asyncio.run(store.get(local_ku))
+        assert unit is not None
+
+        # Local hit at similarity 0.60.
+        async def _fake_semantic_query(_vec, *, limit: int = 10):  # noqa: ANN001
+            return [(unit, 0.60)]
+
+        monkeypatch.setattr(store, "semantic_query", _fake_semantic_query)
+
+        # One sibling peer in the table.
+        async def _fake_list_peers(_enterprise: str):
+            return [_peer_row(l2_id="acme/group-b", domains=["iam"])]
+
+        monkeypatch.setattr(store, "list_aigrp_peers", _fake_list_peers)
+
+        # Remote hit at similarity 0.88 — should out-rank the local one.
+        async def _fake_fan_out(_peers, **_kwargs):
+            return [
+                federation.RemoteHit(
+                    ku_id="ku-remote-hi",
+                    summary="Remote IAM KU, higher similarity",
+                    detail="body",
+                    action="do the thing",
+                    domains=["iam"],
+                    similarity=0.88,
+                    confidence=0.9,
+                    created_by="agent-b1",
+                    peer_l2_id="acme/group-b",
+                    policy_applied="full_body",
+                )
+            ]
+
+        monkeypatch.setattr(app_module.aigrp, "fan_out_forward_query", _fake_fan_out)
+
+        resp = client.post(
+            "/api/v1/aigrp/lookup",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={
+                "context": "how do I rotate an IAM key",
+                "persona": "a1",
+                "min_confidence": 0.0,
+                "min_similarity": 0.0,
+                "exclude_self": False,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        results = resp.json()["results"]
+        assert [r["ku_id"] for r in results] == ["ku-remote-hi", local_ku]
+        # Remote hit kept its confidence + action.
+        assert results[0]["confidence"] == pytest.approx(0.9)
+        assert results[0]["action"] == "do the thing"
+
+    def test_local_only_unchanged_when_no_peers(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """With an empty peer table the lookup must behave exactly as the
+        former local-only path: no fan-out call, local hits only."""
+        _seed_user(username="solo", password="pw")  # pragma: allowlist secret
+        api_key = _mint_api_key(client, _login_jwt(client, "solo", "pw"))
+        local_ku = _propose_one(client, api_key, "Solo-L2 IAM key rotation knowledge unit, local-only path")
+        store = _get_store()
+        store.sync.set_review_status(local_ku, "approved", "solo")
+        _stub_embed(monkeypatch)
+        unit = asyncio.run(store.get(local_ku))
+        assert unit is not None
+
+        async def _fake_semantic_query(_vec, *, limit: int = 10):  # noqa: ANN001
+            return [(unit, 0.71)]
+
+        monkeypatch.setattr(store, "semantic_query", _fake_semantic_query)
+
+        # fan_out must not even be reached — if it is, fail loudly.
+        async def _explode(_peers, **_kwargs):
+            raise AssertionError("fan_out_forward_query called with no peers")
+
+        monkeypatch.setattr(app_module.aigrp, "fan_out_forward_query", _explode)
+
+        resp = client.post(
+            "/api/v1/aigrp/lookup",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={
+                "context": "iam",
+                "persona": "solo",
+                "min_confidence": 0.0,
+                "min_similarity": 0.0,
+                "exclude_self": False,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        results = resp.json()["results"]
+        assert [r["ku_id"] for r in results] == [local_ku]
+
+
+# ---------------------------------------------------------------------------
+# Peer-timeout invariant — slow/dead peer degrades to local-only
+# ---------------------------------------------------------------------------
+
+
+class TestPeerTimeout:
+    def test_lookup_returns_local_results_when_peer_times_out(
+        self,
+        client: TestClient,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _seed_user(username="t1", password="pw")  # pragma: allowlist secret
+        api_key = _mint_api_key(client, _login_jwt(client, "t1", "pw"))
+        local_ku = _propose_one(client, api_key, "Local KU that survives a dead-peer forward-query timeout")
+        store = _get_store()
+        store.sync.set_review_status(local_ku, "approved", "t1")
+        _stub_embed(monkeypatch)
+        unit = asyncio.run(store.get(local_ku))
+        assert unit is not None
+
+        async def _fake_semantic_query(_vec, *, limit: int = 10):  # noqa: ANN001
+            return [(unit, 0.55)]
+
+        monkeypatch.setattr(store, "semantic_query", _fake_semantic_query)
+
+        async def _fake_list_peers(_enterprise: str):
+            return [_peer_row(l2_id="acme/group-b", domains=["iam"])]
+
+        monkeypatch.setattr(store, "list_aigrp_peers", _fake_list_peers)
+
+        # The real fan_out runs, but the peer's HTTP transport raises a
+        # timeout — fan_out_forward_query must swallow it and return [].
+        def _timeout_handler(_request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectTimeout("peer is dead")
+
+        real_forward = federation.forward_query_peer
+
+        async def _forward_with_mock_transport(peer, **kwargs):
+            transport = httpx.MockTransport(_timeout_handler)
+            async with httpx.AsyncClient(transport=transport) as mock_client:
+                kwargs["client"] = mock_client
+                return await real_forward(peer, **kwargs)
+
+        monkeypatch.setattr(federation, "forward_query_peer", _forward_with_mock_transport)
+
+        resp = client.post(
+            "/api/v1/aigrp/lookup",
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={
+                "context": "iam",
+                "persona": "t1",
+                "min_confidence": 0.0,
+                "min_similarity": 0.0,
+                "exclude_self": False,
+            },
+        )
+        # Lookup still 200s with the local hit — the dead peer is skipped.
+        assert resp.status_code == 200, resp.text
+        results = resp.json()["results"]
+        assert [r["ku_id"] for r in results] == [local_ku]
+
+
+# ---------------------------------------------------------------------------
+# 4. confidence round-trip through /aigrp/forward-query
+# ---------------------------------------------------------------------------
+
+
+class TestConfidenceRoundTrip:
+    def test_forward_query_response_carries_confidence(
+        self,
+        client: TestClient,
+    ) -> None:
+        """A KU served by /aigrp/forward-query reports its evidence
+        confidence so a forwarding L2 can apply min_confidence to remote
+        hits the same way it does to local ones."""
+        _seed_user(username="owner", password="pw")  # pragma: allowlist secret
+        api_key = _mint_api_key(client, _login_jwt(client, "owner", "pw"))
+        ku_id = _propose_one(client, api_key, "Forward-query confidence field round-trip knowledge unit")
+        store = _get_store()
+        store.sync.set_review_status(ku_id, "approved", "owner")
+        # Give the KU a known, non-default confidence.
+        with store._engine.begin() as conn:
+            conn.exec_driver_sql(
+                "UPDATE knowledge_units SET embedding = ? WHERE id = ?",
+                (struct.pack("<8f", 1.0, 0, 0, 0, 0, 0, 0, 0), ku_id),
+            )
+        unit = asyncio.run(store.get(ku_id))
+        assert unit is not None
+        expected_conf = unit.evidence.confidence
+
+        resp = client.post(
+            "/api/v1/aigrp/forward-query",
+            headers={
+                "authorization": "Bearer test-peer-key",
+                "x-8l-forwarder-l2-id": "acme/group-a",
+            },
+            json={
+                "query_vec": [1.0, 0, 0, 0, 0, 0, 0, 0],
+                "query_text": "confidence",
+                "requester_l2_id": "acme/group-a",
+                "requester_enterprise": "acme",
+                "requester_group": "group-a",
+                "requester_persona": "agent-a1",
+                "max_results": 5,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["result_count"] == 1
+        hit = body["results"][0]
+        assert hit["ku_id"] == ku_id
+        assert "confidence" in hit
+        assert hit["confidence"] == pytest.approx(expected_conf)


### PR DESCRIPTION
## Problem

`aigrp/lookup` was local-only. An agent on L2-a could not see knowledge units held by a sibling L2-b in the **same Enterprise** — `aigrp/lookup` ran `store.semantic_query` against its own corpus and never fanned out. MVP Scenario 2 surfaced this: knowledge does not compound across L2s within one company, even though Founder Onboarding happily creates multiple L2s per Enterprise.

The receiving side (`POST /aigrp/forward-query`) has existed since Phase 6 — pair-secret auth, forwarder-identity pinning, per-KU sharing policy. What was missing was the **outbound leg**: nothing issued the forward-query.

## Design

`aigrp/lookup` now fans out to same-Enterprise peers via the existing signed `forward-query` endpoint:

- After the local `semantic_query`, it calls `store.list_aigrp_peers(enterprise())` and issues a `forward-query` to every sibling concurrently.
- Remote hits merge with local hits; the union is de-duped by `ku_id` (keeping the higher-similarity copy) and **re-ranked by similarity**, then the existing `min_similarity` / `min_confidence` / `exclude_self` / `max_results` filters apply over the merged set.
- **Cross-group → `summary_only`** is handled entirely by the receiver's existing `_decide_policy_for_ku` — a cross-group KU comes back summary-only with `detail`/`action` redacted.
- **Cross-Enterprise stays untouched** — this PR adds only *intra-Enterprise* fan-out. The receiver's cross-Enterprise consent gate is unchanged; `require_peer_key` / `require_forwarder_identity` are unchanged.
- **Non-blocking**: a slow/dead peer degrades to local-only results, never errors the lookup (`asyncio.gather(return_exceptions=True)`, bounded httpx timeout, per-call error swallow).

## The 4 pieces

1. **Outbound client** — new `aigrp/federation.py`. `forward_query_peer()` POSTs to `{peer}/api/v1/aigrp/forward-query` with the per-pair HKDF bearer (`_aigrp_outbound_bearer`) + `X-8L-Forwarder-L2-Id` header; 3s connect / 8s read timeout; any error returns `[]`.
2. **Fan-out** in `aigrp_lookup` (`app.py`) — concurrent fan, merge, re-rank, filter. Local-only behaviour is byte-for-byte unchanged when there are no peers.
3. **Bloom prefilter** — `select_peers_for_query()` skips peers whose `domain_bloom` matches none of the query's domain tags.
4. **`confidence`** on `AigrpForwardQueryHit` — added and populated from the KU's evidence confidence so a forwarder's `min_confidence` filter applies consistently to remote hits.

## Design choices made

- **Where the query's domain tags come from (Bloom prefilter).** The `aigrp/lookup` request carries only freeform `context` — no domain tags. The query domain set is taken from the **local hits' domains** (the corpus's own answer to "what is this query about"). When there are no local hits there are no domains, so the prefilter is a no-op and all peers are queried — the safe direction.
- **`confidence` is not redacted under `summary_only`.** `summary_only` redacts KU *body* (`detail`, `action`). `confidence` is a scalar quality signal, not body content, so it is returned intact under both policies — otherwise a cross-group remote hit would always read `confidence=0.0` and be dropped by any non-zero `min_confidence`. Older peers that omit the field default to `0.0` (dropped by a non-zero filter — the safe direction: don't surface unscored remote KUs).

## Tests

`tests/test_aigrp_federation.py` (10 tests) — fan-out merge + re-rank, peer-timeout degrades to local-only, Bloom-prefilter skip (4 cases), outbound client signed-request + error handling, `confidence` round-trip, local-only-unchanged. All green; `test_forward_query.py` (13) still green with the new field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #316