### PR TITLE
docs(cli): document install.8th-layer.ai consumer + 8l-cq rename

### DIFF
--- a/cli/RELEASING.md
+++ b/cli/RELEASING.md
@@ -64,3 +64,40 @@ for f in $OUT/*.zip; do aws s3 cp "$f" "s3://$B/cli/v$VER/$(basename $f)" \
 
 Then set `cli_min_version` in `plugins/cq/scripts/bootstrap.json` to `$VER`
 and bump the plugin version in `plugins/cq/.claude-plugin/plugin.json`.
+
+## Consumers of `s3://…/cli/v$VER/`
+
+Two distinct consumers pull from this prefix:
+
+1. **The cq plugin** (`plugins/cq/scripts/cq_binary.py`) — fetches the
+   tarball when a Claude Code session needs a `cq` binary on PATH.
+   Installs as `cq` (the upstream name). This is the path that
+   actually runs `propose` / `query` / `mcp` etc.
+
+2. **The public installer at `install.8th-layer.ai`** — lives in
+   [`OneZero1ai/8l-cli`](https://github.com/OneZero1ai/8l-cli)
+   alongside the operator binary it primarily installs (`8l`). It
+   pulls the cq tarball from this prefix and installs the binary as
+   **`8l-cq`** (not as `8l`, which is reserved for the operator CLI
+   built from `OneZero1ai/8l-cli` and published under the
+   `s3://…/8l/v$VER/` prefix). The rename is a no-op against the
+   tarball — the binary inside is still `cq` and the rename happens
+   on the user's filesystem.
+
+The two binaries live side-by-side on PATH:
+
+| Binary | Source | Subcommand surface |
+|---|---|---|
+| `8l` | `OneZero1ai/8l-cli` | `join`, `quick`, `status`, `unjoin`, `doctor`, `rotate-key` (operator) |
+| `8l-cq` | this repo (`cli/`) | `prompt`, `propose`, `query`, `status`, `confirm`, `drain`, `flag`, `mcp` (agent) |
+
+When publishing a new `cq` release here, the public installer keeps
+working without changes — it pins `8l-cq` to the latest `cli/v*`
+tarball published in this bucket. See OneZero1ai/8th-layer-agent#353
+for the cross-repo tracking issue.
+
+> **Follow-up:** the `cli/` S3 prefix predates the split and is no
+> longer self-describing. Renaming it to `cq/` for symmetry with the
+> `8l/` prefix is on the backlog; that change is breaking for the
+> plugin's `cq_binary.py` and the installer at `install.8th-layer.ai`,
+> so it needs to land with coordinated bumps in both consumers.


### PR DESCRIPTION
## Summary
- Adds a new "Consumers of s3://…/cli/v\$VER/" section to `cli/RELEASING.md` calling out the two consumers of the cq release tarballs: the cq plugin (`plugins/cq/scripts/cq_binary.py`) and the public installer at `install.8th-layer.ai`.
- Documents that the public installer (now hosted in `OneZero1ai/8l-cli`) renames the cq binary to **`8l-cq`** on the user's filesystem, so it can coexist with `8l` (the operator CLI built from `OneZero1ai/8l-cli`, published under the new `s3://…/8l/v*/` prefix).
- Adds a follow-up note about renaming the `cli/` S3 prefix to `cq/` for symmetry with `8l/` — flagged as breaking for both consumers, so out of scope for this PR.

## Why
Part of the installer-correctness umbrella tracked in #353. Today the script at `install.8th-layer.ai` pulls a `cq_*.tar.gz` from this repo's release bucket, renames the binary to `8l`, and the setup tour then tells users to run `8l join` — which doesn't exist in `cq`. The unified installer (PR `8l-cli#C`, coming next) will pull the same tarball but install the binary as `8l-cq`. This PR is the documentation half — no code changes here; the cq tarball layout stays exactly as it is today.

## Test plan
- [x] Renders correctly on GitHub.
- [ ] No follow-up edits needed once PR `8l-cli#C` lands and `install.8th-layer.ai` switches over.

Refs #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)