### PR TITLE
feat(cli): rebrand version output to "8l v0.9.1 (8l-cq · ...)"

### DIFF
--- a/cli/internal/version/version.go
+++ b/cli/internal/version/version.go
@@ -16,6 +16,11 @@ func Version() string {
 }
 
 // String returns the full version string including commit and build date.
+//
+// The CLI is shipped as `8l` (the consumer-facing name) but the source
+// repository identifies as `8l-cq` (an 8th-Layer fork of the upstream
+// mozilla-ai/cq project). The fork identity is included for Apache-2.0
+// attribution context — see NOTICE in this directory.
 func String() string {
-	return fmt.Sprintf("cq v%s (%s), built %s", version, commit, date)
+	return fmt.Sprintf("8l v%s (8l-cq · %s · built %s)", version, commit, date)
 }

--- a/plugins/cq/scripts/bootstrap.json
+++ b/plugins/cq/scripts/bootstrap.json
@@ -1,3 +1,3 @@
 {
-  "cli_min_version": "0.9.0"
+  "cli_min_version": "0.9.1"
 }


### PR DESCRIPTION
Brand alignment: the CLI is shipped as `8l` (consumer-facing); the source repo identifies as `8l-cq` (8th-Layer fork of mozilla-ai/cq). The new `--version` string leads with the consumer brand and references the fork for Apache-2.0 attribution context.

```
Before:  cq v0.9.0 (47db70d), built 2026-05-15T10:12:03Z
After:   8l v0.9.1 (8l-cq · <sha> · built <date>)
```

## Changes

- `cli/internal/version/version.go` — version string format
- `plugins/cq/scripts/bootstrap.json` — `cli_min_version` bumped to `0.9.1` so existing plugin installs re-download

## Already shipped (deploy-side)

- Release artifacts for v0.9.1 uploaded to `s3://8l-cli-releases-124074140789-us-east-1/cli/v0.9.1/` (all 6 OS/arch combos, built locally from this branch).
- `install.8th-layer.ai` Worker updated to fetch v0.9.1.
- New `install.8th-layer.ai` endpoint live (Cloudflare Worker `eighth-layer-install`, route on Cloudflare zone `8th-layer.ai`).
- `s3://8l-cli-releases-124074140789-us-east-1/cli/*` made public-read via a scoped bucket policy (objects only; bucket-list still blocked).

## Backwards compatibility

The plugin's version parser (`cq_binary.py:parse_version`) is `re.search(r'(\d+\.\d+\.\d+)', output)` — pulls the first semver-shaped token. The new format contains `0.9.1` first, so parsing is unchanged.

## On merge

Tag `cli/v0.9.1` on the merge commit per `cli/RELEASING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)