### PR TITLE
feat(aigrp): admin peer-announce endpoint — close #337 directory escape hatch

### DIFF
--- a/docs/ops/peer-announce.md
+++ b/docs/ops/peer-announce.md
@@ -1,0 +1,158 @@
+# Manual peer announce — `POST /api/v1/admin/aigrp/peers`
+
+Escape hatch for direct-CFN and air-gapped L2 deploys that bypass the
+`directory.8th-layer.ai` poll loop. Lets a tenancy-scoped admin
+populate `aigrp_peers` directly so intra-Enterprise mesh ops have peer
+rows on L2s that never registered themselves with the directory.
+
+Closes the immediate substrate gap from
+[#337](https://github.com/OneZero1ai/8th-layer-agent/issues/337) —
+mvp-*, s4-ent-b and other direct-CFN deploys can now wire peer
+discovery by hand instead of waiting on the directory.
+
+## When to use this vs the directory
+
+| Path | Use when | Cost |
+|---|---|---|
+| `directory.8th-layer.ai` poll loop (primary) | The L2 has outbound HTTPS to `directory.8th-layer.ai` and the customer is OK with that runtime dependency | Zero — runs automatically on startup |
+| `POST /admin/aigrp/peers` (this endpoint, escape hatch) | Air-gapped / IL5 / federal / customer policy forbids the directory connection, or the directory is down and you need to unblock now | Admin must paste each peer manually; no auto-refresh |
+
+The two paths are not mutually exclusive — a row inserted by this
+endpoint is overwritten when the directory next pulls a matching record
+(directory's `signature_received=True` upsert wins on `last_signature_at`).
+
+## Scope — intra-Enterprise only
+
+This endpoint populates `aigrp_peers` (the intra-Enterprise mesh
+discovery table). It does **not** populate `aigrp_directory_peerings`
+(the cross-Enterprise offer/accept table). Cross-Enterprise peer
+insertion is intentionally refused with 422 because that table belongs
+to the bilateral peering protocol — an admin can't unilaterally
+fabricate one side of a peering.
+
+The caller's user-row `enterprise_id` must equal `body.enterprise`.
+
+## Request body
+
+```json
+{
+  "l2_id": "acme/sga",
+  "enterprise": "acme",
+  "group": "sga",
+  "endpoint_url": "https://sga.acme.example.com",
+  "pubkey": "<base64url-encoded Ed25519 public key>",
+  "embedding_centroid": [0.12, -0.04, 0.31, ...],
+  "domain_bloom": "<base64-encoded Bloom filter bytes>",
+  "ku_count": 1284,
+  "domain_count": 42,
+  "embedding_model": "sentence-transformers/all-MiniLM-L6-v2"
+}
+```
+
+Field notes:
+
+- **`l2_id`** must decompose to `<enterprise>/<group>` matching the
+  body's `enterprise` + `group` fields. The server rejects mismatches
+  with 422.
+- **`pubkey`** is base64url (no padding) of the peer's 32-byte Ed25519
+  public key. Stored verbatim in `aigrp_peers.public_key_ed25519` and
+  used by the legacy AIGRP forward path to verify peer-signed envelopes.
+- **`embedding_centroid`** is optional on first announce. When present,
+  the server packs the float list to little-endian float32 bytes
+  (byte-compatible with `aigrp._legacy.compute_centroid`'s output). Pass
+  `null` or omit when the peer hasn't computed its centroid yet —
+  semantic-routing fallback handles missing centroids.
+- **`domain_bloom`** is optional base64 of the peer's domain Bloom
+  filter. Non-base64-alphabet input is rejected with 422.
+- **`ku_count`** / **`domain_count`** are snapshots used for ranking
+  tie-breaks; default 0 is safe.
+
+## Auth
+
+`require_admin` — JWT bearer or `cq_session` cookie attached to a user
+whose role is in `_ADMIN_ROLES` (`admin` / `enterprise_admin` /
+`l2_admin`). Plus the tenancy gate: the caller's user-row
+`enterprise_id` must equal `body.enterprise`.
+
+## Response
+
+```json
+{
+  "l2_id": "acme/sga",
+  "enterprise": "acme",
+  "group": "sga",
+  "endpoint_url": "https://sga.acme.example.com",
+  "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
+  "ku_count": 1284,
+  "domain_count": 42,
+  "first_seen_at": "2026-05-20T14:33:01.123456+00:00",
+  "last_seen_at": "2026-05-20T14:33:01.123456+00:00",
+  "last_signature_at": "2026-05-20T14:33:01.123456+00:00",
+  "public_key_ed25519": "<base64url Ed25519 pubkey>",
+  "audit_id": "<32-hex audit id from cross_l2_audit>"
+}
+```
+
+The endpoint is idempotent — re-announcing the same `l2_id` upserts
+cleanly, anchoring `first_seen_at` to the original insert while
+`last_seen_at` / `last_signature_at` advance.
+
+Each successful announce writes a row to `cross_l2_audit` with
+`policy_applied='manual_peer_announce'`, distinguishable from
+directory-pulled rows for forensic review.
+
+## Receiver-side verification
+
+The receiving L2 trusts a manually-announced peer the same way it
+trusts a directory-pulled peer — by verifying signatures on inbound
+AIGRP envelopes against the cached `aigrp_peers.public_key_ed25519`.
+There is no extra round trip; the announce IS the key publication.
+
+That means the **admin pasting the announce is the trust anchor**. The
+operator must verify the peer's Ed25519 public key out-of-band before
+submitting (peer admin reads it off their L2's startup log; the
+receiving admin pastes it into this endpoint). This matches the
+threat-model premise behind the air-gapped escape hatch — when you
+disable the directory, you accept manual key distribution.
+
+## Example — curl
+
+```bash
+JWT=$(cat ~/.config/8l/admin.jwt)
+PEER_PUBKEY=$(ssh peer-l2 'cat /var/lib/cq/aigrp_pubkey.b64u')
+
+curl -sS -X POST https://l2.acme.example.com/api/v1/admin/aigrp/peers \
+  -H "authorization: Bearer ${JWT}" \
+  -H "content-type: application/json" \
+  -d @- <<JSON
+{
+  "l2_id": "acme/sga",
+  "enterprise": "acme",
+  "group": "sga",
+  "endpoint_url": "https://sga.acme.example.com",
+  "pubkey": "${PEER_PUBKEY}"
+}
+JSON
+```
+
+## What this PR does NOT close
+
+- **Cross-Enterprise consult on mvp-\* L2s** — the
+  `aigrp_directory_peerings` table (cross-Enterprise offer/accept rows)
+  is separate. That gap needs a follow-up that either (a) walks the
+  bilateral peering protocol manually or (b) adds a sibling escape
+  hatch for `aigrp_directory_peerings` with cryptographic safeguards
+  appropriate to cross-tenant trust. Tracked as a continuation of #337.
+- **L2 startup auto-announce** — the primary path improvement (have
+  every L2 announce itself to the directory on boot) is a separate
+  follow-up.
+
+## Refs
+
+- [#337](https://github.com/OneZero1ai/8th-layer-agent/issues/337) —
+  parent issue
+- [#322](https://github.com/OneZero1ai/8th-layer-agent/issues/322) —
+  Enterprise-scoped `AigrpPeerKey` (sibling concern: directory could
+  also distribute the peer key)
+- `server/backend/src/cq_server/aigrp_peer_routes.py` — implementation
+- `server/backend/tests/test_aigrp_peer_routes.py` — tests

--- a/server/backend/src/cq_server/aigrp_peer_routes.py
+++ b/server/backend/src/cq_server/aigrp_peer_routes.py
@@ -1,0 +1,292 @@
+"""Admin route — manual AIGRP peer announcement (agent#337).
+
+Endpoint:
+
+  POST /api/v1/admin/aigrp/peers
+
+Escape hatch for direct-CFN / air-gapped deploys that bypass the
+``directory_client.py`` poll loop. Lets a tenancy-scoped admin populate
+``aigrp_peers`` directly so intra-Enterprise mesh ops (semantic-centroid
+match, Bloom-domain filter, signed forward-query) have peer rows to work
+with on L2s that never registered themselves with ``directory.8th-layer.ai``.
+
+The directory poll loop remains the primary path; this endpoint is only
+invoked when the directory is unreachable or intentionally not wired
+(federal / IL5 / air-gapped customer postures per #337's two-tier deploy
+recommendation).
+
+Scope intent (per #337's body discussion):
+
+  * The body shape ``(l2_id, enterprise, group, endpoint_url, pubkey,
+    embedding_centroid?, domain_bloom?)`` matches the ``aigrp_peers``
+    table (intra-Enterprise peer mesh), NOT ``aigrp_directory_peerings``
+    (cross-Enterprise offer/accept). The latter has its own bilateral
+    proposal/cosign protocol — admin can't unilaterally fabricate one
+    side of a peering.
+  * The caller's Enterprise MUST equal ``body.enterprise``. Cross-
+    Enterprise peer insertion is intentionally refused (422) — those
+    rows belong to the bilateral peering protocol, not this escape
+    hatch.
+
+Auth: ``require_admin`` (FO-1c session cookie or bearer JWT) plus the
+defence-in-depth tenancy check via the user row's ``enterprise_id``.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import logging
+import struct
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from .auth import require_admin
+from .deps import get_store
+from .store._sqlite import SqliteStore
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/admin/aigrp/peers", tags=["admin", "aigrp"])
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class PeerAnnounceRequest(BaseModel):
+    """Inputs for the manual peer-announce endpoint.
+
+    ``embedding_centroid`` arrives as a list of floats (server packs to
+    little-endian float32 bytes; ``aigrp_peers.embedding_centroid`` is a
+    BLOB column). ``domain_bloom`` arrives as a base64-encoded byte
+    string. Both default to ``None`` for first-announce ergonomics — the
+    receiving L2 can refresh those fields on a subsequent announce once
+    the new peer has computed its own corpus stats.
+    """
+
+    l2_id: str = Field(min_length=3, max_length=128, description="Peer L2 in '<enterprise>/<group>' form")
+    enterprise: str = Field(min_length=1, max_length=64)
+    group: str = Field(min_length=1, max_length=64)
+    endpoint_url: str = Field(min_length=7, max_length=512, description="HTTPS URL of the peer L2")
+    pubkey: str = Field(min_length=1, max_length=128, description="Base64url-encoded Ed25519 public key")
+    embedding_centroid: list[float] | None = Field(default=None, description="Optional packed-on-server centroid")
+    domain_bloom: str | None = Field(default=None, description="Optional base64-encoded Bloom filter bytes")
+    ku_count: int = Field(default=0, ge=0, description="KU count snapshot at announce time")
+    domain_count: int = Field(default=0, ge=0, description="Distinct-domain count snapshot")
+    embedding_model: str | None = Field(default=None, max_length=128, description="Embedding model id the peer used")
+
+
+class PeerAnnounceResponse(BaseModel):
+    """The row that landed, plus the audit_id from ``cross_l2_audit``."""
+
+    l2_id: str
+    enterprise: str
+    group: str
+    endpoint_url: str
+    embedding_model: str | None
+    ku_count: int
+    domain_count: int
+    first_seen_at: str
+    last_seen_at: str
+    last_signature_at: str | None
+    public_key_ed25519: str | None
+    audit_id: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _pack_centroid(values: list[float] | None) -> bytes | None:
+    """Pack a float list into little-endian float32 BLOB bytes.
+
+    Mirrors ``aigrp._legacy.compute_centroid``'s output format so a
+    manually-announced centroid is byte-compatible with one computed
+    from the local KU corpus.
+    """
+    if values is None:
+        return None
+    if not values:
+        # Empty list is ambiguous — treat as "no centroid" rather than
+        # storing a zero-byte BLOB that the cosine-match path would
+        # mis-interpret.
+        return None
+    try:
+        return struct.pack(f"<{len(values)}f", *values)
+    except struct.error as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=422, detail=f"centroid pack failed: {exc}") from exc
+
+
+def _decode_bloom(b64: str | None) -> bytes | None:
+    """Decode base64 Bloom bytes; raise 422 on malformed input."""
+    if b64 is None:
+        return None
+    if not b64:
+        return None
+    try:
+        # Accept both standard and URL-safe base64; tolerate missing padding.
+        # ``validate=True`` rejects characters outside the base64 alphabet so
+        # malformed input lands a clean 422 instead of silently decoding to
+        # garbage bytes.
+        padded = b64 + "=" * (-len(b64) % 4)
+        return base64.b64decode(padded, validate=True)
+    except (ValueError, TypeError, binascii.Error) as exc:
+        raise HTTPException(status_code=422, detail=f"domain_bloom is not valid base64: {exc}") from exc
+
+
+def _validate_l2_id(l2_id: str, enterprise: str, group: str) -> None:
+    """Confirm ``l2_id`` parses as ``<enterprise>/<group>`` matching the body."""
+    if "/" not in l2_id:
+        raise HTTPException(
+            status_code=422,
+            detail=f"l2_id={l2_id!r} must be in '<enterprise>/<group>' form",
+        )
+    ent_part, grp_part = l2_id.split("/", 1)
+    if ent_part != enterprise or grp_part != group:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"l2_id={l2_id!r} must decompose to enterprise={enterprise!r} "
+                f"group={group!r}; got enterprise={ent_part!r} group={grp_part!r}"
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Route
+# ---------------------------------------------------------------------------
+
+
+@router.post("", response_model=PeerAnnounceResponse, status_code=201)
+async def announce_peer(
+    req: PeerAnnounceRequest,
+    admin: str = Depends(require_admin),
+    store: SqliteStore = Depends(get_store),
+) -> PeerAnnounceResponse:
+    """Insert (or refresh) one ``aigrp_peers`` row from a signed admin request.
+
+    Behaviour:
+
+    1. Validate the body's ``l2_id`` decomposes to the body's
+       ``enterprise`` + ``group``.
+    2. Tenancy gate — the caller's user-row ``enterprise_id`` must equal
+       the body's ``enterprise``. Defence-in-depth on top of
+       ``require_admin``; cross-Enterprise fabricated peers are refused
+       with 422 (those go through the bilateral peering protocol).
+    3. Upsert via ``store.upsert_aigrp_peer`` with
+       ``signature_received=True`` — the manual announce is treated as
+       a signed peer announcement because the admin has authenticated
+       with their bearer token and the inserted row carries the peer's
+       Ed25519 public key.
+    4. Audit-log to ``cross_l2_audit`` with
+       ``policy_applied='manual_peer_announce'`` so the manual route
+       leaves a forensic trail distinguishable from directory-pulled
+       rows.
+    5. Return the resulting row (via ``list_aigrp_peers``) so the admin
+       UI can confirm what landed.
+    """
+    _validate_l2_id(req.l2_id, req.enterprise, req.group)
+
+    user = await store.get_user(admin)
+    if user is None:
+        # Should be impossible after require_admin, but defensive.
+        raise HTTPException(status_code=401, detail="caller user row missing")
+    caller_enterprise = user.get("enterprise_id")
+    if caller_enterprise is None:
+        raise HTTPException(
+            status_code=403,
+            detail="caller user row has no enterprise_id; peer-announce requires a tenancy-scoped admin",
+        )
+    if caller_enterprise != req.enterprise:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"caller enterprise={caller_enterprise!r} does not match body enterprise={req.enterprise!r}; "
+                "cross-Enterprise peer insertion is refused — use the bilateral peering protocol"
+            ),
+        )
+
+    centroid_blob = _pack_centroid(req.embedding_centroid)
+    bloom_blob = _decode_bloom(req.domain_bloom)
+
+    await store.upsert_aigrp_peer(
+        l2_id=req.l2_id,
+        enterprise=req.enterprise,
+        group=req.group,
+        endpoint_url=req.endpoint_url,
+        embedding_centroid=centroid_blob,
+        domain_bloom=bloom_blob,
+        ku_count=req.ku_count,
+        domain_count=req.domain_count,
+        embedding_model=req.embedding_model,
+        signature_received=True,
+        public_key_ed25519=req.pubkey,
+    )
+
+    audit_id = uuid.uuid4().hex
+    now_iso = datetime.now(UTC).isoformat()
+    try:
+        await store.record_cross_l2_audit(
+            audit_id=audit_id,
+            ts=now_iso,
+            requester_l2_id=None,
+            requester_enterprise=req.enterprise,
+            requester_group=req.group,
+            requester_persona=admin,
+            responder_l2_id=req.l2_id,
+            responder_enterprise=req.enterprise,
+            responder_group=req.group,
+            policy_applied="manual_peer_announce",
+            result_count=1,
+            consent_id=None,
+        )
+    except Exception:  # pragma: no cover - audit-log failure must not break the upsert
+        log.exception(
+            "manual_peer_announce: audit-log insert failed for l2_id=%s admin=%s",
+            req.l2_id,
+            admin,
+        )
+
+    # Re-read the row we just wrote so the response reflects exactly
+    # what the DB sees (first_seen_at + last_signature_at populated by
+    # upsert_aigrp_peer, not by us).
+    peers = await store.list_aigrp_peers(req.enterprise)
+    landed: dict[str, Any] | None = next(
+        (p for p in peers if p.get("l2_id") == req.l2_id),
+        None,
+    )
+    if landed is None:  # pragma: no cover - we just inserted it
+        raise HTTPException(
+            status_code=500,
+            detail=f"peer row vanished after upsert: l2_id={req.l2_id!r}",
+        )
+
+    log.info(
+        "manual_peer_announce: l2_id=%s endpoint=%s admin=%s audit_id=%s",
+        req.l2_id,
+        req.endpoint_url,
+        admin,
+        audit_id,
+    )
+
+    return PeerAnnounceResponse(
+        l2_id=landed["l2_id"],
+        enterprise=landed["enterprise"],
+        group=landed["group"],
+        endpoint_url=landed["endpoint_url"],
+        embedding_model=landed.get("embedding_model"),
+        ku_count=landed.get("ku_count", 0) or 0,
+        domain_count=landed.get("domain_count", 0) or 0,
+        first_seen_at=landed["first_seen_at"],
+        last_seen_at=landed["last_seen_at"],
+        last_signature_at=landed.get("last_signature_at"),
+        public_key_ed25519=landed.get("public_key_ed25519"),
+        audit_id=audit_id,
+    )

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -28,6 +28,7 @@ from .activity_logger import log_activity, summary_first_60
 from .activity_routes import router as activity_router
 from .admin_routes import router as admin_xgroup_consent_router
 from .agent_key_routes import router as agent_key_router
+from .aigrp_peer_routes import router as aigrp_peer_router
 from .auth import get_current_user, require_admin
 from .auth import router as auth_router
 from .claim_page import router as claim_page_router
@@ -494,6 +495,10 @@ api_router.include_router(l2_provision_router)
 api_router.include_router(persona_router)
 # FO-4 (#194) — admin Add-Agent: mint agent persona + cqa.v1.* key.
 api_router.include_router(agent_key_router)
+# agent#337 — admin AIGRP peer-announce escape hatch (intra-Enterprise
+# mesh discovery for direct-CFN / air-gapped deploys that bypass the
+# directory poll loop).
+api_router.include_router(aigrp_peer_router)
 # FO-1d (#199) — anonymous /theme endpoint for the per-L2 brand chrome.
 # Mounted on api_router so it lives under both / and /api/v1, same as
 # every other API route. Decision 30 sets the spec.

--- a/server/backend/tests/test_aigrp_peer_routes.py
+++ b/server/backend/tests/test_aigrp_peer_routes.py
@@ -1,0 +1,254 @@
+"""HTTP-level tests for ``POST /api/v1/admin/aigrp/peers`` (agent#337).
+
+Covers:
+
+* Auth gating — non-admin caller gets 403.
+* Tenancy gate — admin in Enterprise A POSTing with ``enterprise=B``
+  is refused with 422 (cross-Enterprise insertion is reserved for the
+  bilateral peering protocol, not this escape hatch).
+* Happy path — 201, row landed in ``aigrp_peers``, response carries
+  the timestamps the upsert populated, ``cross_l2_audit`` row written
+  with ``policy_applied='manual_peer_announce'``.
+* Idempotent re-announce — same ``l2_id`` upserts cleanly; ``first_seen_at``
+  stays anchored to the original insert while ``last_seen_at`` advances.
+* Centroid + Bloom encoding — ``embedding_centroid`` floats packed to
+  little-endian float32 bytes; ``domain_bloom`` base64-decoded to BLOB.
+* L2-id decomposition — body's ``l2_id`` must equal
+  ``<enterprise>/<group>``; mismatched form is 422.
+"""
+
+from __future__ import annotations
+
+import base64
+import struct
+from collections.abc import Iterator
+from pathlib import Path
+
+import bcrypt
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from cq_server.app import _get_store, app
+
+ENT_A = "acme"
+ENT_B = "globex"
+GRP_A = "engineering"
+GRP_B = "engineering"
+
+ADMIN_A = "admin@acme"
+ADMIN_B = "admin@globex"
+NON_ADMIN = "regular@acme"
+PASSWORD = "password123!"  # pragma: allowlist secret
+
+PEER_L2 = f"{ENT_A}/sga"
+PEER_ENDPOINT = "https://sga.acme.example.com"
+# Realistic Ed25519 pubkey shape — 32 bytes of zeros base64url-encoded.
+PEER_PUBKEY_B64U = base64.urlsafe_b64encode(b"\x00" * 32).rstrip(b"=").decode()
+
+
+@pytest.fixture
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "aigrp_peers.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    with TestClient(app) as c:
+        store = _get_store()
+        pw = bcrypt.hashpw(PASSWORD.encode(), bcrypt.gensalt()).decode()
+        store.sync.create_user(ADMIN_A, pw)
+        store.sync.create_user(ADMIN_B, pw)
+        store.sync.create_user(NON_ADMIN, pw)
+        store.sync.set_user_role(ADMIN_A, "admin")
+        store.sync.set_user_role(ADMIN_B, "admin")
+        # Tenancy assignment — mirror the xgroup_consent test pattern.
+        with store._engine.begin() as conn:  # noqa: SLF001
+            conn.execute(
+                text("UPDATE users SET enterprise_id = :e, group_id = :g WHERE username = :u"),
+                {"e": ENT_A, "g": GRP_A, "u": ADMIN_A},
+            )
+            conn.execute(
+                text("UPDATE users SET enterprise_id = :e, group_id = :g WHERE username = :u"),
+                {"e": ENT_B, "g": GRP_B, "u": ADMIN_B},
+            )
+            conn.execute(
+                text("UPDATE users SET enterprise_id = :e, group_id = :g WHERE username = :u"),
+                {"e": ENT_A, "g": GRP_A, "u": NON_ADMIN},
+            )
+        yield c
+
+
+def _login(client: TestClient, username: str) -> dict[str, str]:
+    resp = client.post(
+        "/api/v1/auth/login",
+        json={"username": username, "password": PASSWORD},
+    )
+    assert resp.status_code == 200, resp.text
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
+def _valid_body(**over: object) -> dict[str, object]:
+    body: dict[str, object] = {
+        "l2_id": PEER_L2,
+        "enterprise": ENT_A,
+        "group": "sga",
+        "endpoint_url": PEER_ENDPOINT,
+        "pubkey": PEER_PUBKEY_B64U,
+        "ku_count": 0,
+        "domain_count": 0,
+    }
+    body.update(over)
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Auth gating
+# ---------------------------------------------------------------------------
+
+
+def test_non_admin_gets_403(client: TestClient) -> None:
+    headers = _login(client, NON_ADMIN)
+    resp = client.post("/api/v1/admin/aigrp/peers", headers=headers, json=_valid_body())
+    assert resp.status_code == 403, resp.text
+
+
+def test_unauthenticated_gets_401(client: TestClient) -> None:
+    resp = client.post("/api/v1/admin/aigrp/peers", json=_valid_body())
+    assert resp.status_code == 401, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Tenancy gate
+# ---------------------------------------------------------------------------
+
+
+def test_cross_enterprise_insertion_is_422(client: TestClient) -> None:
+    """Admin in Enterprise A cannot announce a peer in Enterprise B."""
+    headers = _login(client, ADMIN_A)
+    body = _valid_body(
+        l2_id=f"{ENT_B}/sga",
+        enterprise=ENT_B,
+        group="sga",
+    )
+    resp = client.post("/api/v1/admin/aigrp/peers", headers=headers, json=body)
+    assert resp.status_code == 422, resp.text
+    assert "cross-Enterprise peer insertion is refused" in resp.json()["detail"]
+
+
+def test_l2_id_must_decompose_to_enterprise_group(client: TestClient) -> None:
+    headers = _login(client, ADMIN_A)
+    body = _valid_body(l2_id=f"{ENT_A}/research")  # group mismatch
+    resp = client.post("/api/v1/admin/aigrp/peers", headers=headers, json=body)
+    assert resp.status_code == 422, resp.text
+    assert "decompose" in resp.json()["detail"]
+
+
+def test_l2_id_without_slash_is_422(client: TestClient) -> None:
+    headers = _login(client, ADMIN_A)
+    body = _valid_body(l2_id="acme-sga")
+    resp = client.post("/api/v1/admin/aigrp/peers", headers=headers, json=body)
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_announce_happy_path_lands_row_and_audit(client: TestClient) -> None:
+    headers = _login(client, ADMIN_A)
+    resp = client.post("/api/v1/admin/aigrp/peers", headers=headers, json=_valid_body())
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+
+    assert body["l2_id"] == PEER_L2
+    assert body["enterprise"] == ENT_A
+    assert body["group"] == "sga"
+    assert body["endpoint_url"] == PEER_ENDPOINT
+    assert body["public_key_ed25519"] == PEER_PUBKEY_B64U
+    # Upsert populates both first_seen and last_signature_at (signature_received=True).
+    assert body["first_seen_at"]
+    assert body["last_seen_at"]
+    assert body["last_signature_at"]
+    assert body["audit_id"]
+
+    # DB-level confirmation — the row is queryable via the store API.
+    store = _get_store()
+    peers = store.sync.list_aigrp_peers(ENT_A)
+    assert any(p["l2_id"] == PEER_L2 for p in peers)
+
+    # Audit-log row landed with the manual policy tag.
+    with store._engine.connect() as conn:  # noqa: SLF001
+        rows = conn.execute(
+            text("SELECT policy_applied, responder_l2_id, requester_persona FROM cross_l2_audit WHERE audit_id = :id"),
+            {"id": body["audit_id"]},
+        ).fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] == "manual_peer_announce"
+    assert rows[0][1] == PEER_L2
+    assert rows[0][2] == ADMIN_A
+
+
+def test_announce_packs_centroid_and_decodes_bloom(client: TestClient) -> None:
+    headers = _login(client, ADMIN_A)
+    centroid = [0.5, 0.25, -0.125, 0.0]
+    bloom_bytes = b"\x01\x02\x03\x04\x05"
+    bloom_b64 = base64.b64encode(bloom_bytes).decode()
+    body = _valid_body(
+        embedding_centroid=centroid,
+        domain_bloom=bloom_b64,
+        embedding_model="test-embedder/v1",
+        ku_count=12,
+        domain_count=4,
+    )
+    resp = client.post("/api/v1/admin/aigrp/peers", headers=headers, json=body)
+    assert resp.status_code == 201, resp.text
+
+    store = _get_store()
+    peers = store.sync.list_aigrp_peers(ENT_A)
+    row = next(p for p in peers if p["l2_id"] == PEER_L2)
+    # Centroid round-trips through little-endian float32.
+    assert row["embedding_centroid"] == struct.pack("<4f", *centroid)
+    assert row["domain_bloom"] == bloom_bytes
+    assert row["embedding_model"] == "test-embedder/v1"
+    assert row["ku_count"] == 12
+    assert row["domain_count"] == 4
+
+
+def test_invalid_bloom_base64_is_422(client: TestClient) -> None:
+    """Non-alphabet chars in ``domain_bloom`` land a clean 422.
+
+    ``validate=True`` on ``base64.b64decode`` rejects characters outside
+    the base64 alphabet — guards against admins pasting raw bytes into
+    a field that the receiver will treat as a Bloom filter.
+    """
+    headers = _login(client, ADMIN_A)
+    body = _valid_body(domain_bloom="!!!not-base64!!!@@@")
+    resp = client.post("/api/v1/admin/aigrp/peers", headers=headers, json=body)
+    assert resp.status_code == 422, resp.text
+    assert "domain_bloom" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_announce_is_idempotent_keeps_first_seen(client: TestClient) -> None:
+    headers = _login(client, ADMIN_A)
+    first = client.post("/api/v1/admin/aigrp/peers", headers=headers, json=_valid_body())
+    assert first.status_code == 201, first.text
+    first_seen_initial = first.json()["first_seen_at"]
+
+    # Re-announce with the same l2_id; endpoint URL change should land
+    # but first_seen_at must remain anchored.
+    body2 = _valid_body(endpoint_url="https://sga-v2.acme.example.com")
+    second = client.post("/api/v1/admin/aigrp/peers", headers=headers, json=body2)
+    assert second.status_code == 201, second.text
+    j2 = second.json()
+    assert j2["first_seen_at"] == first_seen_initial
+    assert j2["endpoint_url"] == "https://sga-v2.acme.example.com"
+
+    # Only one row, not two.
+    store = _get_store()
+    peers = [p for p in store.sync.list_aigrp_peers(ENT_A) if p["l2_id"] == PEER_L2]
+    assert len(peers) == 1


### PR DESCRIPTION
## What

New admin endpoint `POST /api/v1/admin/aigrp/peers` that populates
`aigrp_peers` directly. Closes the manual-escape-hatch sub-task in #337
so direct-CFN deploys (mvp-*, s4-ent-b, federal/IL5 postures) can wire
intra-Enterprise peer discovery without depending on
`directory.8th-layer.ai`.

## Why

The directory poll loop is the primary path for peer-row population,
but direct-CFN deploys don't talk to the directory by default. Without
peer rows, the AIGRP mesh (semantic-centroid match, Bloom-domain
filter, signed forward-query) has nothing to route against on those
L2s. #337 proposes both directory-default + a manual admin endpoint
for air-gapped customers; this PR ships the manual endpoint.

## Endpoint signature

```
POST /api/v1/admin/aigrp/peers
Authorization: Bearer <admin JWT>   (or cq_session cookie)
Content-Type: application/json

{
  "l2_id": "acme/sga",
  "enterprise": "acme",
  "group": "sga",
  "endpoint_url": "https://sga.acme.example.com",
  "pubkey": "<base64url Ed25519 public key>",
  "embedding_centroid": [0.12, -0.04, ...],   // optional
  "domain_bloom": "<base64 bytes>",           // optional
  "ku_count": 1284,                             // default 0
  "domain_count": 42,                           // default 0
  "embedding_model": "..."                    // optional
}
```

Returns 201 + the row that landed (including timestamps from the
upsert) plus the `audit_id` from the `cross_l2_audit` entry.

## Auth model

- `require_admin` (FO-1c session cookie or JWT bearer; admin /
  enterprise_admin / l2_admin roles per `_ADMIN_ROLES`).
- Tenancy defence-in-depth — the caller's user-row `enterprise_id`
  must equal `body.enterprise`. Cross-Enterprise insertion is refused
  with 422 because cross-Enterprise rows live in
  `aigrp_directory_peerings` (bilateral peering protocol), not
  `aigrp_peers`.

## Scope decision (worth noting)

The issue body says 'inserts into `aigrp_directory_peerings`', but the
proposed body shape (`l2_id, enterprise, group, endpoint_url, pubkey`)
maps to `aigrp_peers` (intra-Enterprise mesh), NOT
`aigrp_directory_peerings` (cross-Enterprise offer/accept). The spawn
brief explicitly resolved this ambiguity in favour of `aigrp_peers`
(intra-Enterprise peer discovery as substitute for the directory),
with the caller's Enterprise gated against the body's Enterprise.

That means this PR does NOT directly unblock cross-Enterprise consult
on mvp-* L2s — the `x-enterprise-forward-request` path still queries
`aigrp_directory_peerings` via `find_active_directory_peering`.
Closing that gap needs a sibling endpoint (or manual driving of the
bilateral peering protocol) with stronger cryptographic safeguards
appropriate to cross-tenant trust. Tracked as a continuation of #337.

## Audit trail

Each successful announce writes a `cross_l2_audit` row with
`policy_applied='manual_peer_announce'` so manually-inserted peers
stay forensically distinguishable from directory-pulled rows. An
audit-log write failure is logged and swallowed (does not break the
upsert response).

## Files

- `server/backend/src/cq_server/aigrp_peer_routes.py` — new router
- `server/backend/src/cq_server/app.py` — wire the router under `/api/v1`
- `server/backend/tests/test_aigrp_peer_routes.py` — 9 new tests
- `docs/ops/peer-announce.md` — operator runbook

## Tests

`server/backend/tests/test_aigrp_peer_routes.py` — 9 tests, all green:

- Auth: non-admin → 403; unauthenticated → 401
- Tenancy: cross-Enterprise body → 422
- Validation: `l2_id` must decompose to `<enterprise>/<group>`; mismatch → 422
- Validation: malformed base64 `domain_bloom` → 422
- Happy path: 201, row landed in `aigrp_peers`, audit row written
- Encoding: centroid packs to LE float32 bytes; Bloom decodes from base64
- Idempotency: re-announce same `l2_id` upserts cleanly; `first_seen_at` stays anchored

Full backend suite remains green (944 passed, 5 skipped, 7 warnings).

## Out of scope

- Cross-Enterprise peer manual insert (`aigrp_directory_peerings`) —
  follow-up; needs cross-tenant trust model spelled out.
- L2 startup auto-announce to the directory — separate follow-up
  (improves the primary path, doesn't change this escape hatch).
- #322 (Enterprise-scoped `AigrpPeerKey`) — left untouched per brief.

## Refs

- Issue: #337
- Sibling concern: #322
- Receiver-side verification: see `docs/ops/peer-announce.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)