### PR TITLE
docs(cli): note cq binary is plugin-runtime-only post-Decision-35

### DIFF
--- a/cli/RELEASING.md
+++ b/cli/RELEASING.md
@@ -1,5 +1,17 @@
 # Releasing the cq binary
 
+> **Scope (Decision 35, 2026-05-20):** This binary is **plugin-runtime-only** going
+> forward. It is downloaded by the `8l-cq` Claude Code plugin on first use; it is
+> never installed onto a user's PATH and never published through
+> https://install.8th-layer.ai. The user-facing operator CLI (`8l`) lives in
+> [`OneZero1ai/8l-cli`](https://github.com/OneZero1ai/8l-cli) and releases to the
+> sibling `8l/v*/` prefix on the same S3 bucket via the `8l-cli-release`
+> CodeBuild project. See:
+> https://github.com/OneZero1ai/crosstalk-enterprise/blob/main/docs/decisions/35-cli-unification-one-8l-binary.md
+>
+> A `DEPRECATED.md` marker has been uploaded to `s3://.../cli/DEPRECATED.md` so
+> anyone poking at the prefix sees the same information.
+
 The 8th-Layer fork ships its own `cq` binary because it carries Go-side
 additions (e.g. the `propose_batch` MCP tool) that upstream's published
 binary does not. The plugin (`plugins/cq/scripts/cq_binary.py`) fetches


### PR DESCRIPTION
Adds a scope banner to `cli/RELEASING.md` flagging that this binary is no longer the user-facing CLI as of Decision 35 ([crosstalk-enterprise#75](https://github.com/OneZero1ai/crosstalk-enterprise/blob/main/docs/decisions/35-cli-unification-one-8l-binary.md)).

## Context

Per Decision 35, the unified user-facing CLI is now `8l` from [OneZero1ai/8l-cli](https://github.com/OneZero1ai/8l-cli), published to the sibling `8l/v*/` prefix on the same S3 bucket via the new `8l-cli-release` CodeBuild project (provisioned today, account 124074140789). https://install.8th-layer.ai serves that binary only.

This prefix (`cli/v*/`) continues to host the Python `cq` binary that the `8l-cq` plugin downloads on first use via `plugins/cq/scripts/cq_binary.py`. **No code change** here, just a banner.

Out-of-band: `s3://.../cli/DEPRECATED.md` marker uploaded today pointing at this same shift.

Closes-via-design: agent#353 (installer correctness), agent#355 (RELEASING.md "two consumers" framing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)