### PR TITLE
feat(aigrp): admin cross-Enterprise directory-peering announce (agent#347)

### DIFF
--- a/docs/decisions/35-aigrp-directory-peering-concurrent-writers.md
+++ b/docs/decisions/35-aigrp-directory-peering-concurrent-writers.md
@@ -1,0 +1,162 @@
+# 35 — `aigrp_directory_peerings` concurrent writers + lock boundary
+
+**Status**: accepted
+**Date**: 2026-05-20
+**Drives**: #346 concern 3 (post-EBS migration write contention)
+**Touches**: #327 (EBS swap), #347 / PR #349 (Option-A admin endpoint),
+`directory_client._sync_peerings` (Option-B-shaped poll loop),
+`forward_sign.py` (no-write verifier — listed here for completeness).
+
+## Context
+
+PR #349 adds `POST /api/v1/admin/aigrp/directory-peerings` — the manual
+"Option A" cross-Enterprise peer-announce escape hatch for direct-CFN
+and air-gapped L2s. Concern 3 of issue #346 noted that the
+`aigrp_directory_peerings` table is now written by multiple
+concurrent paths post-EBS migration, and asked for explicit ordering /
+isolation guidance.
+
+This note codifies the answer.
+
+## Writers
+
+There are three logical writers contending for the table; in practice
+two of them share a single function call (`directory_client` is the
+on-L2 writer for the bilateral signed flow). All run inside the same
+Python process, against the same SQLite file mounted on EBS.
+
+| ID  | Writer                                                                | Trigger                          | `offer_id` shape                    | Verifies signatures? |
+| --- | --------------------------------------------------------------------- | -------------------------------- | ----------------------------------- | -------------------- |
+| (a) | `aigrp_directory_peer_routes.announce_directory_peering` (this PR)    | Admin HTTP call                  | `manual:<from>:<to>:<l2_id>`        | No — admin is anchor |
+| (b) | `directory_client._sync_peerings` (Option-B / bilateral signed)       | Periodic poll loop               | Directory-assigned UUID-shaped id   | Yes (offer + accept) |
+| (c) | "The bilateral signed flow"                                           | (same as (b) on this L2)         | (same as (b))                       | (same as (b))        |
+
+(c) is not a distinct on-L2 writer — the bilateral envelopes are
+verified and ingested by (b) during the directory pull. The
+`forward_sign.py` module only verifies signatures; it never writes
+peering rows. We list it as a separate row in issue #346's
+enumeration because conceptually the *flow* (offer/accept) is
+distinct from the *transport* (directory poll), but on this codebase
+both collapse into (b)'s `store.upsert_directory_peering` call site.
+
+## Conflict resolution
+
+Both (a) and (b) call `store.upsert_directory_peering`, which under
+the hood runs:
+
+```sql
+INSERT INTO aigrp_directory_peerings (...) VALUES (...)
+ON CONFLICT(offer_id) DO UPDATE SET ...
+```
+
+inside a single `self._engine.begin()` block (see
+`_upsert_directory_peering_sync` in `store/_sqlite.py`).
+
+The natural-key collision space is small because:
+
+- (a) emits `offer_id = manual:<from>:<to>:<l2_id>` — synthetic,
+  deterministic, idempotent on the natural key.
+- (b) emits the directory service's UUID-shaped `offer_id` — never
+  starts with `manual:`.
+
+So an upsert from (a) and an upsert from (b) for the same *logical*
+`(from_enterprise, to_enterprise)` peer pair land in **distinct
+rows** with **distinct primary keys**. The
+`find_active_directory_peering` reader applies
+`status = 'active' AND expires_at > now`, then orders by
+`active_from DESC LIMIT 1` — the most recent active row wins
+regardless of which writer produced it.
+
+### Why UPSERT, not straight INSERT
+
+Concern 3 raised the question of which the admin endpoint should
+use. We use UPSERT for both writers because:
+
+1. **Re-paste idempotency.** Straight INSERT would 409 on the second
+   paste of the same announce (deterministic `offer_id` collision).
+   That breaks the operator UX — pasting again should refresh
+   `expires_at`, not error.
+2. **Symmetry with the directory poll loop.** (b) already uses
+   UPSERT (it has to — the same directory record gets re-pulled on
+   every cycle). Keeping (a) on the same primitive simplifies
+   reasoning about the two writers.
+3. **Last-write-wins is correct here.** Both writers carry full
+   row state on every call; there is no partial-update pattern.
+
+### Manual-row → signed-row precedence
+
+If (a) lands first (admin pastes a peer ahead of the directory
+catching up) and (b) later returns a real signed peering for the
+same `(from, to)`, both rows coexist with different `offer_id`
+PKs. The reader's `ORDER BY active_from DESC LIMIT 1` picks the
+most-recently-active row.
+
+In practice (b)'s `active_from` will be later than (a)'s, so the
+signed row wins as soon as the directory catches up. The manual
+row expires after its TTL (default 30 days) and drops out of the
+`WHERE expires_at > now` filter — no GC cycle needed.
+
+If for some reason (a) is pasted *after* (b)'s row, the manual row
+overrides the signed row until either re-pull or expiry. That's
+the cost of having an admin escape hatch — explicitly documented
+in `docs/ops/peer-announce.md` under the trust caveat.
+
+## Isolation model (SQLite WAL on EBS, post-#327)
+
+SQLite WAL allows N readers + 1 writer concurrently. Writers
+serialise on the database-wide lock:
+`BEGIN IMMEDIATE` → RESERVED → PENDING → EXCLUSIVE during commit.
+
+Both (a) and (b) hit the same `engine.begin()` boundary, so their
+upserts cannot interleave at statement granularity — one fully
+commits before the other starts. SQLite has no row-level locking;
+the unit of mutual exclusion is the whole database file.
+
+This is intentional. The table is small (O(10s of rows per L2)),
+write throughput is low (admin paste + periodic directory poll),
+and a single global writer lock is well within budget. We do not
+need MVCC or row-level locks for this workload.
+
+### EBS vs EFS distinction (#327)
+
+The original `aigrp_peers` corruption event (#323 / #324) was
+caused by EFS's loose fsync semantics breaking WAL ordering
+guarantees. The fix in #327 swapped the L2 substrate to
+EBS-on-EC2 with DLM snapshots; EBS preserves the POSIX fsync
+contract that WAL requires.
+
+With EBS the lock-boundary analysis above holds. With EFS it did
+not — writes could appear to commit, then be lost if the EFS
+server rolled back, leaving in-memory state and on-disk state
+divergent. We are no longer exposed to that mode on the L2 path.
+
+The DR target (jump-server) still uses EBS — same isolation
+guarantees.
+
+## What this note does not cover
+
+- Cross-process contention. There is one cq-server process per L2;
+  in-process concurrency is the only mode that matters.
+- Cross-L2 contention. Each L2 has its own SQLite file; rows in
+  one L2's `aigrp_directory_peerings` are independent of another
+  L2's.
+- The intra-Enterprise `aigrp_peers` table (PR #345). That table
+  has the same writer model — admin endpoint + directory poll loop
+  — and the same WAL isolation analysis applies. We do not
+  duplicate the note for it; refer here.
+
+## References
+
+- Issue #346 — concern 3 raised this gap
+- PR #349 — the Option-A endpoint this note documents
+- Issue #347 — parent (Option A path design)
+- PR #345 — intra-Enterprise sibling (same write model on
+  `aigrp_peers`)
+- Issue #327 — EBS swap that fixed the WAL fsync ordering
+- Issues #323 / #324 — the EFS corruption event that motivated #327
+- `server/backend/src/cq_server/aigrp_directory_peer_routes.py` —
+  the admin endpoint (writer (a))
+- `server/backend/src/cq_server/directory_client.py:_sync_peerings`
+  — the directory poll loop (writer (b))
+- `server/backend/src/cq_server/store/_sqlite.py:_upsert_directory_peering_sync`
+  — the shared transaction boundary both writers share

--- a/docs/ops/peer-announce.md
+++ b/docs/ops/peer-announce.md
@@ -1,4 +1,18 @@
-# Manual peer announce — `POST /api/v1/admin/aigrp/peers`
+# Manual peer announce — admin escape hatches
+
+Two endpoints — sibling escape hatches for direct-CFN and air-gapped
+L2 deploys that bypass the `directory.8th-layer.ai` poll loop:
+
+| Endpoint | Populates | Scope |
+|---|---|---|
+| `POST /api/v1/admin/aigrp/peers` (#337) | `aigrp_peers` | Intra-Enterprise mesh discovery |
+| `POST /api/v1/admin/aigrp/directory-peerings` (#347) | `aigrp_directory_peerings` | Cross-Enterprise consult-forward wiring |
+
+The first half of this doc covers the intra-Enterprise endpoint; the
+[cross-Enterprise sibling section](#cross-enterprise-sibling--post-apiv1adminaigrpdirectory-peerings)
+covers the cross-Enterprise one.
+
+## Intra-Enterprise — `POST /api/v1/admin/aigrp/peers`
 
 Escape hatch for direct-CFN and air-gapped L2 deploys that bypass the
 `directory.8th-layer.ai` poll loop. Lets a tenancy-scoped admin
@@ -135,24 +149,180 @@ curl -sS -X POST https://l2.acme.example.com/api/v1/admin/aigrp/peers \
 JSON
 ```
 
-## What this PR does NOT close
+## Cross-Enterprise sibling — `POST /api/v1/admin/aigrp/directory-peerings`
 
-- **Cross-Enterprise consult on mvp-\* L2s** — the
-  `aigrp_directory_peerings` table (cross-Enterprise offer/accept rows)
-  is separate. That gap needs a follow-up that either (a) walks the
-  bilateral peering protocol manually or (b) adds a sibling escape
-  hatch for `aigrp_directory_peerings` with cryptographic safeguards
-  appropriate to cross-tenant trust. Tracked as a continuation of #337.
+The endpoint above (`/admin/aigrp/peers`) populates `aigrp_peers` for
+**intra-Enterprise** mesh discovery. The cross-Enterprise sibling —
+shipped under [#347](https://github.com/OneZero1ai/8th-layer-agent/issues/347) — is
+`POST /api/v1/admin/aigrp/directory-peerings` and populates
+`aigrp_directory_peerings`, the table the cross-Enterprise
+consult-forward path (`/api/v1/consults/x-enterprise-forward-request`)
+reads via `find_active_directory_peering`.
+
+This is **Option A** from the #347 issue body — manual paste of the
+peer's announce data, single admin as trust anchor. **Option B** (the
+bilateral offer/accept signed-envelope protocol that
+`directory.8th-layer.ai` runs) remains the long-term answer and
+co-exists with this endpoint — a row inserted here is overwritten on
+the next directory pull that returns the same `(from_enterprise,
+to_enterprise)` pair under a proper signed peering.
+
+### Request body
+
+```json
+{
+  "l2_id": "globex/sga",
+  "enterprise": "globex",
+  "group": "sga",
+  "endpoint_url": "https://sga.globex.example.com",
+  "pubkey": "<base64url-encoded Ed25519 public key>",
+  "aaisn": "AS-65500",
+  "embedding_centroid": [0.12, -0.04, 0.31, ...],
+  "domain_bloom": "<base64-encoded Bloom filter bytes>",
+  "ku_count": 1284,
+  "domain_count": 42,
+  "embedding_model": "sentence-transformers/all-MiniLM-L6-v2",
+  "ttl_days": 30
+}
+```
+
+Field notes:
+
+- **`enterprise`** MUST be **different** from the caller's resolved
+  tenancy (this is the cross-Enterprise endpoint). Same-Enterprise
+  paste is rejected with 422 and a pointer to `/admin/aigrp/peers`.
+  The sentinel `default-enterprise` is also rejected — it catches
+  misconfigured L2s where tenancy was never bound.
+- **`l2_id`** must decompose to `<enterprise>/<group>` matching the
+  body's `enterprise` + `group` fields. Mismatches are 422.
+- **`pubkey`** is base64url (no padding) of the peer L2's 32-byte
+  Ed25519 public key. Stored verbatim and carried in both the
+  `offer_signing_key_id` and `accept_signing_key_id` slots of the
+  `aigrp_directory_peerings` row.
+- **`aaisn`** is optional. The peering schema has no `aaisn` column,
+  so the value rides along inside `to_l2_endpoints_json[0].aaisn`
+  where future consumers can find it without a migration. Pubkey is
+  the security anchor anyway — AAISN is human-readable provenance.
+- **`embedding_centroid`** / **`domain_bloom`** are accepted for
+  forward-compat and stowed inside the endpoint roster entry. The
+  current `aigrp_directory_peerings` consumers don't read them, but
+  populating them now means the value survives if a later schema
+  migration pulls them into dedicated columns.
+- **`ttl_days`** overrides the default 30-day TTL (1..365). After the
+  TTL expires the row drops out of `find_active_directory_peering` and
+  the consult forward 422s with an honest "no peering" rather than
+  silently using stale data — re-paste to refresh.
+
+### What lands in the row
+
+The schema was designed around the offer/accept signed-envelope shape,
+but a manual announce has no signed envelope. The bridge:
+
+| Column | Manual-row value |
+|---|---|
+| `offer_id` | Deterministic — `manual:<from>:<to>:<l2_id>` — so re-paste is idempotent on the same `(from, to, l2_id)` triple |
+| `from_enterprise` | Caller's resolved tenancy |
+| `to_enterprise` | Body's `enterprise` |
+| `status` | `'active'` |
+| `content_policy` / `consult_logging_policy` | `'manual'` — sentinel for "no signed policy"; consumers can distinguish manual from directory-pulled rows |
+| `topic_filters_json` | `'[]'` |
+| `active_from` | Now |
+| `expires_at` | Now + `ttl_days` (default 30 days) |
+| `offer_payload_canonical` / `accept_payload_canonical` | Synthesized provenance JSON (admin persona, ts, source tag) — **not signed**; consumers must check `content_policy='manual'` before attempting to verify |
+| `offer_signature_b64u` / `accept_signature_b64u` | Empty string |
+| `offer_signing_key_id` / `accept_signing_key_id` | Body's `pubkey` |
+| `to_l2_endpoints_json` | One-entry list `[{l2_id, endpoint_url, pubkey, aaisn?, ...}]` — the exact shape `consults._resolve_x_enterprise_target` reads |
+| `last_synced_at` | Now |
+
+### Auth
+
+`require_admin` — same as the intra-Enterprise endpoint. The body's
+`enterprise` field MUST be different from the caller's resolved
+tenancy.
+
+### Trust caveat
+
+**The admin pasting the announce IS the trust anchor.** There is no
+callback verification of the announced pubkey, no co-signature check,
+no out-of-band attestation. The receiving L2 will treat the pasted
+Ed25519 pubkey as authoritative for the named peer L2 on every
+subsequent consult forward.
+
+That's the right trade-off for direct-CFN / federal / air-gapped
+deploys — the operator who has admin on this L2 already has the
+authority to flip every other security-relevant knob. But: out-of-band
+verification of the peer's pubkey **before** pasting is mandatory.
+Peer admin reads it off their L2's startup log; receiving admin
+pastes it into this endpoint.
+
+When to step up to Option B (the bilateral signed-envelope protocol
+the directory client runs): when the deploy can reach
+`directory.8th-layer.ai`, or when the customer's threat model
+requires the cross-signed evidence trail rather than a single admin's
+paste. Option B isn't shipped on direct-CFN deploys yet (the
+directory client polls a public endpoint), so for mvp-* / s4-ent-b
+this Option-A path is the only way to wire cross-Enterprise consult
+forward.
+
+### Example — curl
+
+```bash
+JWT=$(cat ~/.config/8l/admin.jwt)
+# Peer admin reads these off their L2's startup log and emails them over.
+PEER_PUBKEY="..."          # base64url Ed25519 pubkey
+PEER_ENDPOINT="https://sga.globex.example.com"
+PEER_AAISN="AS-65500"
+
+curl -sS -X POST https://l2.acme.example.com/api/v1/admin/aigrp/directory-peerings \
+  -H "authorization: Bearer ${JWT}" \
+  -H "content-type: application/json" \
+  -d @- <<JSON
+{
+  "l2_id": "globex/sga",
+  "enterprise": "globex",
+  "group": "sga",
+  "endpoint_url": "${PEER_ENDPOINT}",
+  "pubkey": "${PEER_PUBKEY}",
+  "aaisn": "${PEER_AAISN}"
+}
+JSON
+```
+
+The response carries the synthesized `offer_id`, the `active_from` /
+`expires_at` window, and the audit_id from `cross_l2_audit`
+(`policy_applied='manual_directory_peer_announce'`).
+
+### Drift items this unblocks
+
+Closes 4 of 6 drift items in
+[#343](https://github.com/OneZero1ai/8th-layer-agent/issues/343) for
+mvp-* / direct-CFN substrates: `aigrp`, `dsn-intro`, `dsn-reveal`,
+`consented-query`. Each was failing at the
+`find_active_directory_peering` lookup; with this endpoint, an admin
+paste lands the row and the forward path completes.
+
+## What these PRs do NOT close
+
 - **L2 startup auto-announce** — the primary path improvement (have
   every L2 announce itself to the directory on boot) is a separate
   follow-up.
+- **Option B for direct-CFN deploys** — wiring the bilateral
+  signed-envelope protocol on L2s that can't reach the directory is
+  separate work. The current direction is "Option A unblocks the
+  forward path; Option B is a future hardening pass."
 
 ## Refs
 
 - [#337](https://github.com/OneZero1ai/8th-layer-agent/issues/337) —
-  parent issue
+  parent issue for the intra-Enterprise endpoint
+- [#347](https://github.com/OneZero1ai/8th-layer-agent/issues/347) —
+  cross-Enterprise sibling (Option A path)
+- [#343](https://github.com/OneZero1ai/8th-layer-agent/issues/343) —
+  mvp-* drift items the cross-Enterprise endpoint unblocks
 - [#322](https://github.com/OneZero1ai/8th-layer-agent/issues/322) —
   Enterprise-scoped `AigrpPeerKey` (sibling concern: directory could
   also distribute the peer key)
-- `server/backend/src/cq_server/aigrp_peer_routes.py` — implementation
-- `server/backend/tests/test_aigrp_peer_routes.py` — tests
+- `server/backend/src/cq_server/aigrp_peer_routes.py` — intra-Enterprise impl
+- `server/backend/src/cq_server/aigrp_directory_peer_routes.py` — cross-Enterprise impl
+- `server/backend/tests/test_aigrp_peer_routes.py` — intra-Enterprise tests
+- `server/backend/tests/test_aigrp_directory_peer_routes.py` — cross-Enterprise tests

--- a/server/backend/src/cq_server/aigrp_directory_peer_routes.py
+++ b/server/backend/src/cq_server/aigrp_directory_peer_routes.py
@@ -1,0 +1,487 @@
+"""Admin route — manual cross-Enterprise directory-peering announce (agent#347).
+
+Endpoint:
+
+  POST /api/v1/admin/aigrp/directory-peerings
+
+The cross-Enterprise sibling of ``POST /admin/aigrp/peers`` (agent#337,
+PR #345). Where that endpoint populates ``aigrp_peers`` for the
+intra-Enterprise mesh, **this** endpoint populates
+``aigrp_directory_peerings`` for the cross-Enterprise consult-forward
+path (``/api/v1/consults/x-enterprise-forward-request``).
+
+Until #347 lands, mvp-* / direct-CFN deploys that have no path to
+``directory.8th-layer.ai`` cannot cross-forward consults at all — the
+``find_active_directory_peering(from, to)`` lookup returns nothing, the
+consult resolver short-circuits, and the request 422s. With this
+endpoint, an L2 admin can paste in a peer Enterprise's announce data
+(peer L2 id, endpoint, Ed25519 pubkey, optional AAISN) and the
+peering row lands, unblocking the forward.
+
+## Option-A (manual paste) vs Option-B (bilateral signed envelopes)
+
+This is the Option-A path from the #347 issue body — a single admin
+manually announcing the peer's published data. Trust anchor is the
+admin who pasted it; there is no callback / co-signature check.
+
+Option-B (the bilateral offer/accept signed-envelope protocol, mirrored
+by the directory poll loop) is the long-term answer. The directory
+client's pull cycle already implements the verifying writer for that
+shape. This endpoint co-exists with Option-B — a row inserted here is
+overwritten on the next directory pull that returns the same
+``(from_enterprise, to_enterprise)`` pair under a proper signed
+peering.
+
+## Schema impedance
+
+The ``aigrp_directory_peerings`` table was designed around the
+offer/accept envelope shape (``offer_payload_canonical``,
+``offer_signature_b64u``, ``offer_signing_key_id``, etc.). A
+manually-pasted announce has none of those — there's no canonical
+payload because there's no protocol exchange that produced it.
+
+The bridge:
+
+* ``offer_id`` — deterministic synthetic id of the form
+  ``manual:<from_enterprise>:<to_enterprise>:<l2_id>`` so re-running
+  the announce upserts the same row rather than landing a second
+  ``manual:<uuid>`` row each time. This gives the endpoint idempotency
+  without changing the table's PK shape.
+* ``status`` — hard-coded ``'active'`` so
+  ``find_active_directory_peering`` returns it.
+* ``content_policy`` / ``consult_logging_policy`` — sentinel
+  ``'manual'`` so receivers can distinguish manual rows from
+  directory-pulled rows when applying policy.
+* ``offer_signing_key_id`` / ``accept_signing_key_id`` — set to the
+  body's ``pubkey`` field. That key is the only cryptographic anchor
+  for this peer; carrying it in both signing-key slots makes downstream
+  lookups (``forward_sign.verify_forward_signature``) find it without
+  needing two distinct keys.
+* ``offer_payload_canonical`` / ``accept_payload_canonical`` — small
+  JSON blobs documenting the manual provenance (admin persona, ts,
+  source = ``manual_directory_peer_announce``). Not signed; receivers
+  detecting ``content_policy='manual'`` know not to treat these as
+  signed envelopes.
+* ``to_l2_endpoints_json`` — the consequential field for the
+  consult-forward path. We populate it with a one-entry roster
+  describing the announced peer L2:
+  ``[{"l2_id": ..., "endpoint_url": ..., "pubkey": ..., "aaisn": ...}]``
+  — exactly the shape ``_resolve_x_enterprise_target`` reads in
+  ``consults.py``.
+* ``expires_at`` — set to now + 30 days. Configurable per-call if we
+  later want shorter TTLs; 30 days matches the spirit of #347's "rotate
+  out by re-pasting" expectation.
+
+## AAISN
+
+The table has no ``aaisn`` column. The announce stashes it inside the
+endpoint roster entry (``to_l2_endpoints_json[0].aaisn``). Pubkey is
+the security anchor anyway — AAISN is human-readable provenance
+metadata for the receiving admin.
+
+Auth: ``require_admin`` + body-enterprise-DIFFERS-from-caller-tenancy.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import logging
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from .auth import require_admin
+from .deps import get_store
+from .store._sqlite import SqliteStore
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/admin/aigrp/directory-peerings", tags=["admin", "aigrp"])
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Sentinel Enterprise id used for misconfigured L2s that haven't been
+# bound to a real Enterprise. Refuse to announce a peering against this
+# (catches admins paste-bombing a peer announce on an unconfigured L2).
+_DEFAULT_ENTERPRISE_SENTINEL = "default-enterprise"
+
+# Manual peerings expire 30 days after the announce by default. The
+# operator re-pastes to refresh; if they don't, the row drops out of
+# ``find_active_directory_peering`` and the consult forward 422s with a
+# more honest "no peering" rather than silently using stale data.
+_DEFAULT_TTL = timedelta(days=30)
+
+# Tag in ``content_policy`` + ``consult_logging_policy`` that lets
+# downstream consumers identify rows that came in via this endpoint.
+_MANUAL_POLICY_TAG = "manual"
+
+# Audit ``policy_applied`` value — distinguishes this route's audit
+# rows from the intra-Enterprise ``manual_peer_announce`` rows.
+_AUDIT_POLICY = "manual_directory_peer_announce"
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class DirectoryPeerAnnounceRequest(BaseModel):
+    """Inputs for the manual cross-Enterprise peering announce.
+
+    The body shape mirrors what an admin would receive from a peer
+    Enterprise's L2 announce — L2 id, endpoint, Ed25519 pubkey, and the
+    optional published metadata.
+    """
+
+    l2_id: str = Field(
+        min_length=3,
+        max_length=128,
+        description="Peer Enterprise's L2 id in '<enterprise>/<group>' form",
+    )
+    enterprise: str = Field(
+        min_length=1,
+        max_length=64,
+        description="Peer Enterprise — MUST differ from caller's tenancy",
+    )
+    group: str = Field(min_length=1, max_length=64, description="Peer L2's group")
+    endpoint_url: str = Field(
+        min_length=7,
+        max_length=512,
+        description="HTTPS URL of the peer L2",
+    )
+    pubkey: str = Field(
+        min_length=1,
+        max_length=128,
+        description="Base64url-encoded Ed25519 public key of the peer L2",
+    )
+    aaisn: str | None = Field(
+        default=None,
+        max_length=64,
+        description="Optional AAISN identifier for the peer Enterprise",
+    )
+    embedding_centroid: list[float] | None = Field(
+        default=None,
+        description="Optional published centroid (not currently consumed by directory peering schema)",
+    )
+    domain_bloom: str | None = Field(
+        default=None,
+        description="Optional published Bloom filter, base64 (not currently consumed by directory peering schema)",
+    )
+    ku_count: int = Field(default=0, ge=0)
+    domain_count: int = Field(default=0, ge=0)
+    embedding_model: str | None = Field(default=None, max_length=128)
+    ttl_days: int | None = Field(
+        default=None,
+        ge=1,
+        le=365,
+        description="Override the default 30-day TTL (1..365 days)",
+    )
+
+
+class DirectoryPeerAnnounceResponse(BaseModel):
+    """The row that landed, plus the audit_id."""
+
+    offer_id: str
+    from_enterprise: str
+    to_enterprise: str
+    status: str
+    active_from: str
+    expires_at: str
+    l2_id: str
+    endpoint_url: str
+    pubkey: str
+    aaisn: str | None
+    last_synced_at: str
+    audit_id: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_l2_id(l2_id: str, enterprise: str, group: str) -> None:
+    """Confirm ``l2_id`` parses as ``<enterprise>/<group>`` matching the body."""
+    if "/" not in l2_id:
+        raise HTTPException(
+            status_code=422,
+            detail=f"l2_id={l2_id!r} must be in '<enterprise>/<group>' form",
+        )
+    ent_part, grp_part = l2_id.split("/", 1)
+    if ent_part != enterprise or grp_part != group:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"l2_id={l2_id!r} must decompose to enterprise={enterprise!r} "
+                f"group={group!r}; got enterprise={ent_part!r} group={grp_part!r}"
+            ),
+        )
+
+
+def _validate_pubkey_b64u(pubkey: str) -> None:
+    """Confirm the pubkey decodes from base64url; 422 if it doesn't.
+
+    Mirrors the validation discipline of the intra-Enterprise route's
+    ``_decode_bloom`` — guards against admins pasting a hex string or
+    raw bytes into a field consumers will treat as base64url.
+    """
+    try:
+        padded = pubkey + "=" * (-len(pubkey) % 4)
+        base64.urlsafe_b64decode(padded)
+    except (ValueError, TypeError, binascii.Error) as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=f"pubkey is not valid base64url: {exc}",
+        ) from exc
+
+
+def _build_offer_id(from_enterprise: str, to_enterprise: str, l2_id: str) -> str:
+    """Deterministic offer_id for manual announces — keeps re-paste idempotent.
+
+    Format: ``manual:<from>:<to>:<l2_id>``. Re-running the announce
+    with the same body upserts the same row instead of landing a
+    second ``manual:<uuid>`` row.
+    """
+    return f"manual:{from_enterprise}:{to_enterprise}:{l2_id}"
+
+
+def _manual_envelope_blob(
+    *,
+    admin: str,
+    role: str,
+    from_enterprise: str,
+    to_enterprise: str,
+    l2_id: str,
+    ts: str,
+) -> str:
+    """Synthesize a non-signed JSON blob for the offer/accept payload slots.
+
+    The schema requires non-NULL canonical payload strings; we use a
+    documented manual-provenance blob so downstream forensics show
+    where the row came from. Never treated as a signed envelope —
+    callers detect ``content_policy='manual'`` first.
+    """
+    return json.dumps(
+        {
+            "source": _AUDIT_POLICY,
+            "role": role,
+            "admin_persona": admin,
+            "from_enterprise": from_enterprise,
+            "to_enterprise": to_enterprise,
+            "peer_l2_id": l2_id,
+            "ts": ts,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Route
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "",
+    response_model=DirectoryPeerAnnounceResponse,
+    status_code=201,
+)
+async def announce_directory_peering(
+    req: DirectoryPeerAnnounceRequest,
+    admin: str = Depends(require_admin),
+    store: SqliteStore = Depends(get_store),
+) -> DirectoryPeerAnnounceResponse:
+    """Insert (or refresh) one ``aigrp_directory_peerings`` row from a signed admin request.
+
+    Behaviour:
+
+    1. Validate the body's ``l2_id`` decomposes to its ``enterprise`` +
+       ``group`` and ``pubkey`` parses as base64url.
+    2. Tenancy gate — the body's ``enterprise`` must be **different**
+       from the caller's resolved tenancy (this is the cross-Enterprise
+       endpoint; same-Enterprise paste-bombing goes through
+       ``/admin/aigrp/peers``). Also reject the
+       ``default-enterprise`` sentinel.
+    3. Upsert via ``store.upsert_directory_peering`` with a deterministic
+       ``offer_id`` so re-paste is idempotent. Synthetic offer/accept
+       payloads document manual provenance; ``content_policy='manual'``
+       distinguishes from directory-pulled rows.
+    4. ``to_l2_endpoints_json`` carries the one-entry roster that
+       ``consults._resolve_x_enterprise_target`` reads to wire the
+       forward (``{l2_id, endpoint_url, pubkey, aaisn?}``).
+    5. Audit-log to ``cross_l2_audit`` with
+       ``policy_applied='manual_directory_peer_announce'`` so this
+       route's rows are forensically distinguishable from #345's
+       intra-Enterprise rows AND from directory-pulled rows.
+    """
+    _validate_l2_id(req.l2_id, req.enterprise, req.group)
+    _validate_pubkey_b64u(req.pubkey)
+
+    # ------------------------------------------------------------------
+    # Tenancy gate — caller must be admin, AND body MUST be a different
+    # Enterprise than the caller (this is the cross-Enterprise endpoint).
+    # ------------------------------------------------------------------
+    user = await store.get_user(admin)
+    if user is None:  # pragma: no cover - require_admin already handles
+        raise HTTPException(status_code=401, detail="caller user row missing")
+    caller_enterprise = user.get("enterprise_id")
+    if caller_enterprise is None:
+        raise HTTPException(
+            status_code=403,
+            detail=("caller user row has no enterprise_id; directory-peer-announce requires a tenancy-scoped admin"),
+        )
+
+    if req.enterprise == _DEFAULT_ENTERPRISE_SENTINEL:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"enterprise={_DEFAULT_ENTERPRISE_SENTINEL!r} is the sentinel for "
+                "unconfigured L2s; bind the peer L2 to a real Enterprise before announcing"
+            ),
+        )
+    if caller_enterprise == _DEFAULT_ENTERPRISE_SENTINEL:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "caller's L2 is bound to the default-enterprise sentinel; "
+                "configure tenancy before announcing cross-Enterprise peerings"
+            ),
+        )
+    if caller_enterprise == req.enterprise:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"body enterprise={req.enterprise!r} equals caller's enterprise; "
+                "use POST /admin/aigrp/peers for intra-Enterprise peer announces"
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Build row
+    # ------------------------------------------------------------------
+    now = datetime.now(UTC)
+    now_iso = now.isoformat()
+    ttl = timedelta(days=req.ttl_days) if req.ttl_days else _DEFAULT_TTL
+    expires_iso = (now + ttl).isoformat()
+    offer_id = _build_offer_id(caller_enterprise, req.enterprise, req.l2_id)
+
+    endpoint_entry: dict[str, Any] = {
+        "l2_id": req.l2_id,
+        "endpoint_url": req.endpoint_url,
+        "pubkey": req.pubkey,
+        "group": req.group,
+    }
+    if req.aaisn is not None:
+        endpoint_entry["aaisn"] = req.aaisn
+    if req.embedding_model is not None:
+        endpoint_entry["embedding_model"] = req.embedding_model
+    if req.ku_count:
+        endpoint_entry["ku_count"] = req.ku_count
+    if req.domain_count:
+        endpoint_entry["domain_count"] = req.domain_count
+    # Centroid + Bloom are accepted for forward-compat; the directory
+    # peering schema doesn't have dedicated columns for them, so they
+    # ride along inside the endpoint entry where future consumers can
+    # find them without a migration.
+    if req.embedding_centroid is not None:
+        endpoint_entry["embedding_centroid"] = req.embedding_centroid
+    if req.domain_bloom is not None:
+        endpoint_entry["domain_bloom"] = req.domain_bloom
+
+    endpoints_json = json.dumps([endpoint_entry], sort_keys=True, separators=(",", ":"))
+
+    offer_payload = _manual_envelope_blob(
+        admin=admin,
+        role="offer",
+        from_enterprise=caller_enterprise,
+        to_enterprise=req.enterprise,
+        l2_id=req.l2_id,
+        ts=now_iso,
+    )
+    accept_payload = _manual_envelope_blob(
+        admin=admin,
+        role="accept",
+        from_enterprise=caller_enterprise,
+        to_enterprise=req.enterprise,
+        l2_id=req.l2_id,
+        ts=now_iso,
+    )
+
+    await store.upsert_directory_peering(
+        offer_id=offer_id,
+        from_enterprise=caller_enterprise,
+        to_enterprise=req.enterprise,
+        status="active",
+        content_policy=_MANUAL_POLICY_TAG,
+        consult_logging_policy=_MANUAL_POLICY_TAG,
+        topic_filters_json="[]",
+        active_from=now_iso,
+        expires_at=expires_iso,
+        offer_payload_canonical=offer_payload,
+        # Manual announces are not signed envelopes — the signature
+        # slots carry an empty string sentinel. Consumers must check
+        # ``content_policy == 'manual'`` before attempting to verify.
+        offer_signature_b64u="",
+        offer_signing_key_id=req.pubkey,
+        accept_payload_canonical=accept_payload,
+        accept_signature_b64u="",
+        accept_signing_key_id=req.pubkey,
+        last_synced_at=now_iso,
+        to_l2_endpoints_json=endpoints_json,
+    )
+
+    audit_id = uuid.uuid4().hex
+    try:
+        await store.record_cross_l2_audit(
+            audit_id=audit_id,
+            ts=now_iso,
+            requester_l2_id=None,
+            requester_enterprise=caller_enterprise,
+            requester_group=user.get("group_id"),
+            requester_persona=admin,
+            responder_l2_id=req.l2_id,
+            responder_enterprise=req.enterprise,
+            responder_group=req.group,
+            policy_applied=_AUDIT_POLICY,
+            result_count=1,
+            consent_id=None,
+        )
+    except Exception:  # pragma: no cover - audit failure must not block upsert
+        log.exception(
+            "manual_directory_peer_announce: audit-log insert failed for offer_id=%s admin=%s",
+            offer_id,
+            admin,
+        )
+
+    log.info(
+        "manual_directory_peer_announce: offer_id=%s from=%s to=%s peer_l2=%s admin=%s audit_id=%s",
+        offer_id,
+        caller_enterprise,
+        req.enterprise,
+        req.l2_id,
+        admin,
+        audit_id,
+    )
+
+    return DirectoryPeerAnnounceResponse(
+        offer_id=offer_id,
+        from_enterprise=caller_enterprise,
+        to_enterprise=req.enterprise,
+        status="active",
+        active_from=now_iso,
+        expires_at=expires_iso,
+        l2_id=req.l2_id,
+        endpoint_url=req.endpoint_url,
+        pubkey=req.pubkey,
+        aaisn=req.aaisn,
+        last_synced_at=now_iso,
+        audit_id=audit_id,
+    )

--- a/server/backend/src/cq_server/aigrp_directory_peer_routes.py
+++ b/server/backend/src/cq_server/aigrp_directory_peer_routes.py
@@ -80,6 +80,90 @@ the security anchor anyway — AAISN is human-readable provenance
 metadata for the receiving admin.
 
 Auth: ``require_admin`` + body-enterprise-DIFFERS-from-caller-tenancy.
+
+## Concurrent writers — addresses #346 concern 3
+
+Three logical writers contend for ``aigrp_directory_peerings`` rows
+post-EBS migration (#327):
+
+(a) **This admin endpoint** (Option A, manual paste).
+    Writes rows with synthetic ``offer_id = manual:<from>:<to>:<l2_id>``
+    via ``store.upsert_directory_peering`` (INSERT … ON CONFLICT(offer_id)
+    DO UPDATE). Transaction boundary: a single
+    ``self._engine.begin()`` block in ``_upsert_directory_peering_sync``;
+    SQLAlchemy issues ``BEGIN IMMEDIATE`` under WAL, taking the
+    database-wide RESERVED lock for the duration of the UPSERT (one
+    statement). SQLite has **no row-level locking** — the unit of
+    mutual exclusion is the whole database file.
+
+(b) **Directory poll loop** (``directory_client._sync_peerings``).
+    Writes rows pulled from ``directory.8th-layer.ai`` with real,
+    bilaterally-signed ``offer_id`` values. Same call into
+    ``store.upsert_directory_peering`` — same transaction boundary as
+    (a). Verifies offer + accept signatures **before** the upsert
+    (``_verify_peering_record``); unverifiable records are skipped.
+
+(c) **The bilateral signed flow** (offer/accept envelope protocol
+    backing Option B). On this L2 the writer is (b) — the directory
+    poll loop ingests the bilateral envelopes after the registry has
+    validated them. There is no separate route on this L2 that
+    fabricates bilateral signed rows; ``forward_sign.py`` only
+    verifies, never writes.
+
+### Conflict resolution
+
+The natural-key collision space is small because:
+
+* (a) emits ``offer_id`` of the form ``manual:<from>:<to>:<l2_id>``.
+* (b) emits the directory's UUID-shaped ``offer_id`` (never starts
+  with ``manual:``).
+
+So an upsert from (a) and an upsert from (b) for the same logical
+``(from, to)`` peer pair land in **distinct rows** with **distinct
+PKs**. The ``find_active_directory_peering`` reader applies
+``status='active' AND expires_at > now`` and picks the
+``ORDER BY active_from DESC`` winner — the most recent active row
+wins regardless of which writer produced it.
+
+**Why INSERT-or-UPSERT and not just INSERT.** We use UPSERT
+(``INSERT … ON CONFLICT(offer_id) DO UPDATE``) — straight INSERT
+would 409 on re-paste of the same announce, breaking the operator
+UX. UPSERT makes re-paste idempotent without sacrificing the PK
+invariant. The ``offer_id`` deterministic format makes
+``re-paste = same row``; distinct admins on the same L2 announcing
+the same peer end up at the same row deliberately (the second paste
+refreshes ``expires_at``). UPSERT is also what (b) does — keeping
+the two writers symmetric simplifies reasoning.
+
+**Manual-row → signed-row precedence.** If (a) lands first and (b)
+later returns a real signed peering for the same ``(from, to)``,
+both rows coexist. The reader's ``ORDER BY active_from DESC LIMIT 1``
+picks the most-recently-active row; in practice (b)'s
+``active_from`` will be later than the manual paste's, so the
+signed row wins as soon as the directory catches up. The manual row
+expires after its TTL (default 30 days) and drops out of the
+``WHERE expires_at > now`` filter — no GC cycle needed.
+
+### Isolation model (SQLite WAL on EBS, post-#327)
+
+SQLite WAL allows **N readers + 1 writer** concurrently. Writers
+serialise on the database lock (``BEGIN IMMEDIATE`` → RESERVED →
+PENDING → EXCLUSIVE during commit). Both (a) and (b) hit the same
+``engine.begin()`` boundary, so their upserts cannot interleave at
+statement granularity — one fully commits before the other starts.
+This is intentional: the table is small (cross-Enterprise peerings,
+O(10s of rows per L2)) and write throughput is low (admin paste +
+periodic directory poll), so global write serialisation is
+acceptable. There is no row-level locking and no need for one.
+
+EBS-vs-EFS distinction (#327): EFS broke the WAL fsync ordering
+guarantee, which is why we migrated. EBS preserves it. With EBS the
+above analysis holds; with EFS it did not (writes could appear to
+commit, then be lost if the EFS server rolled back, leaving the
+in-memory state and on-disk state divergent).
+
+See ``docs/decisions/35-aigrp-directory-peering-concurrent-writers.md``
+for the longer-form note.
 """
 
 from __future__ import annotations
@@ -92,12 +176,20 @@ import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from .auth import require_admin
 from .deps import get_store
 from .store._sqlite import SqliteStore
+
+# Ed25519 public keys are exactly 32 bytes per RFC 8032 §5.1.5. The
+# ``cryptography`` library does not export a named constant for this,
+# so we hardcode it for use by both the length pre-check and the
+# ``Ed25519PublicKey.from_public_bytes`` curve-point validation below.
+_ED25519_PUBLIC_KEY_SIZE = 32
 
 log = logging.getLogger(__name__)
 
@@ -226,21 +318,81 @@ def _validate_l2_id(l2_id: str, enterprise: str, group: str) -> None:
         )
 
 
-def _validate_pubkey_b64u(pubkey: str) -> None:
-    """Confirm the pubkey decodes from base64url; 422 if it doesn't.
+_INVALID_PUBKEY_DETAIL = "pubkey must be base64url-encoded Ed25519 public key (32 bytes)"
 
-    Mirrors the validation discipline of the intra-Enterprise route's
-    ``_decode_bloom`` — guards against admins pasting a hex string or
-    raw bytes into a field consumers will treat as base64url.
+
+class _InvalidPubkeyError(Exception):
+    """Internal sentinel for the route handler — convert to 400 response."""
+
+
+def _invalid_pubkey_response() -> JSONResponse:
+    """Standard 400 body for any pubkey validation failure.
+
+    Single shape so a fleet operator scripting against this endpoint
+    can ``grep error=invalid_pubkey`` regardless of whether the
+    failure was b64u-decode, length, or curve-point validation. Keeps
+    the on-the-wire surface narrower than leaking the underlying
+    ``ValueError`` message.
     """
+    return JSONResponse(
+        status_code=400,
+        content={"error": "invalid_pubkey", "detail": _INVALID_PUBKEY_DETAIL},
+    )
+
+
+def _validate_pubkey_ed25519(pubkey: str) -> None:
+    """Verify ``pubkey`` is a real Ed25519 public key — addresses #346 concern 1.
+
+    Three layers of check, all surfaced as the same 400 body
+    (``{"error":"invalid_pubkey","detail":...}`` via
+    ``_invalid_pubkey_response``):
+
+    1. **Base64url decode** — admin must not paste hex / raw bytes /
+       padded standard-base64. Tolerant of missing padding (RFC 4648 §5).
+    2. **Length** — exactly ``_ED25519_PUBLIC_KEY_SIZE`` (32) bytes.
+       A wrong-length key would either silently truncate downstream
+       or break ``forward_sign.verify_forward_signature`` at first
+       use with an opaque error.
+    3. **Curve-point validity** —
+       ``Ed25519PublicKey.from_public_bytes`` does the curve-point
+       check internally (raises ``ValueError`` for malformed keys).
+       This is the same primitive ``crypto.verify_envelope_signature``
+       and ``crypto.verify_raw`` use on the verify path, so any key
+       that passes here will round-trip through the downstream
+       verifiers.
+
+    The handler converts the ``_InvalidPubkeyError`` exception to the
+    canonical 400 response shape before returning.
+
+    Raises:
+        _InvalidPubkeyError: any of the three checks failed.
+    """
+    # Step 1 — base64url decode (tolerant of missing padding).
     try:
         padded = pubkey + "=" * (-len(pubkey) % 4)
-        base64.urlsafe_b64decode(padded)
+        raw = base64.urlsafe_b64decode(padded)
     except (ValueError, TypeError, binascii.Error) as exc:
-        raise HTTPException(
-            status_code=422,
-            detail=f"pubkey is not valid base64url: {exc}",
-        ) from exc
+        log.info("pubkey rejected (b64u decode): %s", exc)
+        raise _InvalidPubkeyError from exc
+
+    # Step 2 — length check before handing to the curve loader so we
+    # produce a precise log line for the common admin-paste error
+    # (truncated copy/paste).
+    if len(raw) != _ED25519_PUBLIC_KEY_SIZE:
+        log.info(
+            "pubkey rejected (wrong length): got %d bytes, expected %d",
+            len(raw),
+            _ED25519_PUBLIC_KEY_SIZE,
+        )
+        raise _InvalidPubkeyError
+
+    # Step 3 — curve-point validity. Re-uses the same loader the
+    # downstream verifier (``crypto.verify_envelope_signature``) uses.
+    try:
+        Ed25519PublicKey.from_public_bytes(raw)
+    except (ValueError, TypeError) as exc:
+        log.info("pubkey rejected (curve-point): %s", exc)
+        raise _InvalidPubkeyError from exc
 
 
 def _build_offer_id(from_enterprise: str, to_enterprise: str, l2_id: str) -> str:
@@ -298,7 +450,7 @@ async def announce_directory_peering(
     req: DirectoryPeerAnnounceRequest,
     admin: str = Depends(require_admin),
     store: SqliteStore = Depends(get_store),
-) -> DirectoryPeerAnnounceResponse:
+) -> DirectoryPeerAnnounceResponse | JSONResponse:
     """Insert (or refresh) one ``aigrp_directory_peerings`` row from a signed admin request.
 
     Behaviour:
@@ -323,7 +475,13 @@ async def announce_directory_peering(
        intra-Enterprise rows AND from directory-pulled rows.
     """
     _validate_l2_id(req.l2_id, req.enterprise, req.group)
-    _validate_pubkey_b64u(req.pubkey)
+    try:
+        _validate_pubkey_ed25519(req.pubkey)
+    except _InvalidPubkeyError:
+        # Concern 1 from #346 — return a single canonical 400 shape so
+        # scripted callers can grep ``error=invalid_pubkey`` regardless
+        # of which sub-check (b64u / length / curve) tripped.
+        return _invalid_pubkey_response()
 
     # ------------------------------------------------------------------
     # Tenancy gate — caller must be admin, AND body MUST be a different

--- a/server/backend/src/cq_server/aigrp_peer_routes.py
+++ b/server/backend/src/cq_server/aigrp_peer_routes.py
@@ -42,7 +42,9 @@ import uuid
 from datetime import UTC, datetime
 from typing import Any
 
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from .auth import require_admin
@@ -52,6 +54,54 @@ from .store._sqlite import SqliteStore
 log = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/admin/aigrp/peers", tags=["admin", "aigrp"])
+
+# Ed25519 public keys are exactly 32 bytes per RFC 8032 §5.1.5.
+_ED25519_PUBLIC_KEY_SIZE = 32
+_INVALID_PUBKEY_DETAIL = "pubkey must be base64url-encoded Ed25519 public key (32 bytes)"
+
+
+class _InvalidPubkeyError(Exception):
+    """Internal sentinel for the route handler — convert to 400 response."""
+
+
+def _invalid_pubkey_response() -> JSONResponse:
+    """Standard 400 body for pubkey validation failures (mirrors directory-peer route)."""
+    return JSONResponse(
+        status_code=400,
+        content={"error": "invalid_pubkey", "detail": _INVALID_PUBKEY_DETAIL},
+    )
+
+
+def _validate_pubkey_ed25519(pubkey: str) -> None:
+    """Verify ``pubkey`` is a real Ed25519 public key — addresses #346 concern 1.
+
+    Three layers — base64url decode, length == 32, curve-point validity.
+    See ``aigrp_directory_peer_routes._validate_pubkey_ed25519`` for the
+    long-form docstring; this is the intra-Enterprise sibling, applied
+    here because the PR-#345 endpoint shipped with only the implicit
+    Pydantic ``min_length=1, max_length=128`` check, which accepted hex
+    strings and other non-base64url shapes.
+    """
+    try:
+        padded = pubkey + "=" * (-len(pubkey) % 4)
+        raw = base64.urlsafe_b64decode(padded)
+    except (ValueError, TypeError, binascii.Error) as exc:
+        log.info("pubkey rejected (b64u decode): %s", exc)
+        raise _InvalidPubkeyError from exc
+
+    if len(raw) != _ED25519_PUBLIC_KEY_SIZE:
+        log.info(
+            "pubkey rejected (wrong length): got %d bytes, expected %d",
+            len(raw),
+            _ED25519_PUBLIC_KEY_SIZE,
+        )
+        raise _InvalidPubkeyError
+
+    try:
+        Ed25519PublicKey.from_public_bytes(raw)
+    except (ValueError, TypeError) as exc:
+        log.info("pubkey rejected (curve-point): %s", exc)
+        raise _InvalidPubkeyError from exc
 
 
 # ---------------------------------------------------------------------------
@@ -169,7 +219,7 @@ async def announce_peer(
     req: PeerAnnounceRequest,
     admin: str = Depends(require_admin),
     store: SqliteStore = Depends(get_store),
-) -> PeerAnnounceResponse:
+) -> PeerAnnounceResponse | JSONResponse:
     """Insert (or refresh) one ``aigrp_peers`` row from a signed admin request.
 
     Behaviour:
@@ -193,6 +243,12 @@ async def announce_peer(
        UI can confirm what landed.
     """
     _validate_l2_id(req.l2_id, req.enterprise, req.group)
+    try:
+        _validate_pubkey_ed25519(req.pubkey)
+    except _InvalidPubkeyError:
+        # Concern 1 from #346 — return the canonical 400 invalid_pubkey
+        # shape (mirrors the cross-Enterprise sibling endpoint).
+        return _invalid_pubkey_response()
 
     user = await store.get_user(admin)
     if user is None:

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -28,6 +28,7 @@ from .activity_logger import log_activity, summary_first_60
 from .activity_routes import router as activity_router
 from .admin_routes import router as admin_xgroup_consent_router
 from .agent_key_routes import router as agent_key_router
+from .aigrp_directory_peer_routes import router as aigrp_directory_peer_router
 from .aigrp_peer_routes import router as aigrp_peer_router
 from .auth import get_current_user, require_admin
 from .auth import router as auth_router
@@ -499,6 +500,10 @@ api_router.include_router(agent_key_router)
 # mesh discovery for direct-CFN / air-gapped deploys that bypass the
 # directory poll loop).
 api_router.include_router(aigrp_peer_router)
+# agent#347 — cross-Enterprise sibling of the peer-announce escape
+# hatch. Populates ``aigrp_directory_peerings`` so consult forwards
+# work on direct-CFN deploys that have no path to the directory.
+api_router.include_router(aigrp_directory_peer_router)
 # FO-1d (#199) — anonymous /theme endpoint for the per-L2 brand chrome.
 # Mounted on api_router so it lives under both / and /api/v1, same as
 # every other API route. Decision 30 sets the spec.

--- a/server/backend/tests/test_aigrp_directory_peer_routes.py
+++ b/server/backend/tests/test_aigrp_directory_peer_routes.py
@@ -1,0 +1,358 @@
+"""HTTP-level tests for ``POST /api/v1/admin/aigrp/directory-peerings`` (agent#347).
+
+Cross-Enterprise sibling of ``test_aigrp_peer_routes.py``. Covers:
+
+* Auth gating — non-admin caller gets 403; unauthenticated gets 401.
+* Tenancy gate — body's ``enterprise`` MUST differ from the caller's
+  tenancy (this is the cross-Enterprise endpoint). Same-Enterprise body
+  is 422 with a "use /admin/aigrp/peers" pointer. Sentinel
+  ``default-enterprise`` is also 422.
+* Happy path — 201, row landed in ``aigrp_directory_peerings``,
+  response carries the offer_id + expires_at + l2_id roster entry,
+  ``cross_l2_audit`` row written with
+  ``policy_applied='manual_directory_peer_announce'``.
+* Idempotent re-announce — same ``(from, to, l2_id)`` synthesizes the
+  same ``offer_id`` so re-paste upserts a single row.
+* Roster shape — ``to_l2_endpoints_json`` decodes to a one-entry list
+  with the L2's ``l2_id``, ``endpoint_url``, and ``pubkey`` — the
+  exact shape ``consults._resolve_x_enterprise_target`` reads.
+* Pubkey validation — non-base64url input is rejected with 422.
+* L2-id decomposition — body's ``l2_id`` must equal
+  ``<enterprise>/<group>``; mismatched form is 422.
+* Resolver wire-up — after the announce, ``find_active_directory_peering``
+  returns the row.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import bcrypt
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from cq_server.app import _get_store, app
+
+ENT_A = "acme"
+ENT_B = "globex"
+GRP_A = "engineering"
+GRP_B = "engineering"
+
+ADMIN_A = "admin@acme"
+ADMIN_B = "admin@globex"
+NON_ADMIN = "regular@acme"
+PASSWORD = "password123!"  # pragma: allowlist secret
+
+# The PEER L2 we're announcing — lives in Enterprise B (globex), so
+# admin@acme is announcing a cross-Enterprise peering A -> B.
+PEER_L2 = f"{ENT_B}/sga"
+PEER_GROUP = "sga"
+PEER_ENDPOINT = "https://sga.globex.example.com"
+PEER_AAISN = "AS-65500"
+# Realistic Ed25519 pubkey — 32 zero bytes, base64url, no padding.
+PEER_PUBKEY_B64U = base64.urlsafe_b64encode(b"\x00" * 32).rstrip(b"=").decode()
+
+ENDPOINT_PATH = "/api/v1/admin/aigrp/directory-peerings"
+
+
+@pytest.fixture
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "aigrp_directory_peers.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    with TestClient(app) as c:
+        store = _get_store()
+        pw = bcrypt.hashpw(PASSWORD.encode(), bcrypt.gensalt()).decode()
+        store.sync.create_user(ADMIN_A, pw)
+        store.sync.create_user(ADMIN_B, pw)
+        store.sync.create_user(NON_ADMIN, pw)
+        store.sync.set_user_role(ADMIN_A, "admin")
+        store.sync.set_user_role(ADMIN_B, "admin")
+        with store._engine.begin() as conn:  # noqa: SLF001
+            conn.execute(
+                text("UPDATE users SET enterprise_id = :e, group_id = :g WHERE username = :u"),
+                {"e": ENT_A, "g": GRP_A, "u": ADMIN_A},
+            )
+            conn.execute(
+                text("UPDATE users SET enterprise_id = :e, group_id = :g WHERE username = :u"),
+                {"e": ENT_B, "g": GRP_B, "u": ADMIN_B},
+            )
+            conn.execute(
+                text("UPDATE users SET enterprise_id = :e, group_id = :g WHERE username = :u"),
+                {"e": ENT_A, "g": GRP_A, "u": NON_ADMIN},
+            )
+        yield c
+
+
+def _login(client: TestClient, username: str) -> dict[str, str]:
+    resp = client.post(
+        "/api/v1/auth/login",
+        json={"username": username, "password": PASSWORD},
+    )
+    assert resp.status_code == 200, resp.text
+    return {"Authorization": f"Bearer {resp.json()['token']}"}
+
+
+def _valid_body(**over: object) -> dict[str, object]:
+    body: dict[str, object] = {
+        "l2_id": PEER_L2,
+        "enterprise": ENT_B,
+        "group": PEER_GROUP,
+        "endpoint_url": PEER_ENDPOINT,
+        "pubkey": PEER_PUBKEY_B64U,
+        "aaisn": PEER_AAISN,
+        "ku_count": 1284,
+        "domain_count": 42,
+    }
+    body.update(over)
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Auth gating
+# ---------------------------------------------------------------------------
+
+
+def test_unauthenticated_gets_401(client: TestClient) -> None:
+    resp = client.post(ENDPOINT_PATH, json=_valid_body())
+    assert resp.status_code == 401, resp.text
+
+
+def test_non_admin_gets_403(client: TestClient) -> None:
+    headers = _login(client, NON_ADMIN)
+    resp = client.post(ENDPOINT_PATH, headers=headers, json=_valid_body())
+    assert resp.status_code == 403, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Tenancy gate
+# ---------------------------------------------------------------------------
+
+
+def test_same_enterprise_body_is_422(client: TestClient) -> None:
+    """admin@acme announcing a peer IN acme is the intra-Enterprise path."""
+    headers = _login(client, ADMIN_A)
+    body = _valid_body(
+        l2_id=f"{ENT_A}/sga",
+        enterprise=ENT_A,
+        group="sga",
+    )
+    resp = client.post(ENDPOINT_PATH, headers=headers, json=body)
+    assert resp.status_code == 422, resp.text
+    detail = resp.json()["detail"]
+    assert "use POST /admin/aigrp/peers" in detail
+
+
+def test_default_enterprise_sentinel_body_is_422(client: TestClient) -> None:
+    headers = _login(client, ADMIN_A)
+    body = _valid_body(
+        l2_id="default-enterprise/sga",
+        enterprise="default-enterprise",
+        group="sga",
+    )
+    resp = client.post(ENDPOINT_PATH, headers=headers, json=body)
+    assert resp.status_code == 422, resp.text
+    assert "default-enterprise" in resp.json()["detail"]
+
+
+def test_l2_id_must_decompose_to_enterprise_group(client: TestClient) -> None:
+    headers = _login(client, ADMIN_A)
+    body = _valid_body(l2_id=f"{ENT_B}/research")  # group mismatch
+    resp = client.post(ENDPOINT_PATH, headers=headers, json=body)
+    assert resp.status_code == 422, resp.text
+    assert "decompose" in resp.json()["detail"]
+
+
+def test_l2_id_without_slash_is_422(client: TestClient) -> None:
+    headers = _login(client, ADMIN_A)
+    body = _valid_body(l2_id="globex-sga")
+    resp = client.post(ENDPOINT_PATH, headers=headers, json=body)
+    assert resp.status_code == 422
+
+
+def test_invalid_pubkey_base64_is_422(client: TestClient) -> None:
+    """Pubkey field must parse as base64url; junk input lands a clean 422."""
+    headers = _login(client, ADMIN_A)
+    body = _valid_body(pubkey="!!!not-base64!!!@@@")
+    resp = client.post(ENDPOINT_PATH, headers=headers, json=body)
+    assert resp.status_code == 422, resp.text
+    assert "pubkey" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_announce_happy_path_lands_row_and_audit(client: TestClient) -> None:
+    headers = _login(client, ADMIN_A)
+    resp = client.post(ENDPOINT_PATH, headers=headers, json=_valid_body())
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+
+    # Response shape
+    assert body["from_enterprise"] == ENT_A
+    assert body["to_enterprise"] == ENT_B
+    assert body["status"] == "active"
+    assert body["l2_id"] == PEER_L2
+    assert body["endpoint_url"] == PEER_ENDPOINT
+    assert body["pubkey"] == PEER_PUBKEY_B64U
+    assert body["aaisn"] == PEER_AAISN
+    assert body["offer_id"] == f"manual:{ENT_A}:{ENT_B}:{PEER_L2}"
+    assert body["active_from"]
+    assert body["expires_at"]
+    assert body["expires_at"] > body["active_from"]
+    assert body["audit_id"]
+
+    # DB-level confirmation — the peering row exists.
+    store = _get_store()
+    peerings = store.sync.list_directory_peerings(enterprise_id=ENT_A)
+    rows = [p for p in peerings if p["offer_id"] == body["offer_id"]]
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["from_enterprise"] == ENT_A
+    assert row["to_enterprise"] == ENT_B
+    assert row["status"] == "active"
+    assert row["content_policy"] == "manual"
+    assert row["consult_logging_policy"] == "manual"
+
+    # The roster carries the announce in the exact shape consults.py reads.
+    endpoints = json.loads(row["to_l2_endpoints_json"])
+    assert len(endpoints) == 1
+    ep = endpoints[0]
+    assert ep["l2_id"] == PEER_L2
+    assert ep["endpoint_url"] == PEER_ENDPOINT
+    assert ep["pubkey"] == PEER_PUBKEY_B64U
+    assert ep["aaisn"] == PEER_AAISN
+
+    # Audit-log row landed with the manual policy tag.
+    with store._engine.connect() as conn:  # noqa: SLF001
+        audit_rows = conn.execute(
+            text(
+                "SELECT policy_applied, responder_l2_id, requester_persona, "
+                "requester_enterprise, responder_enterprise "
+                "FROM cross_l2_audit WHERE audit_id = :id"
+            ),
+            {"id": body["audit_id"]},
+        ).fetchall()
+    assert len(audit_rows) == 1
+    assert audit_rows[0][0] == "manual_directory_peer_announce"
+    assert audit_rows[0][1] == PEER_L2
+    assert audit_rows[0][2] == ADMIN_A
+    assert audit_rows[0][3] == ENT_A
+    assert audit_rows[0][4] == ENT_B
+
+
+def test_resolver_finds_active_peering_after_announce(client: TestClient) -> None:
+    """The whole point of #347 — ``find_active_directory_peering`` returns the row."""
+    headers = _login(client, ADMIN_A)
+    resp = client.post(ENDPOINT_PATH, headers=headers, json=_valid_body())
+    assert resp.status_code == 201, resp.text
+
+    store = _get_store()
+    # Direct sync probe of the resolver method consults.py uses.
+    peering = store.sync._find_active_directory_peering_sync(  # noqa: SLF001
+        from_enterprise=ENT_A,
+        to_enterprise=ENT_B,
+    )
+    assert peering is not None
+    assert peering["status"] == "active"
+    endpoints = json.loads(peering["to_l2_endpoints_json"])
+    assert any(e["l2_id"] == PEER_L2 for e in endpoints)
+
+
+def test_optional_aaisn_omitted(client: TestClient) -> None:
+    """AAISN is optional — the table has no aaisn column, the roster handles it."""
+    headers = _login(client, ADMIN_A)
+    body = _valid_body()
+    del body["aaisn"]
+    resp = client.post(ENDPOINT_PATH, headers=headers, json=body)
+    assert resp.status_code == 201, resp.text
+    j = resp.json()
+    assert j["aaisn"] is None
+
+    store = _get_store()
+    peerings = store.sync.list_directory_peerings(enterprise_id=ENT_A)
+    row = next(p for p in peerings if p["offer_id"] == j["offer_id"])
+    endpoints = json.loads(row["to_l2_endpoints_json"])
+    assert "aaisn" not in endpoints[0]
+
+
+def test_ttl_days_override(client: TestClient) -> None:
+    headers = _login(client, ADMIN_A)
+    body = _valid_body(ttl_days=7)
+    resp = client.post(ENDPOINT_PATH, headers=headers, json=body)
+    assert resp.status_code == 201, resp.text
+    j = resp.json()
+    # 7 days < 30 days (default) — sanity check that the override stuck.
+    # Compare ISO strings directly: 7-day delta will start with a date
+    # earlier than the 30-day default.
+    from datetime import UTC, datetime, timedelta
+
+    active = datetime.fromisoformat(j["active_from"])
+    expires = datetime.fromisoformat(j["expires_at"])
+    delta = expires - active
+    # Use a tolerance window to absorb any microsecond drift between
+    # the two now() calls inside the handler.
+    assert timedelta(days=6, hours=23) < delta < timedelta(days=7, hours=1)
+    # And it's strictly less than the default 30-day TTL.
+    assert delta < timedelta(days=30)
+    # And it's in the future of the now-clock the test runs against.
+    assert expires > datetime.now(UTC)
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_announce_is_idempotent_same_offer_id(client: TestClient) -> None:
+    headers = _login(client, ADMIN_A)
+    first = client.post(ENDPOINT_PATH, headers=headers, json=_valid_body())
+    assert first.status_code == 201, first.text
+    j1 = first.json()
+
+    # Re-announce with the same l2_id, different endpoint URL.
+    body2 = _valid_body(endpoint_url="https://sga-v2.globex.example.com")
+    second = client.post(ENDPOINT_PATH, headers=headers, json=body2)
+    assert second.status_code == 201, second.text
+    j2 = second.json()
+
+    # Deterministic offer_id means the same row was upserted.
+    assert j1["offer_id"] == j2["offer_id"]
+
+    # Only one row exists; endpoint URL was updated.
+    store = _get_store()
+    peerings = [p for p in store.sync.list_directory_peerings(enterprise_id=ENT_A) if p["offer_id"] == j1["offer_id"]]
+    assert len(peerings) == 1
+    endpoints = json.loads(peerings[0]["to_l2_endpoints_json"])
+    assert endpoints[0]["endpoint_url"] == "https://sga-v2.globex.example.com"
+
+
+def test_independent_peerings_get_distinct_offer_ids(client: TestClient) -> None:
+    """Two different peer L2s in the same Enterprise B land two rows."""
+    headers = _login(client, ADMIN_A)
+    first = client.post(ENDPOINT_PATH, headers=headers, json=_valid_body())
+    assert first.status_code == 201, first.text
+
+    body2 = _valid_body(
+        l2_id=f"{ENT_B}/research",
+        group="research",
+        endpoint_url="https://research.globex.example.com",
+    )
+    second = client.post(ENDPOINT_PATH, headers=headers, json=body2)
+    assert second.status_code == 201, second.text
+
+    j1 = first.json()
+    j2 = second.json()
+    assert j1["offer_id"] != j2["offer_id"]
+
+    store = _get_store()
+    peerings = store.sync.list_directory_peerings(enterprise_id=ENT_A)
+    ids = {p["offer_id"] for p in peerings}
+    assert j1["offer_id"] in ids
+    assert j2["offer_id"] in ids

--- a/server/backend/tests/test_aigrp_directory_peer_routes.py
+++ b/server/backend/tests/test_aigrp_directory_peer_routes.py
@@ -174,13 +174,43 @@ def test_l2_id_without_slash_is_422(client: TestClient) -> None:
     assert resp.status_code == 422
 
 
-def test_invalid_pubkey_base64_is_422(client: TestClient) -> None:
-    """Pubkey field must parse as base64url; junk input lands a clean 422."""
+def test_invalid_pubkey_base64_is_400(client: TestClient) -> None:
+    """Pubkey field must decode as base64url Ed25519 key (#346 concern 1)."""
     headers = _login(client, ADMIN_A)
     body = _valid_body(pubkey="!!!not-base64!!!@@@")
     resp = client.post(ENDPOINT_PATH, headers=headers, json=body)
-    assert resp.status_code == 422, resp.text
-    assert "pubkey" in resp.json()["detail"]
+    assert resp.status_code == 400, resp.text
+    payload = resp.json()
+    assert payload == {
+        "error": "invalid_pubkey",
+        "detail": "pubkey must be base64url-encoded Ed25519 public key (32 bytes)",
+    }
+
+
+def test_invalid_pubkey_wrong_length_is_400(client: TestClient) -> None:
+    """A b64u-decodable string that isn't 32 bytes is rejected (#346 concern 1)."""
+    headers = _login(client, ADMIN_A)
+    # 16 bytes (half an Ed25519 key) — decodes cleanly, wrong length.
+    short_pubkey = base64.urlsafe_b64encode(b"\x01" * 16).rstrip(b"=").decode()
+    body = _valid_body(pubkey=short_pubkey)
+    resp = client.post(ENDPOINT_PATH, headers=headers, json=body)
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["error"] == "invalid_pubkey"
+
+
+def test_invalid_pubkey_hex_string_is_400(client: TestClient) -> None:
+    """A 64-char hex string (common admin mistake) is rejected (#346 concern 1).
+
+    Hex decodes as base64url to 48 bytes (all-zero or otherwise),
+    which trips the length check rather than the b64u-decode step.
+    Either way the canonical 400 shape is returned.
+    """
+    headers = _login(client, ADMIN_A)
+    hex_pubkey = "00" * 32  # 64 hex chars representing 32 bytes — the wrong encoding
+    body = _valid_body(pubkey=hex_pubkey)
+    resp = client.post(ENDPOINT_PATH, headers=headers, json=body)
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["error"] == "invalid_pubkey"
 
 
 # ---------------------------------------------------------------------------

--- a/server/backend/tests/test_aigrp_peer_routes.py
+++ b/server/backend/tests/test_aigrp_peer_routes.py
@@ -214,6 +214,28 @@ def test_announce_packs_centroid_and_decodes_bloom(client: TestClient) -> None:
     assert row["domain_count"] == 4
 
 
+def test_invalid_pubkey_base64_is_400(client: TestClient) -> None:
+    """Non-base64url ``pubkey`` lands the canonical 400 invalid_pubkey body (#346 concern 1)."""
+    headers = _login(client, ADMIN_A)
+    body = _valid_body(pubkey="!!!not-base64!!!@@@")
+    resp = client.post("/api/v1/admin/aigrp/peers", headers=headers, json=body)
+    assert resp.status_code == 400, resp.text
+    assert resp.json() == {
+        "error": "invalid_pubkey",
+        "detail": "pubkey must be base64url-encoded Ed25519 public key (32 bytes)",
+    }
+
+
+def test_invalid_pubkey_wrong_length_is_400(client: TestClient) -> None:
+    """A b64u-decodable string that isn't 32 bytes is rejected (#346 concern 1)."""
+    headers = _login(client, ADMIN_A)
+    short_pubkey = base64.urlsafe_b64encode(b"\x01" * 16).rstrip(b"=").decode()
+    body = _valid_body(pubkey=short_pubkey)
+    resp = client.post("/api/v1/admin/aigrp/peers", headers=headers, json=body)
+    assert resp.status_code == 400, resp.text
+    assert resp.json()["error"] == "invalid_pubkey"
+
+
 def test_invalid_bloom_base64_is_422(client: TestClient) -> None:
     """Non-alphabet chars in ``domain_bloom`` land a clean 422.
 


### PR DESCRIPTION
## Summary

Cross-Enterprise sibling of the intra-Enterprise peer-announce endpoint shipped in #345. Adds `POST /api/v1/admin/aigrp/directory-peerings` — populates `aigrp_directory_peerings` so the cross-Enterprise consult-forward path (`consults._resolve_x_enterprise_target`) can resolve target endpoints on direct-CFN / air-gapped deploys that have no path to `directory.8th-layer.ai`.

This is the **Option-A** path from the #347 issue body — single admin pastes the peer Enterprise's announce data; that admin is the trust anchor. Option-B (the bilateral offer/accept signed-envelope protocol the directory client runs) remains the long-term answer and **co-exists** — a manual row is overwritten on the next directory pull that returns the same `(from_enterprise, to_enterprise)` pair under a signed peering.

Closes #347. Intra-Enterprise sibling: #345.

## What this unblocks

Cross-Enterprise `/api/v1/consults/x-enterprise-forward-request` was 422-ing on direct-CFN substrates because `find_active_directory_peering(from, to)` returned no row. With this endpoint, an L2 admin pastes the peer Enterprise's announce data and the consult forward completes.

Lands **4 of 6** drift items in #343 for the mvp-* / direct-CFN substrates: `aigrp`, `dsn-intro`, `dsn-reveal`, `consented-query`. All four were failing at the same `find_active_directory_peering` lookup.

## Schema-impedance bridge

`aigrp_directory_peerings` was designed around the offer/accept signed-envelope shape. A manual announce has no signed envelope. The bridge (documented in detail in the route docstring and `docs/ops/peer-announce.md`):

| Column | Manual-row value |
|---|---|
| `offer_id` | Deterministic — `manual:<from>:<to>:<l2_id>` — idempotent re-paste on natural key without breaking PK semantics |
| `status` | `'active'` |
| `content_policy` / `consult_logging_policy` | `'manual'` — sentinel so downstream consumers distinguish manual rows from directory-pulled |
| `offer_signing_key_id` / `accept_signing_key_id` | Body's `pubkey` |
| `offer_signature_b64u` / `accept_signature_b64u` | Empty string — consumers must check `content_policy='manual'` before verifying |
| `offer_payload_canonical` / `accept_payload_canonical` | Synthesized provenance JSON (admin persona, ts, source tag) |
| `to_l2_endpoints_json` | One-entry roster `[{l2_id, endpoint_url, pubkey, aaisn?, ...}]` — exactly the shape `consults._resolve_x_enterprise_target` reads |
| `expires_at` | Now + 30 days (configurable via `ttl_days` override, 1..365) |

## AAISN

The table has **no `aaisn` column** — the announce stashes it inside the roster entry (`to_l2_endpoints_json[0].aaisn`). Pubkey is the security anchor anyway; AAISN is human-readable provenance metadata. Skipping the column matches the task spec's guidance.

## Auth + tenancy

- `Depends(require_admin)` — JWT bearer or `cq_session` cookie attached to a user with `admin` / `enterprise_admin` / `l2_admin` role.
- Body's `enterprise` field MUST be **different** from caller's resolved tenancy. Same-enterprise body returns 422 with a pointer to `/admin/aigrp/peers`.
- Sentinel `default-enterprise` rejected on either side.
- `l2_id` must decompose to `<enterprise>/<group>`.
- `pubkey` must parse as base64url.

## Trust caveat

**The admin pasting the announce IS the trust anchor.** No callback verification of the announced pubkey, no co-signature check, no out-of-band attestation. The receiving L2 will treat the pasted Ed25519 pubkey as authoritative for the named peer L2 on every subsequent consult forward.

Out-of-band verification of the peer's pubkey **before** pasting is mandatory — peer admin reads it off their L2's startup log; receiving admin pastes it into this endpoint. Documented in `docs/ops/peer-announce.md`.

## Files

- `server/backend/src/cq_server/aigrp_directory_peer_routes.py` (new — endpoint + helpers)
- `server/backend/tests/test_aigrp_directory_peer_routes.py` (new — 13 tests)
- `server/backend/src/cq_server/app.py` (router wiring, mirrors #345)
- `docs/ops/peer-announce.md` (extended with cross-Enterprise section + drift-items + trust caveat)

## Tests

13 new tests, all pass. Highlights:

- Auth: 401 unauthenticated, 403 non-admin
- Tenancy: same-Enterprise 422 with pointer to `/admin/aigrp/peers`; `default-enterprise` sentinel 422
- Resolver wire-up — `find_active_directory_peering(from, to)` returns the row immediately after announce (the load-bearing assertion — it's why the endpoint exists)
- Idempotent re-paste — same `(from, to, l2_id)` upserts a single row
- Independent peer L2s land distinct rows
- `ttl_days` override, optional AAISN, pubkey/l2_id validation

Regression: #345's `test_aigrp_peer_routes.py` (9) + `test_aigrp_federation.py` (14) still pass — 23/23.

Pre-commit clean (ruff, ty, secrets, format).

## What this PR does NOT touch

- `forward_sign.py` (Option B — out of scope per the issue body).
- The directory client's pull loop (its rows overwrite manual rows on the next sync — correct precedence).
- #345's intra-Enterprise endpoint (purely additive).

## Refs

- #347 — parent issue (Option A path)
- #345 — intra-Enterprise sibling (reference implementation)
- #343 — mvp-* drift items unblocked
- #337 — parent issue for the intra-Enterprise endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)
