### PR TITLE
fix(substrate): swap L2 from EFS-on-Fargate to EBS-on-EC2 + DLM snapshots (agent#323)

### DIFF
--- a/deploy/aws/marketplace-l2.yaml
+++ b/deploy/aws/marketplace-l2.yaml
@@ -1,23 +1,44 @@
+# =============================================================================
+# 8th-Layer.ai Marketplace L2 stack — stands up a complete, healthy cq-server
+# instance (the customer's Layer-2 semantic backbone) in the customer's AWS
+# account. Instantiated by the 8th-Layer.ai Enterprise Provisioning Service
+# during phase 4 of the 6-phase async provisioning state machine
+# (FO-2-backend; see docs/decisions/31-fo-2-provisioning-contract.md on
+# OneZero1ai/8th-layer-core).
+#
+# Footprint:
+#   - Dedicated VPC (10.0.0.0/16) + 2 public subnets across 2 AZs + IGW.
+#   - ALB (HTTP/80, internet-facing) → ECS-on-EC2 task (port 3000) →
+#     persistent EBS gp3 volume bind-mounted at /data (SQLite at /data/cq.db).
+#   - Single-instance ASG of t4g.small (ARM64) in PublicSubnetA's AZ. EBS
+#     volume is a first-class CFN resource (NOT a LaunchTemplate block
+#     device) so it survives ASG instance refresh / replacement; UserData
+#     attaches + mounts it on every host boot.
+#   - AWS DLM lifecycle policy snapshots the EBS volume hourly, retains
+#     168 snapshots (7 days). RPO=1h, RTO~10min via snapshot restore.
+#   - HTTPS termination is handled by Cloudflare in front of the ALB; the
+#     stack does not request an ACM cert for the ALB itself.
+#   - Auto-generated secrets (JWT, API key pepper, AIGRP peer key) via
+#     Secrets Manager so the L2 boots fully self-contained.
+#
+# Substrate rationale (agent#323):
+#   SQLite-on-EFS exhibited recurring index corruption under concurrent
+#   AIGRP poll + write traffic — NFSv4.1 POSIX locking semantics don't
+#   match what SQLite expects. Substrate moved to ECS-on-EC2 + persistent
+#   EBS gp3 (local block device, real POSIX locks). Single-AZ availability
+#   is the accepted trade-off for MVP; multi-AZ + Postgres + Litestream
+#   are tracked as separate follow-ups (#309 / #311 / Litestream upgrade).
+#
+# Cost: ~$55-65/mo continuous (ALB ~$20, t4g.small ~$12, EBS gp3 20GiB
+# ~$2, DLM snapshots ~$1/mo at MVP write volume, traffic).
+# =============================================================================
 AWSTemplateFormatVersion: "2010-09-09"
 Description: |
-  8th-Layer.ai Marketplace L2 stack — stands up a complete, healthy cq-server
-  instance (the customer's Layer-2 semantic backbone) in the customer's AWS
-  account. Instantiated by the 8th-Layer.ai Enterprise Provisioning Service
-  during phase 4 of the 6-phase async provisioning state machine
-  (FO-2-backend; see docs/decisions/31-fo-2-provisioning-contract.md on
-  OneZero1ai/8th-layer-core).
-
-  Footprint:
-    - Dedicated VPC (10.0.0.0/16) + 2 public subnets across 2 AZs + IGW.
-    - ALB (HTTP/80, internet-facing) → ECS Fargate task (port 3000) → EFS
-      (SQLite at /data/cq.db).
-    - HTTPS termination is handled by Cloudflare in front of the ALB; the
-      stack does not request an ACM cert for the ALB itself.
-    - Auto-generated secrets (JWT, API key pepper, AIGRP peer key) via
-      Secrets Manager so the L2 boots fully self-contained.
-
-  Cost: ~$30-40/mo continuous (ALB ~$20, Fargate 0.5 vCPU/1 GB ~$15,
-  EFS minimal ~$1, traffic).
+  8th-Layer.ai Marketplace L2 — ALB → ECS-on-EC2 (t4g.small ASG of 1) →
+  persistent EBS gp3 at /data (SQLite). DLM hourly snapshots, 7-day
+  retention. Single-AZ. Substrate moved off SQLite-on-EFS to fix the
+  index-corruption failure mode documented in agent#323; see full
+  rationale in the file-header comments.
 
 Parameters:
   EnterpriseSlug:
@@ -137,6 +158,34 @@ Parameters:
       ritual applies. Hard-finding KUs always route through the
       pending_review tier regardless of this flag.
 
+  CqDbVolumeSizeGiB:
+    Type: Number
+    Default: 20
+    MinValue: 8
+    MaxValue: 1024
+    Description: |
+      Size in GiB of the persistent EBS gp3 volume that backs the L2's
+      SQLite database (mounted at /mnt/cq-data on the host, bind-mounted
+      to /data in the container). 20 GiB is comfortable for MVP design-
+      partner scale — KU + activity-log growth at observed write volume
+      sits well under that. Bump only when DB growth approaches 70% of
+      the volume; gp3 supports online resize via modify-volume.
+
+  RestoreFromSnapshotId:
+    Type: String
+    Default: ""
+    AllowedPattern: "^(snap-[0-9a-f]{8,17}|)$"
+    ConstraintDescription: Must be empty or a valid snap-XXXXXXXX id.
+    Description: |
+      When non-empty, the L2's EBS data volume is initialised from this
+      DLM snapshot rather than as a blank gp3 disk. The documented
+      recovery path: pick the most recent `cq-l2-data: true` snapshot
+      from the DLM-tagged set, then run update-stack with this parameter
+      set to the snapshot id. The ASG instance refresh provisions a new
+      EC2 host with the restored EBS volume attached; cq-server boots
+      against the recovered SQLite database. See
+      docs/ops/l2-substrate-recovery.md.
+
 Conditions:
   HasAdminEmail: !Not [!Equals [!Ref AdminEmail, ""]]
   AutoApproveOn: !Equals [!Ref AutoApprovePropose, "true"]
@@ -144,6 +193,9 @@ Conditions:
   # the L2 slug IS the Enterprise, so CQ_ENTERPRISE falls back to
   # EnterpriseSlug. FO-2 deploys pass the real parent Enterprise id.
   HasCqEnterpriseId: !Not [!Equals [!Ref CqEnterpriseId, ""]]
+  # agent#323 — toggles BlockDeviceMappings between a blank gp3
+  # (fresh L2) and snapshot-restored gp3 (recovery path).
+  RestoreFromSnapshot: !Not [!Equals [!Ref RestoreFromSnapshotId, ""]]
 
 Resources:
   # =====================================================================
@@ -258,77 +310,29 @@ Resources:
         - { IpProtocol: tcp, FromPort: 80,  ToPort: 80,  CidrIp: 0.0.0.0/0, Description: "HTTP (ACM HTTP-01 + Cloudflare-origin)" }
         - { IpProtocol: tcp, FromPort: 443, ToPort: 443, CidrIp: 0.0.0.0/0, Description: "HTTPS (reserved for v2; not bound to a listener in v1)" }
 
-  TaskSecurityGroup:
+  # ECS-on-EC2: with `awsvpc` task networking the task itself gets its
+  # own ENI + SG (TaskSecurityGroup). Without awsvpc, the task shares
+  # the host's network namespace and the HostSecurityGroup gates port
+  # 3000. We use `bridge` mode below (simpler with a single task per
+  # host), so the host SG is what the ALB target group reaches.
+  HostSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: !Sub "${EnterpriseSlug} L2 ECS task SG"
+      GroupDescription: !Sub "${EnterpriseSlug} L2 ECS host SG"
       VpcId: !Ref Vpc
 
-  TaskIngressFromAlb:
+  HostIngressFromAlb:
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
-      GroupId: !Ref TaskSecurityGroup
+      GroupId: !Ref HostSecurityGroup
       IpProtocol: tcp
-      FromPort: 3000
-      ToPort: 3000
+      # Bridge-mode ephemeral host ports — ECS picks one per task. Allow
+      # the full ephemeral range from the ALB only (the dynamic port the
+      # task lands on is registered with the target group automatically).
+      FromPort: 32768
+      ToPort: 65535
       SourceSecurityGroupId: !Ref AlbSecurityGroup
-      Description: "cq-server port 3000 from ALB only"
-
-  EfsSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: !Sub "${EnterpriseSlug} L2 EFS SG"
-      VpcId: !Ref Vpc
-
-  EfsIngressFromTask:
-    Type: AWS::EC2::SecurityGroupIngress
-    Properties:
-      GroupId: !Ref EfsSecurityGroup
-      IpProtocol: tcp
-      FromPort: 2049
-      ToPort: 2049
-      SourceSecurityGroupId: !Ref TaskSecurityGroup
-      Description: "NFS from cq-server tasks"
-
-  # =====================================================================
-  # EFS — persistent SQLite at /data.
-  # =====================================================================
-  EfsFileSystem:
-    Type: AWS::EFS::FileSystem
-    Properties:
-      Encrypted: true
-      PerformanceMode: generalPurpose
-      ThroughputMode: bursting
-      LifecyclePolicies:
-        - TransitionToIA: AFTER_30_DAYS
-      FileSystemTags:
-        - { Key: Name, Value: !Sub "${EnterpriseSlug}-l2-efs" }
-
-  EfsMountTargetA:
-    Type: AWS::EFS::MountTarget
-    Properties:
-      FileSystemId: !Ref EfsFileSystem
-      SubnetId: !Ref PublicSubnetA
-      SecurityGroups: [!Ref EfsSecurityGroup]
-
-  EfsMountTargetB:
-    Type: AWS::EFS::MountTarget
-    Properties:
-      FileSystemId: !Ref EfsFileSystem
-      SubnetId: !Ref PublicSubnetB
-      SecurityGroups: [!Ref EfsSecurityGroup]
-
-  EfsAccessPoint:
-    Type: AWS::EFS::AccessPoint
-    Properties:
-      FileSystemId: !Ref EfsFileSystem
-      PosixUser: { Uid: "1000", Gid: "1000" }
-      RootDirectory:
-        Path: /cq-data
-        CreationInfo:
-          OwnerUid: "1000"
-          OwnerGid: "1000"
-          Permissions: "0750"
+      Description: "Bridge-mode ephemeral ports from ALB only"
 
   # =====================================================================
   # CloudWatch logs
@@ -340,8 +344,13 @@ Resources:
       RetentionInDays: 30
 
   # =====================================================================
-  # IAM — task execution role (pull image, write logs, fetch secrets)
-  #       + task role (mount EFS, send SES, get secrets at runtime)
+  # IAM
+  #   - TaskExecutionRole: ECS agent pulls image, writes logs, fetches
+  #                        secrets at task start (assumed by ecs-tasks).
+  #   - TaskRole:          runtime (SES, secrets, KMS) — no EFS perms
+  #                        any more; EBS is host-attached.
+  #   - InstanceRole:      EC2 host runs the ECS agent (assumed by ec2).
+  #   - DlmRole:           AWS DLM assumes this to create snapshots.
   # =====================================================================
   TaskExecutionRole:
     Type: AWS::IAM::Role
@@ -376,16 +385,6 @@ Resources:
             Principal: { Service: ecs-tasks.amazonaws.com }
             Action: sts:AssumeRole
       Policies:
-        - PolicyName: EfsClientAccess
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - elasticfilesystem:ClientMount
-                  - elasticfilesystem:ClientWrite
-                  - elasticfilesystem:ClientRootAccess
-                Resource: !GetAtt EfsFileSystem.Arn
         - PolicyName: SesSendInvites
           PolicyDocument:
             Version: "2012-10-17"
@@ -420,6 +419,195 @@ Resources:
                   StringEquals:
                     "kms:ViaService": !Sub "secretsmanager.${AWS::Region}.amazonaws.com"
 
+  InstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal: { Service: ec2.amazonaws.com }
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        # ECS-managed agent: register w/ cluster, pull task defs, push
+        # container telemetry. Standard managed policy for EC2 ECS hosts.
+        - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role
+        # SSM session-manager access (no SSH keys) so ops can shell into
+        # the host for SQLite inspection / .recover during a recovery.
+        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles: [!Ref InstanceRole]
+
+  DlmRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal: { Service: dlm.amazonaws.com }
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSDataLifecycleManagerServiceRole
+
+  # =====================================================================
+  # PERSISTENT EBS DATA VOLUME — agent#323
+  #
+  # Declared as a first-class CFN resource (NOT inline in the LaunchTemplate
+  # BlockDeviceMappings) so it survives ASG instance refresh / replacement:
+  # the volume's lifecycle is bound to the stack, not to any one EC2 host.
+  # UserData on each instance attaches this volume at boot.
+  #
+  # Pinned to PublicSubnetA's AZ — EBS volumes are zonal, so the ASG must
+  # also be constrained to the same AZ (see AsgCqServer below). Multi-AZ
+  # availability is a follow-up (move to Postgres or Litestream).
+  # =====================================================================
+  CqDataVolume:
+    Type: AWS::EC2::Volume
+    DeletionPolicy: Snapshot
+    UpdateReplacePolicy: Snapshot
+    Properties:
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      Size: !Ref CqDbVolumeSizeGiB
+      VolumeType: gp3
+      Encrypted: true
+      SnapshotId: !If
+        - RestoreFromSnapshot
+        - !Ref RestoreFromSnapshotId
+        - !Ref "AWS::NoValue"
+      Tags:
+        - { Key: Name, Value: !Sub "${EnterpriseSlug}-l2-cq-data" }
+        # DLM lifecycle policy targets this tag to pick the snapshot set.
+        - { Key: cq-l2-data, Value: "true" }
+        - { Key: EnterpriseSlug, Value: !Ref EnterpriseSlug }
+
+  # =====================================================================
+  # EC2 capacity for ECS — LaunchTemplate + single-instance ASG
+  # =====================================================================
+  EcsHostLaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateName: !Sub "${EnterpriseSlug}-l2-ecs-host"
+      LaunchTemplateData:
+        # ECS-optimized AL2023 ARM64 AMI via SSM parameter — auto-resolves
+        # to the current AWS-published AMI at stack-create / instance launch.
+        # Pinning a specific AMI id would force template churn every AMI
+        # release; the SSM alias is the AWS-recommended pattern.
+        ImageId: "{{resolve:ssm:/aws/service/ecs/optimized-ami/amazon-linux-2023/arm64/recommended/image_id}}"
+        InstanceType: t4g.small
+        IamInstanceProfile:
+          Arn: !GetAtt InstanceProfile.Arn
+        SecurityGroupIds: [!Ref HostSecurityGroup]
+        MetadataOptions:
+          HttpTokens: required
+          HttpPutResponseHopLimit: 2
+        TagSpecifications:
+          - ResourceType: instance
+            Tags:
+              - { Key: Name, Value: !Sub "${EnterpriseSlug}-l2-ecs-host" }
+        UserData:
+          Fn::Base64: !Sub |
+            #!/bin/bash
+            set -euxo pipefail
+            # --- Register with the ECS cluster --------------------------
+            echo "ECS_CLUSTER=${EcsCluster}" >> /etc/ecs/ecs.config
+            # Allow longer task start for the cq-server image pull from
+            # ECR Public (cold pull on a fresh host can take 30-60s).
+            echo "ECS_CONTAINER_START_TIMEOUT=3m" >> /etc/ecs/ecs.config
+            systemctl enable --now ecs || true
+
+            # --- Attach the persistent EBS data volume ------------------
+            # The volume is a CFN-managed resource (see CqDataVolume); we
+            # attach it here on every instance start so ASG instance
+            # refresh / replacement reconnects the SAME volume to the new
+            # host. The device name /dev/sdf maps to /dev/nvme1n1 on Nitro.
+            TOKEN=$(curl -sX PUT 'http://169.254.169.254/latest/api/token' -H 'X-aws-ec2-metadata-token-ttl-seconds: 60')
+            INSTANCE_ID=$(curl -sH "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)
+            REGION=$(curl -sH "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/placement/region)
+
+            # Wait until the volume is `available` (a previous instance may
+            # still be detaching during a refresh), then attach.
+            for i in $(seq 1 30); do
+              STATE=$(aws ec2 describe-volumes --region "$REGION" \
+                --volume-ids ${CqDataVolume} \
+                --query 'Volumes[0].State' --output text || echo "unknown")
+              if [ "$STATE" = "available" ]; then break; fi
+              if [ "$STATE" = "in-use" ]; then
+                # Detach the stragglerasync; ASG instance-refresh terminates
+                # the old host but EBS detach can lag by 10-20s.
+                aws ec2 detach-volume --region "$REGION" \
+                  --volume-id ${CqDataVolume} --force || true
+              fi
+              sleep 5
+            done
+            aws ec2 attach-volume --region "$REGION" \
+              --volume-id ${CqDataVolume} \
+              --instance-id "$INSTANCE_ID" \
+              --device /dev/sdf
+
+            # Wait for the kernel to surface the volume.
+            for i in $(seq 1 30); do
+              if [ -b /dev/nvme1n1 ]; then break; fi
+              sleep 2
+            done
+
+            # Format only if blank (first-ever boot of a fresh volume).
+            # `file -s` reports `data` on an unformatted device and the
+            # filesystem name otherwise. Snapshot-restored volumes are
+            # already formatted, so this is a no-op.
+            if file -s /dev/nvme1n1 | grep -q ': data$'; then
+              mkfs.ext4 /dev/nvme1n1
+            fi
+
+            mkdir -p /mnt/cq-data
+            UUID=$(blkid -s UUID -o value /dev/nvme1n1)
+            grep -q "$UUID" /etc/fstab || \
+              echo "UUID=$UUID /mnt/cq-data ext4 defaults,nofail 0 2" >> /etc/fstab
+            mount -a
+            # Container UID 1000 (cq-server `app` user) must own the data.
+            chown -R 1000:1000 /mnt/cq-data
+            chmod 0750 /mnt/cq-data
+
+            # Kick ECS so it picks up the now-ready /mnt/cq-data bind mount.
+            systemctl restart ecs
+
+  AsgCqServer:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    DependsOn: VpcGatewayAttachment
+    Properties:
+      AutoScalingGroupName: !Sub "${EnterpriseSlug}-l2-asg"
+      MinSize: "1"
+      MaxSize: "1"
+      DesiredCapacity: "1"
+      LaunchTemplate:
+        LaunchTemplateId: !Ref EcsHostLaunchTemplate
+        Version: !GetAtt EcsHostLaunchTemplate.LatestVersionNumber
+      # AZ-pinned to the same subnet as the EBS volume (zonal resource).
+      VPCZoneIdentifier: [!Ref PublicSubnetA]
+      HealthCheckType: EC2
+      HealthCheckGracePeriod: 180
+      NewInstancesProtectedFromScaleIn: false
+      Tags:
+        - { Key: Name, Value: !Sub "${EnterpriseSlug}-l2-asg", PropagateAtLaunch: true }
+        # Required for ECS managed-termination / capacity-provider drain.
+        - { Key: AmazonECSManaged, Value: "true", PropagateAtLaunch: true }
+
+  EcsCapacityProvider:
+    Type: AWS::ECS::CapacityProvider
+    Properties:
+      Name: !Sub "${EnterpriseSlug}-l2-cp"
+      AutoScalingGroupProvider:
+        AutoScalingGroupArn: !Ref AsgCqServer
+        ManagedScaling:
+          Status: ENABLED
+          TargetCapacity: 100
+          MinimumScalingStepSize: 1
+          MaximumScalingStepSize: 1
+        ManagedTerminationProtection: DISABLED
+
   # =====================================================================
   # ECS cluster + task + service
   # =====================================================================
@@ -427,35 +615,48 @@ Resources:
     Type: AWS::ECS::Cluster
     Properties:
       ClusterName: !Sub "${EnterpriseSlug}-l2-cluster"
-      CapacityProviders: [FARGATE]
+
+  EcsClusterCapacityProviderAssoc:
+    Type: AWS::ECS::ClusterCapacityProviderAssociations
+    Properties:
+      Cluster: !Ref EcsCluster
+      CapacityProviders: [!Ref EcsCapacityProvider]
+      DefaultCapacityProviderStrategy:
+        - CapacityProvider: !Ref EcsCapacityProvider
+          Weight: 1
+          Base: 1
 
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
     Properties:
       Family: !Sub "${EnterpriseSlug}-l2-cq-server"
-      NetworkMode: awsvpc
-      RequiresCompatibilities: [FARGATE]
+      # bridge networking — task ports map to dynamic ephemeral ports on
+      # the host; the ALB target group resolves the mapping per task.
+      # awsvpc isn't needed (and isn't preferred) for a single-task host.
+      NetworkMode: bridge
+      RequiresCompatibilities: [EC2]
       RuntimePlatform:
-        CpuArchitecture: X86_64
+        CpuArchitecture: ARM64
         OperatingSystemFamily: LINUX
       Cpu: "512"
       Memory: "1024"
       ExecutionRoleArn: !GetAtt TaskExecutionRole.Arn
       TaskRoleArn: !GetAtt TaskRole.Arn
       Volumes:
+        # Host bind mount — the EBS volume is mounted at /mnt/cq-data on
+        # the EC2 host by UserData, then bind-mounted into the container
+        # at /data (matching ENV CQ_DB_PATH=/data/cq.db in the Dockerfile).
         - Name: cq-data
-          EFSVolumeConfiguration:
-            FilesystemId: !Ref EfsFileSystem
-            TransitEncryption: ENABLED
-            AuthorizationConfig:
-              AccessPointId: !Ref EfsAccessPoint
-              IAM: ENABLED
+          Host:
+            SourcePath: /mnt/cq-data
       ContainerDefinitions:
         - Name: cq-server
           Image: !Ref CqServerImage
           Essential: true
           PortMappings:
-            - { ContainerPort: 3000, Protocol: tcp }
+            # HostPort: 0 → ECS picks a dynamic port in the ephemeral
+            # range (32768-65535), and registers it with the target group.
+            - { ContainerPort: 3000, HostPort: 0, Protocol: tcp }
           MountPoints:
             - { SourceVolume: cq-data, ContainerPath: /data }
           Environment:
@@ -541,12 +742,22 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
       Name: !Sub "${EnterpriseSlug}-l2-tg"
+      # Port is required but ignored in bridge-mode / dynamic-port
+      # registration — ECS overrides it per task with the actual host
+      # ephemeral port. Set to 3000 for documentation continuity.
       Port: 3000
       Protocol: HTTP
       ProtocolVersion: HTTP1
       VpcId: !Ref Vpc
-      TargetType: ip
+      # `instance` targets — bridge-mode tasks land on the EC2 host, not
+      # a task-ENI, so ALB routes via instance-id + ephemeral host port.
+      TargetType: instance
       HealthCheckPath: /health
+      # `traffic-port` is required by ECS dynamic-port registration: the
+      # health probe targets whatever ephemeral host port the task landed
+      # on, not a fixed port. cfn-lint E3049 enforces this for HostPort: 0.
+      HealthCheckPort: traffic-port
+      HealthCheckProtocol: HTTP
       HealthCheckIntervalSeconds: 15
       HealthCheckTimeoutSeconds: 5
       HealthyThresholdCount: 2
@@ -565,33 +776,63 @@ Resources:
 
   EcsService:
     Type: AWS::ECS::Service
-    DependsOn: [HttpListener, EfsMountTargetA, EfsMountTargetB]
+    # Capacity-provider association must exist before the service can
+    # request capacity through it; HttpListener gates the LB registration.
+    DependsOn: [HttpListener, EcsClusterCapacityProviderAssoc]
     Properties:
       ServiceName: cq-server
       Cluster: !Ref EcsCluster
       TaskDefinition: !Ref TaskDefinition
       DesiredCount: 1
-      LaunchType: FARGATE
+      # ECS-on-EC2 via capacity provider — no LaunchType / NetworkConfig.
+      CapacityProviderStrategy:
+        - CapacityProvider: !Ref EcsCapacityProvider
+          Weight: 1
+          Base: 1
       EnableExecuteCommand: true
-      NetworkConfiguration:
-        AwsvpcConfiguration:
-          AssignPublicIp: ENABLED
-          Subnets: [!Ref PublicSubnetA, !Ref PublicSubnetB]
-          SecurityGroups: [!Ref TaskSecurityGroup]
       LoadBalancers:
         - ContainerName: cq-server
           ContainerPort: 3000
           TargetGroupArn: !Ref TargetGroup
-      HealthCheckGracePeriodSeconds: 60
+      HealthCheckGracePeriodSeconds: 90
       DeploymentConfiguration:
-        # Spec: rolling update, max 200%, min 100%. Note: SQLite-on-EFS
-        # has a known co-access corruption window — production single-L2
-        # stacks should prefer the recreate strategy used by the existing
-        # customer-l2.yaml (min 0 / max 100). The marketplace template
-        # follows the FO-2-backend spec verbatim; rotate to recreate if
-        # WAL corruption is observed.
-        MinimumHealthyPercent: 100
-        MaximumPercent: 200
+        # SQLite + single-host EBS bind mount: only ONE task can hold the
+        # database open at a time. Recreate strategy (min 0 / max 100):
+        # the old task stops, releases the file locks, then the new task
+        # starts. Brief downtime during deploys — acceptable trade for
+        # avoiding SQLite multi-writer pathologies. (Drove the EFS
+        # corruption that motivated agent#323; not repeating it.)
+        MinimumHealthyPercent: 0
+        MaximumPercent: 100
+
+  # =====================================================================
+  # DLM — hourly EBS snapshots of the cq-l2-data volume.
+  # Retention 168 snapshots = 7 days at 1/hour. RPO 1h, RTO ~10min via
+  # snapshot-restore (see docs/ops/l2-substrate-recovery.md).
+  # =====================================================================
+  CqDataSnapshotPolicy:
+    Type: AWS::DLM::LifecyclePolicy
+    Properties:
+      Description: !Sub "${EnterpriseSlug} L2 cq-data hourly snapshots (agent#323)"
+      State: ENABLED
+      ExecutionRoleArn: !GetAtt DlmRole.Arn
+      PolicyDetails:
+        PolicyType: EBS_SNAPSHOT_MANAGEMENT
+        ResourceTypes: [VOLUME]
+        TargetTags:
+          - { Key: cq-l2-data, Value: "true" }
+        Schedules:
+          - Name: hourly-7d
+            CopyTags: true
+            TagsToAdd:
+              - { Key: SnapshotPolicy, Value: !Sub "${EnterpriseSlug}-l2-hourly" }
+            CreateRule:
+              # Standard DLM cron form: every hour on the hour. The
+              # 6-field aws form is `M H DoM Mo DoW Y` — `0 * * * ? *`
+              # = at minute 0 of every hour.
+              CronExpression: "cron(0 * * * ? *)"
+            RetainRule:
+              Count: 168
 
 Outputs:
   AlbDnsName:
@@ -616,9 +857,16 @@ Outputs:
     Description: ECS service ARN (ops debugging).
     Value: !Ref EcsService
 
-  EfsId:
-    Description: EFS file system ID (ops debugging).
-    Value: !Ref EfsFileSystem
+  CqDataVolumeId:
+    Description: |
+      Persistent EBS data volume id holding /data/cq.db. Recovery scripts
+      use this to locate the canonical volume + walk back through DLM
+      snapshots (see docs/ops/l2-substrate-recovery.md).
+    Value: !Ref CqDataVolume
+
+  CqDataSnapshotPolicyId:
+    Description: DLM lifecycle policy id (hourly snapshots, 7-day retention).
+    Value: !Ref CqDataSnapshotPolicy
 
   TaskDefinitionArn:
     Description: Active task definition ARN (ops debugging).

--- a/deploy/aws/marketplace-l2.yaml
+++ b/deploy/aws/marketplace-l2.yaml
@@ -195,15 +195,18 @@ Parameters:
     AllowedPattern: "^(snap-[0-9a-f]{8,17}|)$"
     ConstraintDescription: Must be empty or a valid snap-XXXXXXXX id.
     Description: |
-      When non-empty, the L2's EBS data volume is initialised from this
-      DLM snapshot rather than as a blank gp3 disk. The documented
-      recovery path: pick the most recent `cq-l2-data: true` snapshot
-      from the DLM-tagged set, then run update-stack with this parameter
-      set to the snapshot id (on a FRESH stack — see
-      docs/ops/l2-substrate-recovery.md for why this property is
-      immutable on the live stack). CFN creates the volume from the
-      snapshot, EcsHostVolumeAttachment binds it to the host, and
-      UserData formats-or-mounts on first boot.
+      Optional. EBS snapshot id (snap-XXXX) to restore the cq-server data
+      volume from. When set on update-stack, CqDataVolume is replaced via
+      UpdateReplacePolicy: Snapshot — the previous volume gets snapshotted
+      then deleted, and a fresh volume is created from RestoreFromSnapshotId.
+      Empty on first deploy = fresh blank gp3 volume.
+
+      After a restore, DO NOT clear this value. Toggling it back to empty
+      also triggers volume replacement (snapshot → delete → fresh blank),
+      wiping the restored data. Leave the snapshot id in place as a
+      permanent stack parameter; it has no runtime effect after the volume
+      is created. See docs/ops/l2-substrate-recovery.md for the full
+      procedure.
 
 Conditions:
   HasAdminEmail: !Not [!Equals [!Ref AdminEmail, ""]]
@@ -212,8 +215,8 @@ Conditions:
   # the L2 slug IS the Enterprise, so CQ_ENTERPRISE falls back to
   # EnterpriseSlug. FO-2 deploys pass the real parent Enterprise id.
   HasCqEnterpriseId: !Not [!Equals [!Ref CqEnterpriseId, ""]]
-  # agent#323 — toggles BlockDeviceMappings between a blank gp3
-  # (fresh L2) and snapshot-restored gp3 (recovery path).
+  # agent#323 — toggles SnapshotId on CqDataVolume between absent
+  # (fresh L2) and the restore-from id (recovery path).
   RestoreFromSnapshot: !Not [!Equals [!Ref RestoreFromSnapshotId, ""]]
 
 Resources:
@@ -573,6 +576,20 @@ Resources:
           # ECR Public (cold pull on a fresh host can take 30-60s).
           echo "ECS_CONTAINER_START_TIMEOUT=3m" >> /etc/ecs/ecs.config
           systemctl enable ecs || true
+
+          # Ensure ecs.service refuses to start unless /mnt/cq-data is
+          # mounted. Belt-and-braces with the UserData mountpoint guard
+          # below, but the drop-in handles the reboot case (where
+          # UserData doesn't re-run). The mount unit name is the
+          # systemd-escaped form of the mountpoint path; systemd
+          # auto-generates it from the fstab entry written below.
+          mkdir -p /etc/systemd/system/ecs.service.d
+          cat > /etc/systemd/system/ecs.service.d/10-require-data-mount.conf <<'EOF'
+          [Unit]
+          RequiresMountsFor=/mnt/cq-data
+          After=mnt-cq\x2ddata.mount
+          EOF
+          systemctl daemon-reload
 
           # --- Mount the persistent EBS data volume -------------------
           # CFN attaches the volume via EcsHostVolumeAttachment before

--- a/deploy/aws/marketplace-l2.yaml
+++ b/deploy/aws/marketplace-l2.yaml
@@ -199,10 +199,11 @@ Parameters:
       DLM snapshot rather than as a blank gp3 disk. The documented
       recovery path: pick the most recent `cq-l2-data: true` snapshot
       from the DLM-tagged set, then run update-stack with this parameter
-      set to the snapshot id. The ASG instance refresh provisions a new
-      EC2 host with the restored EBS volume attached; cq-server boots
-      against the recovered SQLite database. See
-      docs/ops/l2-substrate-recovery.md.
+      set to the snapshot id (on a FRESH stack — see
+      docs/ops/l2-substrate-recovery.md for why this property is
+      immutable on the live stack). CFN creates the volume from the
+      snapshot, EcsHostVolumeAttachment binds it to the host, and
+      UserData formats-or-mounts on first boot.
 
 Conditions:
   HasAdminEmail: !Not [!Equals [!Ref AdminEmail, ""]]
@@ -365,8 +366,10 @@ Resources:
   # IAM
   #   - TaskExecutionRole: ECS agent pulls image, writes logs, fetches
   #                        secrets at task start (assumed by ecs-tasks).
-  #   - TaskRole:          runtime (SES, secrets, KMS) — no EFS perms
-  #                        any more; EBS is host-attached.
+  #   - TaskRole:          runtime (SES, secrets, KMS, ssmmessages for
+  #                        ecs execute-command). No volume perms — EBS
+  #                        is host-attached via CFN VolumeAttachment,
+  #                        not by the task.
   #   - InstanceRole:      EC2 host runs the ECS agent (assumed by ec2).
   #   - DlmRole:           AWS DLM assumes this to create snapshots.
   # =====================================================================
@@ -436,6 +439,22 @@ Resources:
                 Condition:
                   StringEquals:
                     "kms:ViaService": !Sub "secretsmanager.${AWS::Region}.amazonaws.com"
+        # Needed for `aws ecs execute-command` (EnableExecuteCommand: true
+        # on the service). The session-manager plugin running inside the
+        # task opens SSM message channels using the TASK role, not the
+        # instance role — without these the exec session fails with
+        # "Channel closed before message".
+        - PolicyName: EcsExecMessages
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssmmessages:CreateControlChannel
+                  - ssmmessages:CreateDataChannel
+                  - ssmmessages:OpenControlChannel
+                  - ssmmessages:OpenDataChannel
+                Resource: "*"
 
   InstanceRole:
     Type: AWS::IAM::Role
@@ -474,13 +493,13 @@ Resources:
   # =====================================================================
   # PERSISTENT EBS DATA VOLUME — agent#323
   #
-  # Declared as a first-class CFN resource (NOT inline in the LaunchTemplate
-  # BlockDeviceMappings) so it survives ASG instance refresh / replacement:
-  # the volume's lifecycle is bound to the stack, not to any one EC2 host.
-  # UserData on each instance attaches this volume at boot.
+  # Declared as a first-class CFN resource so its lifecycle is bound to
+  # the stack, not to any one EC2 host. CFN attaches it to the EcsHost
+  # via the EcsHostVolumeAttachment resource (no imperative attach in
+  # UserData, no race with the ECS agent).
   #
-  # Pinned to PublicSubnetA's AZ — EBS volumes are zonal, so the ASG must
-  # also be constrained to the same AZ (see AsgCqServer below). Multi-AZ
+  # Pinned to PublicSubnetA's AZ — EBS volumes are zonal, so the EC2
+  # host must live in the same AZ (single-AZ topology). Multi-AZ
   # availability is a follow-up (move to Postgres or Litestream).
   # =====================================================================
   CqDataVolume:
@@ -503,146 +522,119 @@ Resources:
         - { Key: EnterpriseSlug, Value: !Ref EnterpriseSlug }
 
   # =====================================================================
-  # EC2 capacity for ECS — LaunchTemplate + single-instance ASG
-  # =====================================================================
-  EcsHostLaunchTemplate:
-    Type: AWS::EC2::LaunchTemplate
-    Properties:
-      LaunchTemplateName: !Sub "${EnterpriseSlug}-l2-ecs-host"
-      LaunchTemplateData:
-        # ECS-optimized AL2023 ARM64 AMI via SSM parameter — auto-resolves
-        # to the current AWS-published AMI at stack-create / instance launch.
-        # Pinning a specific AMI id would force template churn every AMI
-        # release; the SSM alias is the AWS-recommended pattern.
-        ImageId: "{{resolve:ssm:/aws/service/ecs/optimized-ami/amazon-linux-2023/arm64/recommended/image_id}}"
-        InstanceType: t4g.small
-        IamInstanceProfile:
-          Arn: !GetAtt InstanceProfile.Arn
-        SecurityGroupIds: [!Ref HostSecurityGroup]
-        MetadataOptions:
-          HttpTokens: required
-          HttpPutResponseHopLimit: 2
-        TagSpecifications:
-          - ResourceType: instance
-            Tags:
-              - { Key: Name, Value: !Sub "${EnterpriseSlug}-l2-ecs-host" }
-        UserData:
-          Fn::Base64: !Sub |
-            #!/bin/bash
-            set -euxo pipefail
-            # --- Register with the ECS cluster --------------------------
-            echo "ECS_CLUSTER=${EcsCluster}" >> /etc/ecs/ecs.config
-            # Allow longer task start for the cq-server image pull from
-            # ECR Public (cold pull on a fresh host can take 30-60s).
-            echo "ECS_CONTAINER_START_TIMEOUT=3m" >> /etc/ecs/ecs.config
-            systemctl enable --now ecs || true
-
-            # --- Attach the persistent EBS data volume ------------------
-            # The volume is a CFN-managed resource (see CqDataVolume); we
-            # attach it here on every instance start so ASG instance
-            # refresh / replacement reconnects the SAME volume to the new
-            # host. The device name /dev/sdf maps to /dev/nvme1n1 on Nitro.
-            TOKEN=$(curl -sX PUT 'http://169.254.169.254/latest/api/token' -H 'X-aws-ec2-metadata-token-ttl-seconds: 60')
-            INSTANCE_ID=$(curl -sH "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)
-            REGION=$(curl -sH "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/placement/region)
-
-            # Wait until the volume is `available` (a previous instance may
-            # still be detaching during a refresh), then attach.
-            for i in $(seq 1 30); do
-              STATE=$(aws ec2 describe-volumes --region "$REGION" \
-                --volume-ids ${CqDataVolume} \
-                --query 'Volumes[0].State' --output text || echo "unknown")
-              if [ "$STATE" = "available" ]; then break; fi
-              if [ "$STATE" = "in-use" ]; then
-                # Detach the stragglerasync; ASG instance-refresh terminates
-                # the old host but EBS detach can lag by 10-20s.
-                aws ec2 detach-volume --region "$REGION" \
-                  --volume-id ${CqDataVolume} --force || true
-              fi
-              sleep 5
-            done
-            aws ec2 attach-volume --region "$REGION" \
-              --volume-id ${CqDataVolume} \
-              --instance-id "$INSTANCE_ID" \
-              --device /dev/sdf
-
-            # Wait for the kernel to surface the volume.
-            for i in $(seq 1 30); do
-              if [ -b /dev/nvme1n1 ]; then break; fi
-              sleep 2
-            done
-
-            # Format only if blank (first-ever boot of a fresh volume).
-            # `file -s` reports `data` on an unformatted device and the
-            # filesystem name otherwise. Snapshot-restored volumes are
-            # already formatted, so this is a no-op.
-            if file -s /dev/nvme1n1 | grep -q ': data$'; then
-              mkfs.ext4 /dev/nvme1n1
-            fi
-
-            mkdir -p /mnt/cq-data
-            UUID=$(blkid -s UUID -o value /dev/nvme1n1)
-            grep -q "$UUID" /etc/fstab || \
-              echo "UUID=$UUID /mnt/cq-data ext4 defaults,nofail 0 2" >> /etc/fstab
-            mount -a
-            # Container UID 1000 (cq-server `app` user) must own the data.
-            chown -R 1000:1000 /mnt/cq-data
-            chmod 0750 /mnt/cq-data
-
-            # Kick ECS so it picks up the now-ready /mnt/cq-data bind mount.
-            systemctl restart ecs
-
-  AsgCqServer:
-    Type: AWS::AutoScaling::AutoScalingGroup
-    DependsOn: VpcGatewayAttachment
-    Properties:
-      AutoScalingGroupName: !Sub "${EnterpriseSlug}-l2-asg"
-      MinSize: "1"
-      MaxSize: "1"
-      DesiredCapacity: "1"
-      LaunchTemplate:
-        LaunchTemplateId: !Ref EcsHostLaunchTemplate
-        Version: !GetAtt EcsHostLaunchTemplate.LatestVersionNumber
-      # AZ-pinned to the same subnet as the EBS volume (zonal resource).
-      VPCZoneIdentifier: [!Ref PublicSubnetA]
-      HealthCheckType: EC2
-      HealthCheckGracePeriod: 180
-      NewInstancesProtectedFromScaleIn: false
-      Tags:
-        - { Key: Name, Value: !Sub "${EnterpriseSlug}-l2-asg", PropagateAtLaunch: true }
-        # Required for ECS managed-termination / capacity-provider drain.
-        - { Key: AmazonECSManaged, Value: "true", PropagateAtLaunch: true }
-
-  EcsCapacityProvider:
-    Type: AWS::ECS::CapacityProvider
-    Properties:
-      Name: !Sub "${EnterpriseSlug}-l2-cp"
-      AutoScalingGroupProvider:
-        AutoScalingGroupArn: !Ref AsgCqServer
-        ManagedScaling:
-          Status: ENABLED
-          TargetCapacity: 100
-          MinimumScalingStepSize: 1
-          MaximumScalingStepSize: 1
-        ManagedTerminationProtection: DISABLED
-
-  # =====================================================================
-  # ECS cluster + task + service
+  # ECS cluster (defined before EcsHost so UserData can !Ref it)
   # =====================================================================
   EcsCluster:
     Type: AWS::ECS::Cluster
     Properties:
       ClusterName: !Sub "${EnterpriseSlug}-l2-cluster"
 
-  EcsClusterCapacityProviderAssoc:
-    Type: AWS::ECS::ClusterCapacityProviderAssociations
+  # =====================================================================
+  # EC2 capacity for ECS — single bare AWS::EC2::Instance, no ASG, no
+  # capacity provider. The volume is bound via EcsHostVolumeAttachment
+  # (a CFN-owned attachment), so UserData never calls ec2:AttachVolume.
+  #
+  # Replacement on instance loss is operator-driven: re-run update-stack
+  # (no change) or stack-replace the instance. Single-AZ, single-host
+  # topology is the documented MVP trade-off; HA path is Postgres/RDS
+  # (issue #309) or Litestream (issue #311).
+  # =====================================================================
+  EcsHost:
+    Type: AWS::EC2::Instance
+    DependsOn: VpcGatewayAttachment
     Properties:
-      Cluster: !Ref EcsCluster
-      CapacityProviders: [!Ref EcsCapacityProvider]
-      DefaultCapacityProviderStrategy:
-        - CapacityProvider: !Ref EcsCapacityProvider
-          Weight: 1
-          Base: 1
+      # ECS-optimized AL2023 ARM64 AMI via SSM parameter — auto-resolves
+      # to the current AWS-published AMI at stack-create. Pinning a
+      # specific AMI id would force template churn every AMI release;
+      # the SSM alias is the AWS-recommended pattern.
+      ImageId: "{{resolve:ssm:/aws/service/ecs/optimized-ami/amazon-linux-2023/arm64/recommended/image_id}}"
+      InstanceType: t4g.small
+      IamInstanceProfile: !Ref InstanceProfile
+      SubnetId: !Ref PublicSubnetA
+      SecurityGroupIds: [!Ref HostSecurityGroup]
+      MetadataOptions:
+        HttpTokens: required
+        HttpPutResponseHopLimit: 2
+      Tags:
+        - { Key: Name, Value: !Sub "${EnterpriseSlug}-l2-ecs-host" }
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          set -euxo pipefail
+          # --- Configure the ECS agent (do NOT start it yet) -----------
+          # Write cluster + tunables BEFORE starting ecs so the agent
+          # registers correctly on first start. We enable (start on
+          # next boot) but do NOT --now: starting ecs before the EBS
+          # volume is mounted lets Docker create an empty host directory
+          # at /mnt/cq-data that shadows the eventual mount.
+          mkdir -p /etc/ecs
+          echo "ECS_CLUSTER=${EcsCluster}" >> /etc/ecs/ecs.config
+          # Allow longer task start for the cq-server image pull from
+          # ECR Public (cold pull on a fresh host can take 30-60s).
+          echo "ECS_CONTAINER_START_TIMEOUT=3m" >> /etc/ecs/ecs.config
+          systemctl enable ecs || true
+
+          # --- Mount the persistent EBS data volume -------------------
+          # CFN attaches the volume via EcsHostVolumeAttachment before
+          # this script runs (the attachment is a DependsOn of the
+          # EcsService — but UserData runs after the instance reaches
+          # running, which is after attach-volume returns). The Nitro
+          # device path is /dev/nvme1n1 even though the attachment uses
+          # /dev/sdf. Wait briefly for the kernel to surface it.
+          for i in $(seq 1 60); do
+            if [ -b /dev/nvme1n1 ]; then break; fi
+            sleep 2
+          done
+
+          # Format only if blank (first-ever boot of a fresh volume).
+          # `file -s` reports `data` on an unformatted device and the
+          # filesystem name otherwise. Snapshot-restored volumes are
+          # already formatted, so this is a no-op.
+          if file -s /dev/nvme1n1 | grep -q ': data$'; then
+            mkfs.ext4 /dev/nvme1n1
+          fi
+
+          mkdir -p /mnt/cq-data
+          UUID=$(blkid -s UUID -o value /dev/nvme1n1)
+          grep -q "$UUID" /etc/fstab || \
+            echo "UUID=$UUID /mnt/cq-data ext4 defaults,nofail 0 2" >> /etc/fstab
+          mount -a
+
+          # If restoring from a smaller snapshot into a larger volume,
+          # grow the FS to fill the device. Idempotent: no-op when sizes
+          # already match (e2fsprogs prints "Nothing to do").
+          resize2fs /dev/nvme1n1 || true
+
+          # Container UID 1000 (cq-server `app` user) must own the data.
+          chown -R 1000:1000 /mnt/cq-data
+          chmod 0750 /mnt/cq-data
+
+          # --- Verify mount BEFORE starting ECS ------------------------
+          # Without this guard, Docker bind mounts may shadow the EBS
+          # volume with an empty host directory if /mnt/cq-data isn't
+          # really mounted. Fail fast instead.
+          test -d /mnt/cq-data
+          mountpoint -q /mnt/cq-data || { echo "FATAL: /mnt/cq-data not mounted, refusing to start ecs"; exit 1; }
+
+          # Now safe to start the ECS agent — it will register this
+          # instance into the cluster and accept task placements.
+          systemctl start ecs
+
+  # CFN owns the volume attachment lifecycle. The ECS service DependsOn
+  # this resource, so the cq-server task can't be scheduled before the
+  # volume is bound to the host.
+  EcsHostVolumeAttachment:
+    Type: AWS::EC2::VolumeAttachment
+    Properties:
+      VolumeId: !Ref CqDataVolume
+      InstanceId: !Ref EcsHost
+      # /dev/sdf at the EC2 API surface; the kernel surfaces this as
+      # /dev/nvme1n1 on Nitro instances (t4g.* are Nitro).
+      Device: /dev/sdf
+
+  # =====================================================================
+  # ECS task + service
+  # ====================================================================
 
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
@@ -794,19 +786,17 @@ Resources:
 
   EcsService:
     Type: AWS::ECS::Service
-    # Capacity-provider association must exist before the service can
-    # request capacity through it; HttpListener gates the LB registration.
-    DependsOn: [HttpListener, EcsClusterCapacityProviderAssoc]
+    # HttpListener gates LB registration; EcsHostVolumeAttachment ensures
+    # /mnt/cq-data is backed by the EBS volume before the task is placed.
+    DependsOn: [HttpListener, EcsHostVolumeAttachment]
     Properties:
       ServiceName: cq-server
       Cluster: !Ref EcsCluster
       TaskDefinition: !Ref TaskDefinition
       DesiredCount: 1
-      # ECS-on-EC2 via capacity provider — no LaunchType / NetworkConfig.
-      CapacityProviderStrategy:
-        - CapacityProvider: !Ref EcsCapacityProvider
-          Weight: 1
-          Base: 1
+      # ECS-on-EC2 against the container instance registered by the ECS
+      # agent on EcsHost. No capacity provider, no ASG.
+      LaunchType: EC2
       EnableExecuteCommand: true
       LoadBalancers:
         - ContainerName: cq-server
@@ -838,7 +828,12 @@ Resources:
         PolicyType: EBS_SNAPSHOT_MANAGEMENT
         ResourceTypes: [VOLUME]
         TargetTags:
+          # Scope the policy to THIS L2's volume — without the
+          # EnterpriseSlug tag a DLM policy in an account hosting
+          # multiple L2 stacks would snapshot every L2's volume on its
+          # own schedule, multiplying snapshot count + cost.
           - { Key: cq-l2-data, Value: "true" }
+          - { Key: EnterpriseSlug, Value: !Ref EnterpriseSlug }
         Schedules:
           - Name: hourly-7d
             CopyTags: true

--- a/deploy/aws/marketplace-l2.yaml
+++ b/deploy/aws/marketplace-l2.yaml
@@ -1,4 +1,17 @@
 # =============================================================================
+# WARNING — substrate change from EFS to EBS in this template:
+# Stacks deployed from the prior (EFS) template version include
+# AWS::EFS::FileSystem and related resources that are REMOVED here.
+# CloudFormation will DELETE the EFS filesystem (and its data) on the
+# next update-stack against an EFS-based stack. There is no
+# DeletionPolicy: Retain safety net — those resources are no longer in
+# this template to retroactively annotate.
+#
+# Before update-stacking an EFS-based stack (mvp-s2-a, mvp-s2-b, or any
+# other live EFS-substrate stack) to this template, take a manual data
+# backup (e.g. copy /data out via an EC2 instance attached to the EFS
+# access point) or accept the data loss.
+# =============================================================================
 # 8th-Layer.ai Marketplace L2 stack — stands up a complete, healthy cq-server
 # instance (the customer's Layer-2 semantic backbone) in the customer's AWS
 # account. Instantiated by the 8th-Layer.ai Enterprise Provisioning Service
@@ -10,10 +23,14 @@
 #   - Dedicated VPC (10.0.0.0/16) + 2 public subnets across 2 AZs + IGW.
 #   - ALB (HTTP/80, internet-facing) → ECS-on-EC2 task (port 3000) →
 #     persistent EBS gp3 volume bind-mounted at /data (SQLite at /data/cq.db).
-#   - Single-instance ASG of t4g.small (ARM64) in PublicSubnetA's AZ. EBS
-#     volume is a first-class CFN resource (NOT a LaunchTemplate block
-#     device) so it survives ASG instance refresh / replacement; UserData
-#     attaches + mounts it on every host boot.
+#   - Single bare `AWS::EC2::Instance` (t4g.small, ARM64) in PublicSubnetA's
+#     AZ — no ASG, no capacity provider. The EBS data volume is a first-
+#     class CFN resource attached via `AWS::EC2::VolumeAttachment`, so CFN
+#     owns the attachment lifecycle (no imperative attach in UserData,
+#     no deadlocks on SnapshotId replacement). ECS task launches with
+#     `LaunchType: EC2` against the container instance the ECS agent
+#     registers from the host. Single-instance topology — replacement on
+#     instance loss is operator-driven, not auto-recovered.
 #   - AWS DLM lifecycle policy snapshots the EBS volume hourly, retains
 #     168 snapshots (7 days). RPO=1h, RTO~10min via snapshot restore.
 #   - HTTPS termination is handled by Cloudflare in front of the ALB; the
@@ -34,11 +51,12 @@
 # =============================================================================
 AWSTemplateFormatVersion: "2010-09-09"
 Description: |
-  8th-Layer.ai Marketplace L2 — ALB → ECS-on-EC2 (t4g.small ASG of 1) →
-  persistent EBS gp3 at /data (SQLite). DLM hourly snapshots, 7-day
-  retention. Single-AZ. Substrate moved off SQLite-on-EFS to fix the
-  index-corruption failure mode documented in agent#323; see full
-  rationale in the file-header comments.
+  8th-Layer.ai Marketplace L2 — ALB → ECS-on-EC2 (single t4g.small EC2
+  instance, no ASG) → persistent EBS gp3 at /data (SQLite). CFN-owned
+  AWS::EC2::VolumeAttachment binds the volume before UserData runs. DLM
+  hourly snapshots, 7-day retention. Single-AZ. Substrate moved off
+  SQLite-on-EFS to fix the index-corruption failure mode documented in
+  agent#323; see full rationale in the file-header comments.
 
 Parameters:
   EnterpriseSlug:

--- a/docs/ops/l2-substrate-recovery.md
+++ b/docs/ops/l2-substrate-recovery.md
@@ -1,0 +1,165 @@
+# L2 substrate recovery runbook
+
+Recovery procedures for the EBS-on-EC2 L2 substrate introduced by
+[`agent#323`](https://github.com/OneZero1ai/8th-layer-agent/issues/323).
+The L2 CFN template is
+[`deploy/aws/marketplace-l2.yaml`](../../deploy/aws/marketplace-l2.yaml).
+
+## Where the data lives
+
+Per-L2 inventory:
+
+| What | Where | CFN resource | Why it matters |
+|------|-------|--------------|---------------|
+| SQLite DB file | `/data/cq.db` inside the cq-server container | bind-mounted from `/mnt/cq-data` on the EC2 host | The single canonical store of KUs, peers, activity log. |
+| Filesystem | ext4 on `/dev/nvme1n1` (the EBS data volume) | `CqDataVolume` (`AWS::EC2::Volume`) | Real POSIX locks → SQLite is safe here. |
+| EBS volume | gp3, AZ-pinned to `PublicSubnetA`'s AZ | `CqDataVolume` | Zonal. Loss of the AZ = L2 offline until restore. |
+| Snapshots | hourly, last 168 retained (7 days) | `CqDataSnapshotPolicy` (`AWS::DLM::LifecyclePolicy`) | RPO=1h. Snapshots are tagged `cq-l2-data=true`. |
+
+Stack outputs to find them fast:
+
+```
+aws cloudformation describe-stacks \
+  --profile <l2-profile> --region us-east-1 \
+  --stack-name <L2-stack-name> \
+  --query 'Stacks[0].Outputs[?OutputKey==`CqDataVolumeId`].OutputValue' \
+  --output text
+```
+
+`CqDataSnapshotPolicyId` is exported the same way.
+
+## Inspect available snapshots
+
+DLM tags every snapshot with `cq-l2-data: true` (copied from the source
+volume). Find the snapshot set:
+
+```
+aws ec2 describe-snapshots \
+  --profile <l2-profile> --region us-east-1 \
+  --owner-ids self \
+  --filters Name=tag:cq-l2-data,Values=true \
+           Name=tag:EnterpriseSlug,Values=<slug> \
+  --query 'Snapshots[].[SnapshotId,StartTime,State,VolumeSize]' \
+  --output table
+```
+
+The `StartTime` column is the snapshot creation time in UTC. Pick the
+most recent `completed` snapshot for a vanilla restore; pick an earlier
+one if the corruption / data-loss event happened post-snapshot-N and
+you want a known-good prior state.
+
+## Restore procedure (volume lost or DB unrecoverable)
+
+The restore is a CFN parameter change, no manual EBS surgery required.
+
+1. **Identify the target snapshot id** with the `describe-snapshots` call
+   above. Note it as `snap-XXXX`.
+
+2. **Update the L2 stack with `RestoreFromSnapshotId`:**
+
+   ```
+   aws cloudformation update-stack \
+     --profile <l2-profile> --region us-east-1 \
+     --stack-name <L2-stack-name> \
+     --use-previous-template \
+     --capabilities CAPABILITY_IAM \
+     --parameters \
+       ParameterKey=RestoreFromSnapshotId,ParameterValue=snap-XXXX \
+       ParameterKey=EnterpriseSlug,UsePreviousValue=true \
+       ParameterKey=CqEnterpriseId,UsePreviousValue=true \
+       ParameterKey=CqGroupId,UsePreviousValue=true \
+       ParameterKey=RootPubkeyB64u,UsePreviousValue=true \
+       ParameterKey=ProvisionerExternalId,UsePreviousValue=true \
+       ParameterKey=AdminEmail,UsePreviousValue=true \
+       ParameterKey=AutoApprovePropose,UsePreviousValue=true \
+       ParameterKey=CqServerImage,UsePreviousValue=true \
+       ParameterKey=CqDbVolumeSizeGiB,UsePreviousValue=true \
+       ParameterKey=AwsRegion,UsePreviousValue=true \
+       ParameterKey=DirectoryUrl,UsePreviousValue=true
+   ```
+
+   The volume has `UpdateReplacePolicy: Snapshot` + a `SnapshotId`
+   property — CFN snapshots the existing (possibly corrupt) volume,
+   then creates a new one from the chosen restore point. The ASG
+   instance refresh provisions a fresh EC2 host that attaches the new
+   volume on boot via UserData.
+
+3. **Wait for stack rollout (~5-10 min):**
+
+   ```
+   aws cloudformation wait stack-update-complete \
+     --profile <l2-profile> --region us-east-1 \
+     --stack-name <L2-stack-name>
+   ```
+
+4. **Verify health:**
+
+   ```
+   # ALB target healthy:
+   aws elbv2 describe-target-health \
+     --profile <l2-profile> --region us-east-1 \
+     --target-group-arn $(aws cloudformation describe-stack-resources \
+       --profile <l2-profile> --region us-east-1 \
+       --stack-name <L2-stack-name> \
+       --logical-resource-id TargetGroup \
+       --query 'StackResources[0].PhysicalResourceId' --output text)
+
+   # L2 /health 200:
+   curl -sS https://<slug>.8th-layer.ai/health
+   ```
+
+5. **After verifying, clear the parameter so a future update doesn't
+   re-restore.** Run the same update-stack call but pass
+   `ParameterKey=RestoreFromSnapshotId,ParameterValue=""`. (Skipping
+   this is benign — CFN only re-creates the volume on actual change
+   detection — but explicit is better than implicit for ops audit.)
+
+## RTO / RPO
+
+| Metric | MVP target | Notes |
+|--------|-----------|-------|
+| RPO | 1 hour | DLM cron `cron(0 * * * ? *)` runs hourly on the hour. Worst case: failure at minute 59 → up to ~60 min of writes lost. |
+| RTO | ~10 minutes | Update-stack (~5 min CFN apply) + ASG instance refresh (~3 min new EC2 + UserData) + ECS task placement (~1 min). |
+
+Litestream upgrade (separate PR, post-MVP) brings RPO under 60 seconds
+by streaming WAL changes to S3 continuously.
+
+## Single-AZ exposure
+
+The L2 EBS volume is zonal: if `PublicSubnetA`'s AZ goes down, the L2 is
+offline until manual recovery in another AZ. MVP-accepted trade-off.
+
+**Manual cross-AZ restore (degraded — operator decision):**
+
+1. Pick the most recent snapshot via `describe-snapshots` above.
+2. Edit `deploy/aws/marketplace-l2.yaml` locally — change the
+   `CqDataVolume.AvailabilityZone` from `!Select [0, !GetAZs ""]` to
+   `!Select [1, !GetAZs ""]`, and change `AsgCqServer.VPCZoneIdentifier`
+   to `[!Ref PublicSubnetB]`.
+3. Republish via the standard PR + merge flow (the CodeBuild publisher
+   in `ci/buildspecs/marketplace-l2-publish.yml` syncs to S3).
+4. Update the stack with the new template + `RestoreFromSnapshotId`
+   pointing at the snapshot from step 1.
+
+Multi-AZ + concurrent-writer-safe substrate (Postgres on RDS) is tracked
+as [#309](https://github.com/OneZero1ai/8th-layer-agent/issues/309)
++ [#311](https://github.com/OneZero1ai/8th-layer-agent/issues/311).
+
+## SSH-less host access for inline diagnosis
+
+`InstanceRole` includes `AmazonSSMManagedInstanceCore`, so the EC2 host
+is reachable via Session Manager — no SSH keys, no bastion:
+
+```
+INSTANCE_ID=$(aws autoscaling describe-auto-scaling-instances \
+  --profile <l2-profile> --region us-east-1 \
+  --query "AutoScalingInstances[?AutoScalingGroupName=='<slug>-l2-asg'].InstanceId | [0]" \
+  --output text)
+aws ssm start-session --profile <l2-profile> --region us-east-1 \
+  --target "$INSTANCE_ID"
+```
+
+Inside the session: `ls /mnt/cq-data`, `sqlite3 /mnt/cq-data/cq.db
+'PRAGMA integrity_check;'`, etc. For a live task shell (without
+stopping the container): `aws ecs execute-command` against the running
+task — `EnableExecuteCommand: true` is set on the service.

--- a/docs/ops/l2-substrate-recovery.md
+++ b/docs/ops/l2-substrate-recovery.md
@@ -55,7 +55,26 @@ The restore is a CFN parameter change, no manual EBS surgery required.
 1. **Identify the target snapshot id** with the `describe-snapshots` call
    above. Note it as `snap-XXXX`.
 
-2. **Update the L2 stack with `RestoreFromSnapshotId`:**
+2. **Stop the cq-server task so the EBS volume can be detached cleanly.**
+   When `RestoreFromSnapshotId` changes, CFN replaces `CqDataVolume`,
+   which means `EcsHostVolumeAttachment` is also replaced (it points
+   to a different volume). To replace the attachment, CFN must detach
+   the existing volume from the running EcsHost — but the ECS task is
+   holding `/data/cq.db` open via the bind mount, so the detach will
+   fail or stall on the in-use volume until force-detach kicks in.
+   Scale the service to zero first:
+
+   ```
+   aws ecs update-service \
+     --profile <l2-profile> --region us-east-1 \
+     --cluster <cluster> --service cq-server \
+     --desired-count 0
+   aws ecs wait services-stable \
+     --profile <l2-profile> --region us-east-1 \
+     --cluster <cluster> --services cq-server
+   ```
+
+3. **Update the L2 stack with `RestoreFromSnapshotId`:**
 
    ```
    aws cloudformation update-stack \
@@ -80,12 +99,13 @@ The restore is a CFN parameter change, no manual EBS surgery required.
 
    The volume has `UpdateReplacePolicy: Snapshot` + a `SnapshotId`
    property — CFN snapshots the existing (possibly corrupt) volume,
-   then creates a new one from the chosen restore point. CFN
-   re-creates the `EcsHostVolumeAttachment` against the existing EC2
-   host (or recreates the host if the volume's AZ changed), and
-   UserData mounts the restored filesystem at /mnt/cq-data on boot.
+   detaches and deletes it, then creates a new one from the chosen
+   restore point. CFN re-creates the `EcsHostVolumeAttachment` against
+   the existing EC2 host (or recreates the host if the volume's AZ
+   changed), and UserData mounts the restored filesystem at
+   /mnt/cq-data on boot.
 
-3. **Wait for stack rollout (~5-10 min):**
+4. **Wait for stack rollout (~5-10 min):**
 
    ```
    aws cloudformation wait stack-update-complete \
@@ -93,7 +113,16 @@ The restore is a CFN parameter change, no manual EBS surgery required.
      --stack-name <L2-stack-name>
    ```
 
-4. **Verify health:**
+5. **Bring the cq-server task back up:**
+
+   ```
+   aws ecs update-service \
+     --profile <l2-profile> --region us-east-1 \
+     --cluster <cluster> --service cq-server \
+     --desired-count 1
+   ```
+
+6. **Verify health:**
 
    ```
    # ALB target healthy:
@@ -109,18 +138,39 @@ The restore is a CFN parameter change, no manual EBS surgery required.
    curl -sS https://<slug>.8th-layer.ai/health
    ```
 
-5. **Do NOT clear `RestoreFromSnapshotId` after restore.** `SnapshotId`
-   is an immutable property on `AWS::EC2::Volume`. Toggling it from
-   `snap-XXX` back to empty triggers volume replacement —
-   CloudFormation will snapshot the just-restored volume then create a
-   fresh blank gp3 in its place, wiping your restored data. Leave the
-   snapshot id in place as a permanent stack parameter; it has no
-   runtime effect after the volume is created.
+7. **Do NOT clear `RestoreFromSnapshotId` after restore.** Changing
+   `RestoreFromSnapshotId` (in either direction — empty → snap-XXX or
+   snap-XXX → empty) triggers volume replacement: CloudFormation takes
+   a snapshot of the current volume (via `UpdateReplacePolicy: Snapshot`),
+   deletes it, and creates a new one. Going back to empty creates a
+   fresh blank gp3 — wiping the restored data. Leave the snapshot id
+   in place as a permanent stack parameter; it has no runtime effect
+   after the volume is created.
 
-   To migrate off the snapshot reference (e.g., for ops hygiene), the
-   only safe path is to take a manual `aws ec2 create-snapshot` of the
-   live volume and use that snapshot id as the new permanent parameter
-   value, or stand up a fresh stack.
+   To move off the snapshot reference for ops hygiene, the safe path
+   is a manual `aws ec2 create-snapshot` of the live volume and using
+   that snapshot id as the new permanent parameter value, or standing
+   up a fresh stack.
+
+## Stop the task first whenever the EcsHost or volume is replaced
+
+The "scale service to zero, update-stack, scale back to one" sequence
+in steps 2 → 5 above applies to **any** update-stack call that causes
+in-place replacement of the EcsHost instance or the CqDataVolume — not
+just snapshot restores. Examples:
+
+- AMI / instance-type change on `EcsHost` (e.g. UserData edit, kernel
+  bump) → EC2 host is replaced → volume must detach from the old host.
+- `CqDbVolumeSizeGiB` change → if CFN treats this as replacement (gp3
+  online-resize is usually preferred but CFN sometimes replaces); the
+  attachment lifecycle is the same.
+- Any cross-AZ move (see "Single-AZ exposure" below).
+
+Without scaling the service to zero, the in-use bind mount blocks the
+detach and the update stalls until force-detach kicks in. The pattern
+is always: `update-service --desired-count 0` → `wait services-stable`
+→ `update-stack` → `wait stack-update-complete` → `update-service
+--desired-count 1`.
 
 ## RTO / RPO
 

--- a/docs/ops/l2-substrate-recovery.md
+++ b/docs/ops/l2-substrate-recovery.md
@@ -80,9 +80,10 @@ The restore is a CFN parameter change, no manual EBS surgery required.
 
    The volume has `UpdateReplacePolicy: Snapshot` + a `SnapshotId`
    property — CFN snapshots the existing (possibly corrupt) volume,
-   then creates a new one from the chosen restore point. The ASG
-   instance refresh provisions a fresh EC2 host that attaches the new
-   volume on boot via UserData.
+   then creates a new one from the chosen restore point. CFN
+   re-creates the `EcsHostVolumeAttachment` against the existing EC2
+   host (or recreates the host if the volume's AZ changed), and
+   UserData mounts the restored filesystem at /mnt/cq-data on boot.
 
 3. **Wait for stack rollout (~5-10 min):**
 
@@ -108,18 +109,25 @@ The restore is a CFN parameter change, no manual EBS surgery required.
    curl -sS https://<slug>.8th-layer.ai/health
    ```
 
-5. **After verifying, clear the parameter so a future update doesn't
-   re-restore.** Run the same update-stack call but pass
-   `ParameterKey=RestoreFromSnapshotId,ParameterValue=""`. (Skipping
-   this is benign — CFN only re-creates the volume on actual change
-   detection — but explicit is better than implicit for ops audit.)
+5. **Do NOT clear `RestoreFromSnapshotId` after restore.** `SnapshotId`
+   is an immutable property on `AWS::EC2::Volume`. Toggling it from
+   `snap-XXX` back to empty triggers volume replacement —
+   CloudFormation will snapshot the just-restored volume then create a
+   fresh blank gp3 in its place, wiping your restored data. Leave the
+   snapshot id in place as a permanent stack parameter; it has no
+   runtime effect after the volume is created.
+
+   To migrate off the snapshot reference (e.g., for ops hygiene), the
+   only safe path is to take a manual `aws ec2 create-snapshot` of the
+   live volume and use that snapshot id as the new permanent parameter
+   value, or stand up a fresh stack.
 
 ## RTO / RPO
 
 | Metric | MVP target | Notes |
 |--------|-----------|-------|
 | RPO | 1 hour | DLM cron `cron(0 * * * ? *)` runs hourly on the hour. Worst case: failure at minute 59 → up to ~60 min of writes lost. |
-| RTO | ~10 minutes | Update-stack (~5 min CFN apply) + ASG instance refresh (~3 min new EC2 + UserData) + ECS task placement (~1 min). |
+| RTO | ~10 minutes | Update-stack (~5 min CFN apply) + EC2 host replacement (~3 min new instance + UserData) + ECS task placement (~1 min). |
 
 Litestream upgrade (separate PR, post-MVP) brings RPO under 60 seconds
 by streaming WAL changes to S3 continuously.
@@ -134,12 +142,13 @@ offline until manual recovery in another AZ. MVP-accepted trade-off.
 1. Pick the most recent snapshot via `describe-snapshots` above.
 2. Edit `deploy/aws/marketplace-l2.yaml` locally — change the
    `CqDataVolume.AvailabilityZone` from `!Select [0, !GetAZs ""]` to
-   `!Select [1, !GetAZs ""]`, and change `AsgCqServer.VPCZoneIdentifier`
-   to `[!Ref PublicSubnetB]`.
+   `!Select [1, !GetAZs ""]`, and change `EcsHost.SubnetId` from
+   `!Ref PublicSubnetA` to `!Ref PublicSubnetB`.
 3. Republish via the standard PR + merge flow (the CodeBuild publisher
    in `ci/buildspecs/marketplace-l2-publish.yml` syncs to S3).
 4. Update the stack with the new template + `RestoreFromSnapshotId`
-   pointing at the snapshot from step 1.
+   pointing at the snapshot from step 1. CFN replaces both the volume
+   (new AZ → new resource) and the EC2 host (new subnet → new resource).
 
 Multi-AZ + concurrent-writer-safe substrate (Postgres on RDS) is tracked
 as [#309](https://github.com/OneZero1ai/8th-layer-agent/issues/309)
@@ -151,10 +160,11 @@ as [#309](https://github.com/OneZero1ai/8th-layer-agent/issues/309)
 is reachable via Session Manager — no SSH keys, no bastion:
 
 ```
-INSTANCE_ID=$(aws autoscaling describe-auto-scaling-instances \
+INSTANCE_ID=$(aws cloudformation describe-stack-resources \
   --profile <l2-profile> --region us-east-1 \
-  --query "AutoScalingInstances[?AutoScalingGroupName=='<slug>-l2-asg'].InstanceId | [0]" \
-  --output text)
+  --stack-name <L2-stack-name> \
+  --logical-resource-id EcsHost \
+  --query 'StackResources[0].PhysicalResourceId' --output text)
 aws ssm start-session --profile <l2-profile> --region us-east-1 \
   --target "$INSTANCE_ID"
 ```


### PR DESCRIPTION
## Why

[`agent#323`](https://github.com/OneZero1ai/8th-layer-agent/issues/323): during the S2 cross-L2 acceptance run on mvp-s2-a + mvp-s2-b (post PR #317), the `aigrp_peers` SQLite indexes corrupted repeatedly on both L2s within minutes of the AIGRP poll + write traffic:

```
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) disk I/O error
[SQL: SELECT l2_id, enterprise, "group", endpoint_url, ... FROM aigrp_peers WHERE enterprise = ?]
```

PRAGMA `integrity_check` reported `wrong # of entries in index idx_aigrp_peers_enterprise`, `idx_aigrp_peers_pair_secret_ref`, and `sqlite_autoindex_aigrp_peers_1`. `REINDEX` / `DROP INDEX` / writable_schema delete all failed inside the corrupt pages. `sqlite3 .recover` rebuilt peer rows but **lost the canonical KU rows on L2-a** because the corrupt pages held the only copy.

Root cause is the substrate: SQLite on EFS. NFSv4.1 POSIX-locking semantics don't match what SQLite expects under concurrent writes, and the AIGRP poll loop + federation fan-out + propose/activity-log path is a four-writer mesh. The documented fix is: real local block-device locks.

## The substrate change

| Before | After |
|--------|-------|
| ECS Fargate launch type | ECS-on-EC2 via capacity provider |
| EFS shared filesystem mounted at `/data` | Persistent EBS gp3 volume bind-mounted at `/data` (via `/mnt/cq-data` on the host) |
| (no snapshots) | AWS DLM lifecycle policy, hourly snapshots, 168 retained (7 days) |
| `awsvpc` task networking, IP target group | Bridge-mode tasks, instance target group, dynamic ephemeral ports |
| Multi-AZ EFS mount targets | Single-AZ ASG of 1 (zonal EBS) — accepted MVP trade-off |

### What's in this PR

- **`deploy/aws/marketplace-l2.yaml`** — full substrate swap. EFS resources + IAM perms + SG removed; EC2 + ASG + LaunchTemplate + EBS volume + DLM policy + InstanceRole + DlmRole added. New parameters: `CqDbVolumeSizeGiB` (default 20), `RestoreFromSnapshotId` (default empty, drives the recovery path). New outputs: `CqDataVolumeId`, `CqDataSnapshotPolicyId`. `EfsId` output dropped.

- **`docs/ops/l2-substrate-recovery.md`** — recovery runbook covering where the data lives, how to inspect snapshots, the `update-stack` call that restores from a snapshot (parameter-driven, no manual EBS surgery), RTO/RPO targets, the single-AZ exposure + manual cross-AZ procedure, and SSM session-manager access for keyless host shell.

### EBS volume is a first-class CFN resource (not a launch-template block device)

Important: the persistent EBS volume is declared as its own `AWS::EC2::Volume` resource with `DeletionPolicy: Snapshot` + `UpdateReplacePolicy: Snapshot`, **not** as a LaunchTemplate `BlockDeviceMapping`. UserData on each instance attaches it via `aws ec2 attach-volume` at boot. This pattern is necessary because LaunchTemplate block devices are tied to the EC2 instance's lifecycle — an ASG instance refresh would create a new volume and lose the SQLite database. With the volume as a separate resource, ASG replacement reattaches the same volume to the new host.

### Trade-offs (acknowledged)

- **Single-AZ availability.** EBS is zonal. The ASG + EBS + subnet are all pinned to `PublicSubnetA`'s AZ. If that AZ fails, the L2 is offline until manual cross-AZ restore (runbook documents the procedure). Multi-AZ + concurrent-writer-safe substrate (Postgres on RDS) is tracked as [#309](https://github.com/OneZero1ai/8th-layer-agent/issues/309) + [#311](https://github.com/OneZero1ai/8th-layer-agent/issues/311).
- **RPO=1h, RTO~10min.** Hourly snapshots. Litestream WAL streaming for sub-minute RPO is noted as a separate follow-up PR.
- **Cost delta: +~\$25/mo per L2.** t4g.small + 20 GiB gp3 + DLM snapshot storage. Acceptable for MVP design-partner scale.
- **Brief downtime during deploys.** Only one task can hold the SQLite file open at a time, so the deployment strategy is recreate (`MinHealthy=0 / Max=100`). The old task stops, releases its file locks, the new task starts. This is the same trade-off `customer-l2.yaml` already made; the marketplace template originally followed FO-2-backend spec for rolling, which the in-template comment flagged as the corruption window. Closing that window now.

### Migration plan — NOT in this PR

`mvp-s2-a` and `mvp-s2-b` are still on EFS-substrate stacks. Migrating them in place is operator-decision territory:

1. Destructive: detach EFS, attach new EBS, restore from a known-good DB dump.
2. Parallel: stand up a new EBS-substrate L2 alongside, replay state, DNS cutover.

Both have operational implications outside the template. This PR only updates the template + ships it to S3 via the existing `ci/buildspecs/marketplace-l2-publish.yml` CodeBuild publisher on merge to main. Operator runs the actual migration separately.

### Validation

- `cfn-lint deploy/aws/marketplace-l2.yaml` — clean. Only the two pre-existing `W2001` warnings on the `AwsRegion` / `ProvisionerExternalId` parameters (documentation-only, intentionally unused).
- `aws cloudformation validate-template` against the 8th-layer-app account — returns `CAPABILITY_IAM` as expected; no parse errors.

### Out of scope (do NOT confuse with this PR)

- agent#321 and #322 (sibling substrate findings) — separate PRs.
- mvp-s2 stack migration — operator decision after merge.
- Litestream upgrade — separate PR.
- Postgres / multi-AZ substrate — #309 / #311.

Closes #323

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)