### PR TITLE
feat(transactional): central mail service (closes #348, Decision 34)

### DIFF
--- a/bin/backfill-tx-keys.py
+++ b/bin/backfill-tx-keys.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Backfill ``tx_send_key`` SSM parameters for L2s deployed pre-Decision-34.
+
+Decision 34 introduced a per-L2 HMAC key (``TX_SEND_KEY``) sourced from
+SSM at ``/8th-layer/l2/{enterprise}/{group}/tx_send_key`` in the L2's
+own AWS account. New L2s get this minted by the provisioning service.
+L2s that pre-date Decision 34 need a one-time backfill — that's what
+this script does.
+
+# Usage
+
+Mint a key for one L2:
+
+    ./bin/backfill-tx-keys.py \\
+        --aws-profile <l2-profile> \\
+        --enterprise <ent> \\
+        --group <grp>
+
+Bulk-mint for a list of L2s (one ``ent/grp`` per line in a file):
+
+    ./bin/backfill-tx-keys.py \\
+        --aws-profile <l2-profile> \\
+        --from-file l2s.txt
+
+Dry-run (default if neither --execute nor --from-file is passed):
+
+    ./bin/backfill-tx-keys.py --aws-profile foo --enterprise acme --group eng --dry-run
+
+# Twin write
+
+The control-plane resolver (``SsmKeyResolver``) reads the key from SSM
+in the control-plane account (``124074140789``) — the central service
+needs to know what each L2 is signing with. So this script writes to
+BOTH:
+
+* The L2's own AWS account (so the ECS task can read it at startup).
+* The control plane account (so the central service can verify the
+  HMAC).
+
+Pass ``--control-plane-profile`` to enable the control-plane write
+(omit to skip — useful in dev / when running by hand against just one
+account).
+
+# Idempotency
+
+The same key value is written to both accounts. Re-running the script
+on an existing L2 with ``--rotate`` mints a fresh key and overwrites
+both sides atomically (the central side first, then the L2 side; if
+the L2 side fails the central side gets rolled back to the previous
+value via a second write).
+
+Without ``--rotate``, the script refuses to overwrite an existing key
+(by default — guard against accidental rotation). Use ``--force`` to
+override.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import secrets
+import sys
+from pathlib import Path
+from typing import Iterable
+
+# Boto3 is imported lazily so --help on a machine without boto3 still works.
+
+log = logging.getLogger("backfill-tx-keys")
+
+CONTROL_PLANE_ACCOUNT = "124074140789"
+
+
+def _mint_key() -> str:
+    """Generate a fresh HMAC key.
+
+    64 hex chars (256 bits) of cryptographic randomness. The control-
+    plane signature scheme uses HMAC-SHA256, so 256 bits is the
+    natural key size. Hex (not base64) for grep-friendly diagnostics.
+    """
+    return secrets.token_hex(32)
+
+
+def _ssm_param_name(enterprise: str, group: str) -> str:
+    return f"/8th-layer/l2/{enterprise}/{group}/tx_send_key"
+
+
+def _write_param(
+    session: "boto3.session.Session",  # noqa: F821 — forward ref
+    enterprise: str,
+    group: str,
+    value: str,
+    *,
+    overwrite: bool,
+    dry_run: bool,
+    label: str,
+) -> None:
+    name = _ssm_param_name(enterprise, group)
+    if dry_run:
+        log.info("DRY-RUN [%s]: would put_parameter Name=%s Overwrite=%s", label, name, overwrite)
+        return
+    client = session.client("ssm")
+    client.put_parameter(
+        Name=name,
+        Description=f"Decision 34 tx_send_key for {enterprise}/{group}",
+        Value=value,
+        Type="SecureString",
+        Overwrite=overwrite,
+        Tier="Standard",
+    )
+    log.info("[%s] put_parameter %s OK (len=%d)", label, name, len(value))
+
+
+def _read_param(
+    session: "boto3.session.Session",  # noqa: F821
+    enterprise: str,
+    group: str,
+) -> str | None:
+    name = _ssm_param_name(enterprise, group)
+    client = session.client("ssm")
+    try:
+        resp = client.get_parameter(Name=name, WithDecryption=True)
+    except client.exceptions.ParameterNotFound:
+        return None
+    return resp["Parameter"]["Value"]
+
+
+def backfill_one(
+    *,
+    l2_session: "boto3.session.Session",  # noqa: F821
+    cp_session: "boto3.session.Session | None",  # noqa: F821
+    enterprise: str,
+    group: str,
+    dry_run: bool,
+    rotate: bool,
+    force: bool,
+) -> bool:
+    """Backfill (or rotate) one L2's tx_send_key. Returns True on success."""
+    existing = _read_param(l2_session, enterprise, group) if not dry_run else None
+    if existing and not (rotate or force):
+        log.warning(
+            "%s/%s already has a tx_send_key — pass --rotate to mint a new one "
+            "or --force to overwrite without rotating",
+            enterprise,
+            group,
+        )
+        return False
+
+    new_key = _mint_key()
+    overwrite = bool(existing) or rotate or force
+
+    # Control-plane write first (so the central service knows the new
+    # key before the L2 starts signing with it).
+    if cp_session is not None:
+        _write_param(
+            cp_session,
+            enterprise,
+            group,
+            new_key,
+            overwrite=overwrite,
+            dry_run=dry_run,
+            label="control-plane",
+        )
+    else:
+        log.info(
+            "skipping control-plane write (no --control-plane-profile); "
+            "the central service must be updated separately"
+        )
+
+    # Then the L2 side. If THIS fails we have a brief window where the
+    # control plane has the new key but the L2 doesn't — the L2 keeps
+    # signing with whatever's in its env (no SSM re-read on the hot
+    # path; the env is set once at task start). That's safe.
+    try:
+        _write_param(
+            l2_session,
+            enterprise,
+            group,
+            new_key,
+            overwrite=overwrite,
+            dry_run=dry_run,
+            label="l2",
+        )
+    except Exception as exc:
+        log.error("L2-side write failed for %s/%s: %s", enterprise, group, exc)
+        if cp_session is not None and existing:
+            # Roll the control-plane side back so the two stay in sync.
+            log.warning("rolling control-plane back to previous value")
+            try:
+                _write_param(
+                    cp_session,
+                    enterprise,
+                    group,
+                    existing,
+                    overwrite=True,
+                    dry_run=dry_run,
+                    label="control-plane-rollback",
+                )
+            except Exception:
+                log.exception("rollback ALSO failed — manual intervention required")
+        return False
+
+    log.info("backfill OK: %s/%s", enterprise, group)
+    return True
+
+
+def _read_l2_list(path: Path) -> Iterable[tuple[str, str]]:
+    """File format: one ``enterprise/group`` per line. ``#`` comments allowed."""
+    for raw_line in path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "/" not in line:
+            log.warning("skipping malformed line: %r (expected enterprise/group)", line)
+            continue
+        ent, grp = line.split("/", 1)
+        yield ent.strip(), grp.strip()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--aws-profile", required=True, help="boto3 profile for the L2's own AWS account")
+    parser.add_argument("--control-plane-profile", help="boto3 profile for the control-plane account (124074140789); enables twin-write")
+    parser.add_argument("--enterprise", help="single L2's enterprise slug")
+    parser.add_argument("--group", help="single L2's group slug")
+    parser.add_argument("--from-file", type=Path, help="bulk: file with enterprise/group lines")
+    parser.add_argument("--dry-run", action="store_true", help="read-only; print what would happen")
+    parser.add_argument("--execute", action="store_true", help="actually write; required for non-dry-run")
+    parser.add_argument("--rotate", action="store_true", help="mint a fresh key even if one exists")
+    parser.add_argument("--force", action="store_true", help="overwrite without rotating (recovery path)")
+    parser.add_argument("--region", default="us-east-1", help="AWS region (default us-east-1)")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
+    # Default to dry-run if neither --execute nor --dry-run is set.
+    # Explicit is better than the inverse default.
+    if not args.execute and not args.dry_run:
+        log.info("neither --execute nor --dry-run set; defaulting to --dry-run")
+        args.dry_run = True
+
+    # Resolve target list.
+    if args.from_file:
+        targets = list(_read_l2_list(args.from_file))
+    elif args.enterprise and args.group:
+        targets = [(args.enterprise, args.group)]
+    else:
+        parser.error("pass either --from-file OR both --enterprise and --group")
+
+    import boto3
+
+    l2_session = boto3.session.Session(
+        profile_name=args.aws_profile, region_name=args.region
+    )
+    cp_session = (
+        boto3.session.Session(
+            profile_name=args.control_plane_profile, region_name=args.region
+        )
+        if args.control_plane_profile
+        else None
+    )
+
+    if cp_session is not None and not args.dry_run:
+        # Sanity check: the control-plane account is 124074140789.
+        sts = cp_session.client("sts")
+        ident = sts.get_caller_identity()
+        if ident["Account"] != CONTROL_PLANE_ACCOUNT:
+            log.error(
+                "control-plane profile resolves to account %s, expected %s — refusing",
+                ident["Account"],
+                CONTROL_PLANE_ACCOUNT,
+            )
+            return 2
+
+    ok = 0
+    failed = 0
+    for ent, grp in targets:
+        if backfill_one(
+            l2_session=l2_session,
+            cp_session=cp_session,
+            enterprise=ent,
+            group=grp,
+            dry_run=args.dry_run,
+            rotate=args.rotate,
+            force=args.force,
+        ):
+            ok += 1
+        else:
+            failed += 1
+
+    log.info("done: %d ok, %d failed", ok, failed)
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/aws/marketplace-l2.yaml
+++ b/deploy/aws/marketplace-l2.yaml
@@ -114,6 +114,18 @@ Parameters:
       cq-server task — the L2 pulls peerings from here to authorize
       incoming cross-Enterprise consults.
 
+  TxSendBaseUrl:
+    Type: String
+    Default: https://directory.8th-layer.ai
+    Description: |
+      Base URL of the central transactional-mail service (Decision 34,
+      agent#348). Becomes TX_SEND_BASE_URL on the cq-server task; the
+      L2 posts every outbound transactional email here (invite magic-
+      link, password reset, 2FA, account event, security alert) via
+      HMAC-signed JSON. Co-located with the directory by default;
+      operators can split if/when transactional mail moves to its own
+      subdomain.
+
   RootPubkeyB64u:
     Type: String
     Description: |
@@ -369,10 +381,13 @@ Resources:
   # IAM
   #   - TaskExecutionRole: ECS agent pulls image, writes logs, fetches
   #                        secrets at task start (assumed by ecs-tasks).
-  #   - TaskRole:          runtime (SES, secrets, KMS, ssmmessages for
-  #                        ecs execute-command). No volume perms — EBS
-  #                        is host-attached via CFN VolumeAttachment,
-  #                        not by the task.
+  #   - TaskRole:          runtime (SSM read for TX_SEND_KEY, secrets,
+  #                        KMS, ssmmessages for ecs execute-command).
+  #                        SES is GONE — Decision 34 moved all mail
+  #                        dispatch to the central control-plane
+  #                        service; L2s never call SES directly. No
+  #                        volume perms either — EBS is host-attached
+  #                        via CFN VolumeAttachment, not by the task.
   #   - InstanceRole:      EC2 host runs the ECS agent (assumed by ec2).
   #   - DlmRole:           AWS DLM assumes this to create snapshots.
   # =====================================================================
@@ -398,6 +413,24 @@ Resources:
                   - !Ref JwtSecret
                   - !Ref ApiKeyPepper
                   - !Ref AigrpPeerKey
+        # Decision 34 — the ECS-task-secret integration uses the TASK
+        # EXECUTION role to fetch the SSM parameter at task start, then
+        # injects the value as TX_SEND_KEY in the container's env. The
+        # task role above grants the running container read-access; this
+        # one grants ECS itself read-access at startup.
+        - PolicyName: TxSendKeySsmReadAtStart
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: [ssm:GetParameters]
+                Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/8th-layer/l2/${EnterpriseSlug}/${CqGroupId}/tx_send_key"
+              - Effect: Allow
+                Action: [kms:Decrypt]
+                Resource: "*"
+                Condition:
+                  StringEquals:
+                    "kms:ViaService": !Sub "ssm.${AWS::Region}.amazonaws.com"
 
   TaskRole:
     Type: AWS::IAM::Role
@@ -409,19 +442,27 @@ Resources:
             Principal: { Service: ecs-tasks.amazonaws.com }
             Action: sts:AssumeRole
       Policies:
-        - PolicyName: SesSendInvites
+        # Decision 34 (agent#348): SES IAM has been removed. L2 tasks
+        # NO LONGER call SES directly — every transactional send is
+        # routed via HMAC-signed POST to the central control-plane
+        # service at TxSendBaseUrl. The task role gets SSM read on the
+        # per-L2 tx_send_key parameter (below) instead.
+        - PolicyName: TxSendKeyRead
           PolicyDocument:
             Version: "2012-10-17"
             Statement:
               - Effect: Allow
-                Action:
-                  - ses:SendEmail
-                  - ses:SendRawEmail
+                Action: [ssm:GetParameter, ssm:GetParameters]
+                Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/8th-layer/l2/${EnterpriseSlug}/${CqGroupId}/tx_send_key"
+              # ECS task secrets fetched via SSM use kms:Decrypt against
+              # the alias used to encrypt the parameter; allow the
+              # alias-managed decrypt path same as SecretsManager.
+              - Effect: Allow
+                Action: [kms:Decrypt]
                 Resource: "*"
                 Condition:
                   StringEquals:
-                    "ses:FromAddress":
-                      - !Sub "noreply@${EnterpriseSlug}.8th-layer.ai"
+                    "kms:ViaService": !Sub "ssm.${AWS::Region}.amazonaws.com"
         - PolicyName: SecretsReadRuntime
           PolicyDocument:
             Version: "2012-10-17"
@@ -721,6 +762,11 @@ Resources:
             - { Name: CQ_DIRECTORY_PULL_INTERVAL_SEC, Value: "60" }
             - { Name: CQ_AIGRP_IS_FIRST_DEPLOY, Value: "true" }
             - { Name: CQ_AIGRP_SEED_PEER_URL, Value: "" }
+            # Decision 34 (agent#348) — base URL of the central
+            # transactional-mail service. The L2's email_sender posts
+            # signed JSON to {TX_SEND_BASE_URL}/api/v1/transactional/send
+            # instead of calling SES directly.
+            - { Name: TX_SEND_BASE_URL, Value: !Ref TxSendBaseUrl }
             # agent#180 — only emitted when AutoApprovePropose=true, so a
             # default deploy leaves the env unset (status='pending').
             - !If
@@ -741,6 +787,13 @@ Resources:
             - { Name: CQ_JWT_SECRET,      ValueFrom: !Ref JwtSecret }
             - { Name: CQ_API_KEY_PEPPER,  ValueFrom: !Ref ApiKeyPepper }
             - { Name: CQ_AIGRP_PEER_KEY,  ValueFrom: !Ref AigrpPeerKey }
+            # Decision 34 — TX_SEND_KEY mounted from SSM at task start.
+            # The parameter is written into the L2's own account by the
+            # provisioning service (or backfilled via bin/backfill-tx-keys
+            # for L2s that pre-date Decision 34). ValueFrom takes the
+            # full SSM parameter ARN for cross-account-safe resolution.
+            - Name: TX_SEND_KEY
+              ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/8th-layer/l2/${EnterpriseSlug}/${CqGroupId}/tx_send_key"
           # Container-level health check uses python (urllib) rather than
           # curl because the cq-server image (Python slim base) doesn't
           # ship curl/wget. The image already declares the same probe in

--- a/docs/ops/transactional-mail-migration.md
+++ b/docs/ops/transactional-mail-migration.md
@@ -1,0 +1,172 @@
+# Transactional mail migration (Decision 34)
+
+How to migrate an existing L2 from the pre-Decision-34 self-SES posture
+to the central transactional-mail service.
+
+## Why
+
+Pre-Decision-34, every L2 called SES from its own AWS account using
+the L2 task role's `ses:SendEmail` IAM permission. Customer L2s had
+to verify `8th-layer.ai` as a domain identity in their account, exit
+SES sandbox, and own the DKIM + SPF DNS records — none of which is
+plausible for a marketplace one-click deploy.
+
+Decision 34 (in `8th-layer-core/docs/decisions/34-...`) moves all
+transactional mail to a central service running on the control-plane
+deployment. L2s post HMAC-signed JSON to
+`https://directory.8th-layer.ai/api/v1/transactional/send`; the
+control plane dispatches via SES from account `124074140789`, where
+DKIM + SPF + bounce/complaint handling are already wired.
+
+## What changes per L2
+
+Three things land on each existing L2:
+
+1. **A `tx_send_key` SSM parameter** in the L2's own AWS account, at
+   `/8th-layer/l2/{enterprise}/{group}/tx_send_key`. Same key value
+   is written into the control-plane SSM under the same path (for the
+   HMAC resolver to verify with).
+2. **A CFN stack update** that adds the `TX_SEND_KEY` task secret
+   binding + `TX_SEND_BASE_URL` env var + drops the `SesSendInvites`
+   IAM policy.
+3. **A cq-server image bump** to a build that includes the
+   HTTP-client-based `email_sender.py` (Decision 34 build).
+
+Steps 1 and 3 unblock new sends. Step 2 is the IAM cleanup; it can
+land in a separate pass with the standard `update-stack` discipline
+(no image bump required).
+
+## Migration sequence
+
+### Pre-flight
+
+1. Confirm the central service is up:
+   ```
+   curl -sS https://directory.8th-layer.ai/api/v1/health
+   ```
+2. Confirm the control-plane SES is configured:
+   ```
+   aws --profile 8th-layer-app ses get-account-sending-enabled --region us-east-1
+   ```
+3. Confirm the bounce/complaint SNS topics exist in 124074140789:
+   ```
+   aws --profile 8th-layer-app sns list-topics --region us-east-1 \
+       | grep -E "ses-(bounces|complaints)"
+   ```
+
+### Per-L2 backfill
+
+Mint the per-L2 key and write to both accounts:
+
+```
+./bin/backfill-tx-keys.py \
+    --aws-profile <l2-aws-profile> \
+    --control-plane-profile 8th-layer-app \
+    --enterprise <ent> \
+    --group <grp> \
+    --execute
+```
+
+Verify:
+
+```
+aws --profile <l2-aws-profile> ssm get-parameter \
+    --name /8th-layer/l2/<ent>/<grp>/tx_send_key \
+    --with-decryption | jq -r .Parameter.Value
+```
+
+### Roll the image (image-bump-only deploy)
+
+```
+aws cloudformation update-stack \
+    --profile <l2-aws-profile> \
+    --stack-name <l2-stack> \
+    --use-previous-template \
+    --parameters \
+        ParameterKey=CqServerImage,ParameterValue=public.ecr.aws/w2i0e4m6/cq-server:<decision-34-build> \
+        ParameterKey=...rest-with-UsePreviousValue
+```
+
+At this point the L2 task picks up the new image; the new
+`email_sender.py` reads `TX_SEND_KEY` from env (still empty —
+parameter exists but the task definition hasn't been updated to bind
+it) and falls back to legacy SES IF `CQ_EMAIL_LEGACY_SES=1` is set,
+or errors otherwise.
+
+To enable the legacy fallback during the migration window:
+
+```
+# Edit the task definition out-of-band (or set CQ_EMAIL_LEGACY_SES
+# in the CFN template as an interim override).
+```
+
+### Stack-template update (drops SES IAM + binds TX_SEND_KEY)
+
+```
+aws cloudformation update-stack \
+    --profile <l2-aws-profile> \
+    --stack-name <l2-stack> \
+    --template-body file://deploy/aws/marketplace-l2.yaml \
+    --parameters \
+        ParameterKey=CqServerImage,ParameterValue=<decision-34-build> \
+        ...rest-with-UsePreviousValue \
+    --capabilities CAPABILITY_NAMED_IAM
+```
+
+After this update:
+
+* `TX_SEND_KEY` is bound from SSM at task start.
+* The task role has no `ses:SendEmail` IAM at all.
+* The L2 sends via HTTP. Verify with the next invite-mint.
+
+### Verify
+
+Mint a test invite from the L2's admin shell to an external address
+you control. Watch:
+
+* The L2's task logs — `email_sender: HTTP transport error` would
+  surface here if the central service is unreachable.
+* The control-plane task logs —
+  `transactional/send ok l2_id=<ent>/<grp> ...` lines per send.
+* CloudWatch SES metrics in 124074140789 (Send count should tick up).
+* The recipient inbox.
+
+## Estimated time per L2
+
+| Phase | Time |
+|--|--|
+| Backfill (single L2) | ~30 seconds |
+| Image-bump update-stack | ~3 minutes (ECS rolling-restart) |
+| Template-change update-stack | ~5 minutes (IAM change + new task-def revision) |
+| Verification send | ~1 minute |
+| **Total per L2** | **~10 minutes** |
+
+For the 11 live L2s, plan ~2 hours of focused operator time. Bulk
+backfill with `--from-file` reduces that to ~1.5 hours since the
+backfill phase becomes one command.
+
+## L2s in scope
+
+(Refresh this list before running — these are the L2s known as of
+2026-05-20.)
+
+* eng (engineering / 8th-layer)
+* sga (sga / 8th-layer)
+* mvp-s1 … mvp-s4
+* team-dw
+* Carmen's L2 (the trigger case)
+
+Plus any further L2s deployed between 2026-05-20 and the cut-over.
+
+## Rollback
+
+If a per-L2 backfill goes wrong: re-run with `--rotate --force` to
+mint a fresh key.
+
+If the central service is degraded and the L2 needs to bypass it
+quickly: set `CQ_EMAIL_LEGACY_SES=1` in the task definition (or via
+the CFN parameter once a follow-up adds it). The L2 will detect the
+missing TX_SEND_KEY (if you've already pulled it via the template
+update) and fall back to legacy SES with a clear deprecation log
+line. This is the migration-window safety net; reset to clean state
+once central is healthy.

--- a/server/backend/alembic/versions/0026_transactional_suppression.py
+++ b/server/backend/alembic/versions/0026_transactional_suppression.py
@@ -1,0 +1,107 @@
+"""Decision 34 — ``transactional_suppression`` table (central mail service).
+
+Revision ID: 0026_transactional_suppression
+Revises: 0025_activity_log_aigrp_lookup_event
+Create Date: 2026-05-20
+
+Central transactional-mail service (agent#348 / Decision 34). The
+control-plane cq-server runs an SES dispatcher for every L2; bounces
+and complaints fan back via SNS → suppression writer → this table. The
+send path checks the table before SES dispatch and returns 409 on a
+hit.
+
+Schema:
+
+* ``address`` — recipient email, lowercased. PRIMARY KEY so a re-hit
+  on the same address is idempotent. Suppression is cross-category by
+  design: once you bounce on any send, no further sends go out from
+  any L2.
+* ``reason`` — short tag (e.g. ``hard_bounce_2026-05-15``,
+  ``complaint_2026-05-15``). Free-form; the writer composes it from
+  the SNS event type + date.
+* ``suppressed_at`` — ISO 8601 timestamp, matches the convention used
+  by the rest of the schema (``users.created_at``, ``invites.*``, …).
+* ``source_event_id`` — the SNS ``MessageId`` of the bounce /
+  complaint event that drove the insert. Lets us reconcile against
+  the SES → SNS audit trail when investigating.
+
+# Idempotency
+
+PRIMARY KEY on ``address`` means a second insert for the same address
+is a no-op when the writer uses ``INSERT … ON CONFLICT DO NOTHING``.
+The first reason wins; subsequent bounces don't overwrite (the address
+is already blocked, so the diagnostic value of an updated reason is
+low).
+
+# Why not soft-delete
+
+Unsuppression is a deliberate operator action (e.g. customer-reported
+false-positive after their mailbox rebound). A ``suppressed_at``
+column with no ``unsuppressed_at`` partner keeps the table append-only
+in the happy path; un-suppressing is ``DELETE FROM
+transactional_suppression WHERE address = ?`` and an audit-log entry,
+not a tombstone. Mass un-suppression (e.g. after a domain-wide bounce
+storm) is rare enough that the runbook delta isn't worth a schema
+column.
+
+# Chain note
+
+Sits on top of 0025; no upstream dependency on FO-* migrations.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0026_transactional_suppression"
+down_revision: str | Sequence[str] | None = "0025_activity_log_aigrp_lookup_event"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _table_exists(bind: sa.engine.Connection, table_name: str) -> bool:
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def upgrade() -> None:
+    """Create the ``transactional_suppression`` table."""
+    bind = op.get_bind()
+
+    if _table_exists(bind, "transactional_suppression"):
+        return
+
+    op.create_table(
+        "transactional_suppression",
+        sa.Column("address", sa.Text(), primary_key=True, nullable=False),
+        sa.Column("reason", sa.Text(), nullable=False),
+        sa.Column("suppressed_at", sa.Text(), nullable=False),
+        sa.Column("source_event_id", sa.Text(), nullable=True),
+    )
+    # Index on suppressed_at — operator queries "what bounced in the
+    # last 24h?" are common enough to warrant the index. address is
+    # the PK so equality lookups (send-path check) are already fast.
+    op.create_index(
+        "idx_transactional_suppression_suppressed_at",
+        "transactional_suppression",
+        ["suppressed_at"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the index and table."""
+    bind = op.get_bind()
+    if not _table_exists(bind, "transactional_suppression"):
+        return
+
+    inspector = sa.inspect(bind)
+    idx_names = {idx["name"] for idx in inspector.get_indexes("transactional_suppression")}
+    if "idx_transactional_suppression_suppressed_at" in idx_names:
+        op.drop_index(
+            "idx_transactional_suppression_suppressed_at",
+            table_name="transactional_suppression",
+        )
+    op.drop_table("transactional_suppression")

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -55,6 +55,7 @@ from .store._sqlite import SqliteStore
 from .tables import DEFAULT_ENTERPRISE_ID, DEFAULT_GROUP_ID
 from .theme_routes import router as theme_router
 from .tour_routes import router as tour_router
+from .transactional import transactional_router
 
 _STATIC_DIR = Path(__file__).parent / "static"
 
@@ -511,6 +512,13 @@ api_router.include_router(theme_router)
 # Founder-tour persistence — GET/PUT /api/v1/users/me/tour-state for
 # the in-app onboarding walkthrough.
 api_router.include_router(tour_router)
+# Decision 34 (agent#348) — central transactional-mail service. Only
+# served by the control-plane deployment (the cq-directory role); L2s
+# leave the route enabled but never receive sends since their HMAC
+# resolver is empty (StaticKeyResolver({})) and every request 401s.
+# That's the right fails-closed default — production wiring is in
+# deploy/aws/ for the control-plane stack.
+api_router.include_router(transactional_router)
 
 
 @api_router.get("/health")

--- a/server/backend/src/cq_server/email_sender.py
+++ b/server/backend/src/cq_server/email_sender.py
@@ -1,48 +1,102 @@
-"""Email sending — boto3 SES wrapper for invite delivery (FO-1b).
+"""Email sending — L2-side client for the central transactional-mail service.
 
-The production sender (``EmailSender``) wraps a boto3 SES v1 client. The
-mock variant (``MockEmailSender``) captures sends in memory so tests can
-assert on subject / recipient / body without touching AWS.
+# Decision 34 migration (2026-05-20)
 
-Both classes share the same ``send_invite(...)`` shape so callers
-inject the wiring at construction time and never branch on type.
+Pre-Decision-34, each L2 called SES from its own AWS account. That
+required every customer to verify ``8th-layer.ai`` as a domain
+identity, exit SES sandbox, and wire SNS bounce/complaint — the
+opposite of the marketplace "drop into your AWS account" pitch.
 
-# Why SES v1 (not SESv2)
+After Decision 34, every L2 posts to
+``https://directory.8th-layer.ai/api/v1/transactional/send`` with an
+HMAC signature; the control plane dispatches via SES from account
+``124074140789``. Customer L2s have ZERO SES setup.
 
-The AWS account that ships 8th-Layer.ai's invite-domain identity is
-already configured for SES v1; the v2 surface is only marginally
-different and we have no need for the extra features (bulk send,
-template engine) right now. Stay on v1; revisit if we want
-``SendBulkEmail``-style batching later.
+The public ``send_invite(...)`` signature is preserved. Callers (the
+admin invite route + future ``send_2fa`` / ``send_password_reset``
+helpers) don't change. Suppression hits are surfaced cleanly via
+:class:`EmailSendOutcome`.
 
-# Sandbox vs production
+# Backwards-compat fallback (migration window)
 
-Outside SES sandbox, ``send_email`` works against any verified-sender
-identity. Inside the sandbox, the *recipient* must also be verified —
-the operator runs the sandbox-exit ticket separately (agent#198). This
-module is identical across the two; the difference is operator-side
-(IAM + SES-identity setup), not code.
+If ``TX_SEND_KEY`` env var is missing AND ``CQ_EMAIL_LEGACY_SES=1``
+is set, the sender falls back to the old boto3 SES path. This lets
+the L2 image roll out ahead of the per-L2 SSM-key backfill +
+template update; the operator clears the flag once the per-L2
+``tx_send_key`` is in place. A clear deprecation log line fires every
+time the legacy path is used.
 
-# Source identity + region
+# Production wiring
 
-* ``CQ_INVITE_FROM_EMAIL`` — the From: header. Defaults to
-  ``invites@8th-layer.ai`` per FO-1 spec.
-* ``CQ_AWS_REGION`` — the SES regional endpoint. Defaults to
-  ``us-east-1`` (matches the ``orion`` profile + Bedrock region).
+* ``TX_SEND_BASE_URL`` — defaults to ``https://directory.8th-layer.ai``.
+* ``TX_SEND_KEY`` — per-L2 HMAC key, mounted from SSM at
+  ``/8th-layer/l2/{enterprise}/{group}/tx_send_key`` via the ECS
+  task definition.
+* ``CQ_ENTERPRISE`` + ``CQ_GROUP`` — already wired, used to build
+  the ``X-8L-L2-Id`` header.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
+
+from .transactional.auth import compute_signature
 
 log = logging.getLogger(__name__)
 
-DEFAULT_FROM_EMAIL = "invites@8th-layer.ai"
+DEFAULT_TX_BASE_URL = "https://directory.8th-layer.ai"
+DEFAULT_FROM_EMAIL = "invites@8th-layer.ai"  # used by MockEmailSender capture only
 DEFAULT_AWS_REGION = "us-east-1"
+DEFAULT_HTTP_TIMEOUT_SEC = 10.0
+
+# Outcome status values surfaced to callers. The route handler maps
+# 202 → "sent", 409 → "suppressed", everything else → "error". This
+# is the same envelope the admin invite route wants to log.
+SendStatus = Literal["sent", "suppressed", "error"]
+
+
+@dataclass
+class EmailSendOutcome:
+    """What ``send_invite`` (and siblings) return.
+
+    Wraps the central-service response so callers don't have to
+    introspect raw HTTP status codes. ``status`` is the load-bearing
+    field; ``reason`` is populated for ``suppressed`` and ``error``.
+    """
+
+    status: SendStatus
+    delivery_handle: str | None = None
+    ses_message_id: str | None = None
+    reason: str | None = None
+    raw: dict[str, Any] | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "sent"
+
+
+# ---------------------------------------------------------------------------
+# Env resolution
+# ---------------------------------------------------------------------------
+
+
+def _tx_base_url() -> str:
+    return os.environ.get("TX_SEND_BASE_URL", DEFAULT_TX_BASE_URL).rstrip("/")
+
+
+def _tx_send_key() -> str | None:
+    return os.environ.get("TX_SEND_KEY") or None
+
+
+def _l2_id() -> str:
+    enterprise = os.environ.get("CQ_ENTERPRISE", "")
+    group = os.environ.get("CQ_GROUP", "")
+    return f"{enterprise}/{group}"
 
 
 def _from_email() -> str:
@@ -54,13 +108,16 @@ def _aws_region() -> str:
 
 
 def _public_host(default: str = "https://app.8th-layer.ai") -> str:
-    """Return the public host used to build the claim URL.
-
-    ``CQ_PUBLIC_HOST`` is the production override. Falls back to the
-    well-known marketing domain — never to ``localhost`` because invite
-    emails sent from a localhost-baseurl would dead-link.
-    """
     return os.environ.get("CQ_PUBLIC_HOST", default)
+
+
+def _legacy_ses_enabled() -> bool:
+    return os.environ.get("CQ_EMAIL_LEGACY_SES", "").lower() in {"1", "true", "yes"}
+
+
+# ---------------------------------------------------------------------------
+# Body composition helpers (unchanged from pre-Decision-34)
+# ---------------------------------------------------------------------------
 
 
 def _claim_url(jwt: str, *, host: str | None = None) -> str:
@@ -129,12 +186,19 @@ def _render_html_body(
     )
 
 
-class EmailSender:
-    """boto3-backed SES sender. One instance per process is fine.
+# ---------------------------------------------------------------------------
+# HTTP-based EmailSender (Decision 34)
+# ---------------------------------------------------------------------------
 
-    The boto3 client is lazy-initialised on first send so import time is
-    cheap and unit tests that never call ``send_invite`` don't pay the
-    boto3 import cost.
+
+class EmailSender:
+    """HTTP-backed sender that posts to the central transactional service.
+
+    One instance per process is fine. The httpx client is lazy-
+    initialised on first send so import-time cost stays low.
+
+    Tests don't need to construct this directly — they use
+    ``MockEmailSender`` via dependency override.
     """
 
     def __init__(
@@ -143,19 +207,184 @@ class EmailSender:
         from_email: str | None = None,
         region: str | None = None,
         public_host: str | None = None,
+        base_url: str | None = None,
+        tx_key: str | None = None,
+        l2_id: str | None = None,
+        timeout_sec: float = DEFAULT_HTTP_TIMEOUT_SEC,
     ) -> None:
-        """Build the sender; resolves env-driven defaults at construction."""
+        # ``from_email`` + ``region`` retained for backwards-compat with
+        # any test fixtures that still pass them — central service
+        # ignores them (sender is persona-keyed).
         self._from_email = from_email or _from_email()
         self._region = region or _aws_region()
-        self._public_host = public_host  # None → resolved per-call
+        self._public_host = public_host
+        self._base_url = (base_url or _tx_base_url()).rstrip("/")
+        # Resolve key/l2_id lazily — env vars may be set after construction
+        # in some test patterns.
+        self._tx_key_override = tx_key
+        self._l2_id_override = l2_id
+        self._timeout = timeout_sec
         self._client: Any = None
+        self._legacy_ses_client: Any = None
 
-    def _get_client(self) -> Any:
+    # ------------------------------------------------------------------
+    # HTTP plumbing
+    # ------------------------------------------------------------------
+
+    def _get_http(self) -> Any:
         if self._client is None:
-            import boto3  # local import — keeps cold-start cost off the import graph
+            import httpx  # local — keeps cold-start cheap
 
-            self._client = boto3.client("ses", region_name=self._region)
+            self._client = httpx.Client(timeout=self._timeout)
         return self._client
+
+    def _resolve_key(self) -> str | None:
+        return self._tx_key_override or _tx_send_key()
+
+    def _resolve_l2_id(self) -> str:
+        return self._l2_id_override or _l2_id()
+
+    def _post_send(
+        self,
+        *,
+        from_persona: str,
+        to: str,
+        subject: str,
+        text_body: str,
+        html_body: str | None,
+        category: str,
+        audit_ref: str | None = None,
+    ) -> EmailSendOutcome:
+        """Post one transactional send. Returns a uniform outcome envelope."""
+        key = self._resolve_key()
+        l2_id = self._resolve_l2_id()
+        if not key:
+            # Fallback path — see module docstring on the migration window.
+            if _legacy_ses_enabled():
+                log.warning(
+                    "email_sender: TX_SEND_KEY missing; falling back to legacy SES "
+                    "(Decision 34 backfill not yet applied to this L2)"
+                )
+                return self._legacy_ses_send(
+                    from_persona=from_persona,
+                    to=to,
+                    subject=subject,
+                    text_body=text_body,
+                    html_body=html_body,
+                )
+            log.error(
+                "email_sender: TX_SEND_KEY missing and legacy SES not enabled; "
+                "cannot deliver email (set TX_SEND_KEY or CQ_EMAIL_LEGACY_SES=1)"
+            )
+            return EmailSendOutcome(
+                status="error", reason="tx_send_key_missing"
+            )
+
+        body: dict[str, Any] = {
+            "from_persona": from_persona,
+            "to": to,
+            "subject": subject,
+            "text": text_body,
+            "category": category,
+        }
+        if html_body:
+            body["html"] = html_body
+        if audit_ref:
+            body["audit_ref"] = audit_ref
+
+        # The signature is over the EXACT body bytes the server reads.
+        # Build the JSON once and reuse, so re-serialisation differences
+        # (whitespace, key order) can't break the digest.
+        body_bytes = json.dumps(body, separators=(",", ":")).encode("utf-8")
+        headers = {
+            "X-8L-L2-Id": l2_id,
+            "X-8L-Signature": compute_signature(key, body_bytes),
+            "Content-Type": "application/json",
+        }
+        if audit_ref:
+            # audit_ref doubles as the default idempotency hint — the
+            # server falls back to ``{l2_id}:ref:{audit_ref}`` when no
+            # explicit header is provided.
+            pass
+
+        url = f"{self._base_url}/api/v1/transactional/send"
+        client = self._get_http()
+        try:
+            resp = client.post(url, content=body_bytes, headers=headers)
+        except Exception as exc:
+            log.exception("email_sender: HTTP transport error to %s", url)
+            return EmailSendOutcome(status="error", reason=f"transport_error:{type(exc).__name__}")
+
+        if resp.status_code == 202:
+            payload = resp.json()
+            return EmailSendOutcome(
+                status="sent",
+                delivery_handle=payload.get("delivery_handle"),
+                ses_message_id=payload.get("ses_message_id"),
+                raw=payload,
+            )
+        if resp.status_code == 409:
+            payload = resp.json()
+            detail = payload.get("detail", payload)
+            return EmailSendOutcome(
+                status="suppressed",
+                reason=detail.get("reason"),
+                raw=detail,
+            )
+        log.error(
+            "email_sender: unexpected response status=%s body=%s",
+            resp.status_code,
+            resp.text[:200],
+        )
+        return EmailSendOutcome(
+            status="error",
+            reason=f"http_{resp.status_code}",
+            raw={"status_code": resp.status_code, "body": resp.text[:500]},
+        )
+
+    # ------------------------------------------------------------------
+    # Legacy SES fallback — used only during the migration window.
+    # ------------------------------------------------------------------
+
+    def _legacy_ses_send(
+        self,
+        *,
+        from_persona: str,
+        to: str,
+        subject: str,
+        text_body: str,
+        html_body: str | None,
+    ) -> EmailSendOutcome:
+        """Old boto3 SES path. Kept until the per-L2 backfill completes."""
+        try:
+            if self._legacy_ses_client is None:
+                import boto3
+
+                self._legacy_ses_client = boto3.client("ses", region_name=self._region)
+            client = self._legacy_ses_client
+            body_msg: dict[str, Any] = {"Text": {"Data": text_body, "Charset": "UTF-8"}}
+            if html_body:
+                body_msg["Html"] = {"Data": html_body, "Charset": "UTF-8"}
+            resp = client.send_email(
+                Source=self._from_email,
+                Destination={"ToAddresses": [to]},
+                Message={
+                    "Subject": {"Data": subject, "Charset": "UTF-8"},
+                    "Body": body_msg,
+                },
+            )
+            return EmailSendOutcome(
+                status="sent",
+                ses_message_id=resp.get("MessageId"),
+                raw=resp,
+            )
+        except Exception as exc:  # pragma: no cover — env-specific
+            log.exception("email_sender: legacy SES path failed")
+            return EmailSendOutcome(status="error", reason=f"legacy_ses_error:{type(exc).__name__}")
+
+    # ------------------------------------------------------------------
+    # Public send_* helpers — preserved signatures.
+    # ------------------------------------------------------------------
 
     def send_invite(
         self,
@@ -165,11 +394,55 @@ class EmailSender:
         enterprise_name: str,
         expiry: datetime,
     ) -> dict[str, Any]:
-        """Send an invite email. Returns the SES response (or raises).
+        """Send an invite email. Backwards-compat shape: returns a dict.
 
-        ``expiry`` is rendered as an ISO 8601 string in the email body
-        — the reader sees the deadline; the JWT enforces it.
+        For backwards compatibility with pre-Decision-34 callers that
+        expected the SES ``SendEmail`` response, we wrap the outcome
+        in a compatible-enough dict:
+
+        * ``MessageId`` — present on ``sent`` and legacy paths.
+        * ``status`` — new field. ``"sent" | "suppressed" | "error"``.
+        * ``delivery_handle`` — central-service handle (sent path).
+        * ``reason`` — populated for ``suppressed`` and ``error``.
+
+        Callers checking ``response["MessageId"]`` keep working; new
+        callers should check ``response["status"]``.
         """
+        outcome = self._send_invite_envelope(
+            to=to,
+            jwt=jwt,
+            inviter_name=inviter_name,
+            enterprise_name=enterprise_name,
+            expiry=expiry,
+        )
+        return _outcome_to_legacy_dict(outcome)
+
+    def send_invite_outcome(
+        self,
+        to: str,
+        jwt: str,
+        inviter_name: str,
+        enterprise_name: str,
+        expiry: datetime,
+    ) -> EmailSendOutcome:
+        """Same as ``send_invite`` but returns the structured outcome."""
+        return self._send_invite_envelope(
+            to=to,
+            jwt=jwt,
+            inviter_name=inviter_name,
+            enterprise_name=enterprise_name,
+            expiry=expiry,
+        )
+
+    def _send_invite_envelope(
+        self,
+        *,
+        to: str,
+        jwt: str,
+        inviter_name: str,
+        enterprise_name: str,
+        expiry: datetime,
+    ) -> EmailSendOutcome:
         claim_url = _claim_url(jwt, host=self._public_host)
         expiry_iso = expiry.isoformat()
         subject = _render_subject(inviter_name, enterprise_name)
@@ -185,19 +458,22 @@ class EmailSender:
             expiry_iso=expiry_iso,
             claim_url=claim_url,
         )
-
-        client = self._get_client()
-        return client.send_email(
-            Source=self._from_email,
-            Destination={"ToAddresses": [to]},
-            Message={
-                "Subject": {"Data": subject, "Charset": "UTF-8"},
-                "Body": {
-                    "Text": {"Data": text_body, "Charset": "UTF-8"},
-                    "Html": {"Data": html_body, "Charset": "UTF-8"},
-                },
-            },
+        return self._post_send(
+            from_persona="invites",
+            to=to,
+            subject=subject,
+            text_body=text_body,
+            html_body=html_body,
+            category="invite_magic_link",
+            # Tie idempotency to the invite jti — re-mints with the
+            # same jti dedup within the 60s server-side window.
+            audit_ref=f"invite:{jwt[:32]}",
         )
+
+
+# ---------------------------------------------------------------------------
+# Mock — preserved for tests that exercise the email channel.
+# ---------------------------------------------------------------------------
 
 
 @dataclass
@@ -220,12 +496,18 @@ class MockEmailSender:
     """Test double — captures every ``send_invite`` call.
 
     Public attribute: ``sent`` is the captured-call list, in order.
-    Tests assert on ``sent[-1].to``, ``sent[-1].subject``, etc.
+    Existing tests asserting on ``sent[-1].to``, ``sent[-1].subject``,
+    etc., keep working unchanged.
     """
 
     from_email: str = field(default_factory=_from_email)
     public_host: str | None = None
     sent: list[CapturedEmail] = field(default_factory=list)
+    # New: simulate the central-service outcome. Default ``"sent"``
+    # preserves pre-Decision-34 behaviour; tests of the suppression
+    # branch override this.
+    next_outcome: SendStatus = "sent"
+    next_reason: str | None = None
 
     def send_invite(
         self,
@@ -235,7 +517,6 @@ class MockEmailSender:
         enterprise_name: str,
         expiry: datetime,
     ) -> dict[str, Any]:
-        """Capture the would-be send and return a fake SES MessageId."""
         claim_url = _claim_url(jwt, host=self.public_host)
         expiry_iso = expiry.isoformat()
         subject = _render_subject(inviter_name, enterprise_name)
@@ -264,4 +545,36 @@ class MockEmailSender:
                 claim_url=claim_url,
             )
         )
-        return {"MessageId": f"mock-{len(self.sent)}"}
+        outcome = EmailSendOutcome(
+            status=self.next_outcome,
+            delivery_handle=f"mock-handle-{len(self.sent)}"
+            if self.next_outcome == "sent"
+            else None,
+            ses_message_id=f"mock-{len(self.sent)}"
+            if self.next_outcome == "sent"
+            else None,
+            reason=self.next_reason,
+        )
+        return _outcome_to_legacy_dict(outcome)
+
+
+# ---------------------------------------------------------------------------
+# Internal — outcome → legacy dict adapter
+# ---------------------------------------------------------------------------
+
+
+def _outcome_to_legacy_dict(outcome: EmailSendOutcome) -> dict[str, Any]:
+    """Adapt ``EmailSendOutcome`` to the dict shape pre-Decision-34 callers expect.
+
+    Pre-Decision-34 ``send_invite`` returned the raw SES
+    ``SendEmail`` response (which has a ``MessageId`` field). New
+    callers should look at ``status``; old callers checking
+    ``["MessageId"]`` keep working when status is ``sent`` (also
+    populated on the legacy SES fallback path).
+    """
+    return {
+        "status": outcome.status,
+        "MessageId": outcome.ses_message_id,
+        "delivery_handle": outcome.delivery_handle,
+        "reason": outcome.reason,
+    }

--- a/server/backend/src/cq_server/invite_routes.py
+++ b/server/backend/src/cq_server/invite_routes.py
@@ -222,7 +222,7 @@ async def create_invite_route(
 
     expiry = datetime.fromisoformat(invite.expires_at)
     try:
-        email_sender.send_invite(
+        send_result = email_sender.send_invite(
             to=str(request.email),
             jwt=token,
             inviter_name=admin_username,
@@ -239,6 +239,41 @@ async def create_invite_route(
             status_code=502,
             detail="invite minted but email delivery failed; revoke + retry",
         ) from None
+
+    # Decision 34: send_invite now returns a structured envelope. A
+    # ``"suppressed"`` outcome is NOT an exception — the central
+    # service blocked the dispatch because the address bounced or
+    # complained on a prior send. Surface it as 409 so the admin UI
+    # can render a meaningful message and prompt revoke+retry to a
+    # different address.
+    status = (send_result or {}).get("status", "sent")
+    if status == "suppressed":
+        log.info(
+            "invite email suppressed invite_id=%s reason=%s",
+            invite.id,
+            (send_result or {}).get("reason"),
+        )
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "email_suppressed",
+                "reason": (send_result or {}).get("reason"),
+                "message": (
+                    "Invite minted but the recipient is on the suppression list "
+                    "(hard bounce or complaint). Revoke and retry to a different address."
+                ),
+            },
+        )
+    if status == "error":
+        log.error(
+            "invite email error invite_id=%s reason=%s",
+            invite.id,
+            (send_result or {}).get("reason"),
+        )
+        raise HTTPException(
+            status_code=502,
+            detail="invite minted but email delivery failed; revoke + retry",
+        )
 
     return _to_public(invite)
 

--- a/server/backend/src/cq_server/migrations.py
+++ b/server/backend/src/cq_server/migrations.py
@@ -36,7 +36,7 @@ BASELINE_REVISION = "0001"
 # Phase 2 (task #100) — chain head after porting fork-delta tables to
 # Alembic. Update this string when adding a new migration so test
 # assertions and ops scripts stay in sync with the actual chain head.
-HEAD_REVISION = "0025_activity_log_aigrp_lookup_event"
+HEAD_REVISION = "0026_transactional_suppression"
 
 
 def _find_alembic_ini() -> Path:

--- a/server/backend/src/cq_server/transactional/__init__.py
+++ b/server/backend/src/cq_server/transactional/__init__.py
@@ -1,0 +1,42 @@
+"""Central transactional-mail service — Decision 34 (agent#348).
+
+This package implements the control-plane endpoint family that every L2
+calls instead of dispatching SES directly. The shape is documented in
+``docs/decisions/34-central-transactional-mail-service.md`` (in
+``8th-layer-core``).
+
+Public surface:
+
+* :mod:`transactional.routes` — the FastAPI router mounted at
+  ``/api/v1/transactional/*``.
+* :mod:`transactional.auth` — per-L2 HMAC signature verification.
+* :mod:`transactional.suppression` — read + write helpers for the
+  ``transactional_suppression`` table.
+* :mod:`transactional.dispatcher` — the SES v1 send wrapper. Mockable
+  via :class:`MockSesDispatcher` for tests.
+* :mod:`transactional.idempotency` — in-memory dedup-within-60s store.
+"""
+
+from __future__ import annotations
+
+from .auth import HmacKeyResolver, verify_hmac_signature
+from .dispatcher import MockSesDispatcher, SesDispatcher
+from .idempotency import IdempotencyStore
+from .routes import router as transactional_router
+from .suppression import (
+    SuppressionEntry,
+    check_suppression,
+    record_suppression,
+)
+
+__all__ = [
+    "HmacKeyResolver",
+    "IdempotencyStore",
+    "MockSesDispatcher",
+    "SesDispatcher",
+    "SuppressionEntry",
+    "check_suppression",
+    "record_suppression",
+    "transactional_router",
+    "verify_hmac_signature",
+]

--- a/server/backend/src/cq_server/transactional/__init__.py
+++ b/server/backend/src/cq_server/transactional/__init__.py
@@ -23,6 +23,7 @@ from .auth import HmacKeyResolver, verify_hmac_signature
 from .dispatcher import MockSesDispatcher, SesDispatcher
 from .idempotency import IdempotencyStore
 from .routes import router as transactional_router
+from .sns_writer import handle_lambda_event, handle_sns_message
 from .suppression import (
     SuppressionEntry,
     check_suppression,
@@ -36,6 +37,8 @@ __all__ = [
     "SesDispatcher",
     "SuppressionEntry",
     "check_suppression",
+    "handle_lambda_event",
+    "handle_sns_message",
     "record_suppression",
     "transactional_router",
     "verify_hmac_signature",

--- a/server/backend/src/cq_server/transactional/auth.py
+++ b/server/backend/src/cq_server/transactional/auth.py
@@ -1,0 +1,164 @@
+"""HMAC v0 auth for the central transactional-mail service (Decision 34).
+
+# Why HMAC and not AAISN
+
+Decision 34 picks HMAC v0 for ship-now. AAISN (the Ed25519 identity
+that signs AIGRP envelopes) is the v1 follow-up. Comparable security
+in practice (per-L2 secret in SSM, scoped to one role), strictly
+simpler to implement.
+
+# Signing scheme
+
+The L2 signs the raw request body with HMAC-SHA256, keyed by its
+per-L2 ``tx_send_key`` (also stored in SSM at
+``/8th-layer/l2/{enterprise}/{group}/tx_send_key``). It posts:
+
+* ``X-8L-L2-Id: {enterprise}/{group}`` — identifies the caller.
+* ``X-8L-Signature: sha256={hex digest}`` — body MAC.
+
+The server resolves the key by ``l2_id``, recomputes the digest, and
+compares with :func:`hmac.compare_digest` (constant-time).
+
+Format choice notes:
+
+* ``sha256=...`` prefix matches GitHub's webhook signature convention
+  — operators recognise the shape; trivial to grep in logs.
+* Hex (not base64) because the prefix grammar is documented and the
+  extra ~20% size is negligible at sub-kB body sizes.
+* Body-only MAC (no headers in the input) keeps verification simple
+  and lets reverse proxies / WAFs add headers without breaking auth.
+  The body itself carries everything tenancy-relevant (``from_persona``,
+  ``to``, ``category``).
+"""
+
+from __future__ import annotations
+
+import hmac
+import logging
+import os
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import Protocol
+
+log = logging.getLogger(__name__)
+
+# X-8L-Signature shape: "sha256=<hex>". Lifted from GitHub's webhook
+# signature convention for grep-friendliness.
+SIGNATURE_PREFIX = "sha256="
+
+
+class HmacKeyResolver(Protocol):
+    """Pluggable lookup: ``l2_id`` → per-L2 ``tx_send_key`` string.
+
+    Production resolver hits SSM at
+    ``/8th-layer/l2/{enterprise}/{group}/tx_send_key`` once and caches
+    in-process. Test resolver returns from a dict.
+    """
+
+    def __call__(self, l2_id: str) -> str | None:  # pragma: no cover
+        ...
+
+
+@dataclass
+class StaticKeyResolver:
+    """In-memory key store, primarily for tests.
+
+    Production resolver implementations subscribe to the same protocol
+    but read from SSM with a small TTL cache (60s) so a rotation lands
+    within a minute without per-request SSM cost.
+    """
+
+    keys: dict[str, str]
+
+    def __call__(self, l2_id: str) -> str | None:
+        return self.keys.get(l2_id)
+
+
+from dataclasses import field as _field  # noqa: E402  — local alias
+
+
+@dataclass
+class SsmKeyResolver:
+    """Production resolver — fetches ``tx_send_key`` from SSM on first hit.
+
+    The control-plane runtime needs *read* access to every L2's
+    ``tx_send_key`` parameter. The expected layout is one parameter
+    per L2, written by the provisioning service (or the
+    ``bin/backfill-tx-keys`` script for L2s that pre-date Decision 34):
+
+        /8th-layer/l2/{enterprise}/{group}/tx_send_key
+
+    Cache TTL is per-process; on rotation, the operator restarts the
+    control-plane task or waits ``ttl_seconds``.
+    """
+
+    ttl_seconds: int = 60
+    _cache: dict[str, tuple[float, str]] = _field(default_factory=dict)
+
+    def __call__(self, l2_id: str) -> str | None:
+        import time
+
+        now = time.monotonic()
+        entry = self._cache.get(l2_id)
+        if entry is not None and now - entry[0] < self.ttl_seconds:
+            return entry[1]
+
+        try:
+            import boto3
+        except ImportError:  # pragma: no cover — boto3 is a runtime dep
+            log.error("boto3 unavailable; cannot resolve tx_send_key for l2_id=%s", l2_id)
+            return None
+
+        try:
+            enterprise, group = l2_id.split("/", 1)
+        except ValueError:
+            log.warning("malformed l2_id passed to SsmKeyResolver: %r", l2_id)
+            return None
+
+        client = boto3.client("ssm", region_name=os.environ.get("CQ_AWS_REGION", "us-east-1"))
+        param_name = f"/8th-layer/l2/{enterprise}/{group}/tx_send_key"
+        try:
+            resp = client.get_parameter(Name=param_name, WithDecryption=True)
+        except Exception as exc:  # pragma: no cover — env-specific
+            log.warning("SSM get_parameter failed for %s: %s", param_name, exc)
+            return None
+
+        value = resp.get("Parameter", {}).get("Value")
+        if value:
+            self._cache[l2_id] = (now, value)
+        return value
+
+
+def compute_signature(key: str, body: bytes) -> str:
+    """Return the ``sha256=<hex>`` signature for ``body`` under ``key``.
+
+    Exposed so the L2-side client can sign without reimplementing the
+    scheme. Both sides MUST use this function — divergence shows up
+    as a 401, which masks more interesting failures.
+    """
+    mac = hmac.new(key.encode("utf-8"), body, sha256).hexdigest()
+    return f"{SIGNATURE_PREFIX}{mac}"
+
+
+def verify_hmac_signature(
+    *,
+    body: bytes,
+    signature_header: str | None,
+    l2_id: str,
+    resolver: HmacKeyResolver,
+) -> bool:
+    """Verify a request's HMAC. Returns True iff the digest matches.
+
+    Constant-time compare; returns False on every failure mode
+    (missing header, unknown l2_id, malformed signature, mismatched
+    digest). The caller maps False → 401 — no need to leak which
+    failure mode triggered the reject (denies a key-enumeration
+    oracle).
+    """
+    if not signature_header or not signature_header.startswith(SIGNATURE_PREFIX):
+        return False
+    expected_key = resolver(l2_id)
+    if expected_key is None:
+        return False
+    expected = compute_signature(expected_key, body)
+    return hmac.compare_digest(expected, signature_header)

--- a/server/backend/src/cq_server/transactional/dispatcher.py
+++ b/server/backend/src/cq_server/transactional/dispatcher.py
@@ -1,0 +1,130 @@
+"""SES dispatcher — the central service's SES boto3 wrapper.
+
+The L2-side ``email_sender.EmailSender`` USED to do this; under
+Decision 34 it's now central-only. One instance per process. The
+boto3 client is lazy-initialised so import time is cheap.
+
+# Account
+
+SES sends originate from the control-plane account
+(``124074140789``). DKIM + SPF for ``8th-layer.ai`` are wired in that
+account; ``signup-events`` is the configuration set in scope.
+
+# Sender identities
+
+Three persona addresses, all verified in the control-plane account:
+
+* ``invites@8th-layer.ai`` — magic-link / invite mail.
+* ``auth@8th-layer.ai`` — password reset, 2FA codes.
+* ``notifications@8th-layer.ai`` — account events, security alerts.
+
+The mapping from request ``from_persona`` to sender address lives
+here so the route handler stays declarative.
+
+# Why SES v1 (still)
+
+Same reasoning as the previous L2-side EmailSender: v1 already has
+prod access, the v2 surface adds features we don't need. Stay on v1.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+DEFAULT_AWS_REGION = "us-east-1"
+DEFAULT_CONFIGURATION_SET = "signup-events"
+
+# Persona → sender address. The route handler validates the persona
+# value (Pydantic Literal) so a missing key here would be a code bug,
+# not a runtime input failure.
+PERSONA_SENDERS: dict[str, str] = {
+    "invites": "invites@8th-layer.ai",
+    "auth": "auth@8th-layer.ai",
+    "notifications": "notifications@8th-layer.ai",
+}
+
+
+def _aws_region() -> str:
+    return os.environ.get("CQ_AWS_REGION", DEFAULT_AWS_REGION)
+
+
+def _configuration_set() -> str:
+    return os.environ.get("CQ_SES_CONFIGURATION_SET", DEFAULT_CONFIGURATION_SET)
+
+
+@dataclass
+class SesDispatcher:
+    """boto3-backed SES sender. Production dispatch surface."""
+
+    region: str = field(default_factory=_aws_region)
+    configuration_set: str = field(default_factory=_configuration_set)
+    _client: Any = None
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            import boto3  # local — keep cold-start cost off the import graph
+
+            self._client = boto3.client("ses", region_name=self.region)
+        return self._client
+
+    def send(
+        self,
+        *,
+        from_persona: str,
+        to: str,
+        subject: str,
+        text_body: str,
+        html_body: str | None = None,
+    ) -> dict[str, Any]:
+        """Dispatch one SES send. Returns ``{"MessageId": ...}``.
+
+        Raises ``KeyError`` if ``from_persona`` isn't a known persona
+        — the route handler's Pydantic ``Literal`` already gates this,
+        so a KeyError here is genuinely a code bug.
+        """
+        sender = PERSONA_SENDERS[from_persona]
+        body: dict[str, Any] = {"Text": {"Data": text_body, "Charset": "UTF-8"}}
+        if html_body:
+            body["Html"] = {"Data": html_body, "Charset": "UTF-8"}
+        client = self._get_client()
+        return client.send_email(
+            Source=sender,
+            Destination={"ToAddresses": [to]},
+            Message={
+                "Subject": {"Data": subject, "Charset": "UTF-8"},
+                "Body": body,
+            },
+            ConfigurationSetName=self.configuration_set,
+        )
+
+
+@dataclass
+class MockSesDispatcher:
+    """Test double — captures every send for assertion."""
+
+    sent: list[dict[str, Any]] = field(default_factory=list)
+
+    def send(
+        self,
+        *,
+        from_persona: str,
+        to: str,
+        subject: str,
+        text_body: str,
+        html_body: str | None = None,
+    ) -> dict[str, Any]:
+        self.sent.append(
+            {
+                "from_persona": from_persona,
+                "to": to,
+                "subject": subject,
+                "text_body": text_body,
+                "html_body": html_body,
+            }
+        )
+        return {"MessageId": f"mock-tx-{len(self.sent)}"}

--- a/server/backend/src/cq_server/transactional/idempotency.py
+++ b/server/backend/src/cq_server/transactional/idempotency.py
@@ -1,0 +1,76 @@
+"""In-memory idempotency cache for ``Idempotency-Key`` headers (Decision 34).
+
+The window is 60 seconds — small enough that a single restarted task
+forgets pre-restart keys (acceptable; the L2 retries on a different
+key or accepts a duplicate send). Distributed dedup is not in scope
+for V1; the central service runs as a single ECS task right now, so
+in-process state is the right granularity.
+
+Storage:
+
+* ``dict[key, (timestamp, cached_response)]``.
+* Lazy eviction on access — no background sweeper. The cache stays
+  small in practice (~ tens of keys / minute).
+
+Cached value is the full response envelope (``dict``) so a replay
+returns the exact same body the original send produced (handle,
+ses_message_id, suppression_check). This is the property a
+well-behaved retry expects: same key → same answer, byte-for-byte.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+DEFAULT_TTL_SECONDS = 60.0
+
+
+@dataclass
+class IdempotencyStore:
+    """Thread-safe in-memory dedup cache.
+
+    Two methods:
+
+    * :meth:`get` — return the cached response if the key is fresh,
+      else None.
+    * :meth:`put` — record a response under the key.
+
+    The lock is a stdlib ``Lock``; contention is negligible at our
+    rate (sub-100 sends/sec realistic).
+    """
+
+    ttl_seconds: float = DEFAULT_TTL_SECONDS
+    _entries: dict[str, tuple[float, dict[str, Any]]] = field(default_factory=dict)
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def get(self, key: str) -> dict[str, Any] | None:
+        if not key:
+            return None
+        now = time.monotonic()
+        with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                return None
+            ts, cached = entry
+            if now - ts > self.ttl_seconds:
+                # Lazy eviction — stale entry, drop it.
+                self._entries.pop(key, None)
+                return None
+            return cached
+
+    def put(self, key: str, response: dict[str, Any]) -> None:
+        if not key:
+            return
+        now = time.monotonic()
+        with self._lock:
+            self._entries[key] = (now, response)
+
+    def _sweep_locked(self) -> None:
+        """Drop expired entries — exposed for tests, not the hot path."""
+        now = time.monotonic()
+        stale = [k for k, (ts, _) in self._entries.items() if now - ts > self.ttl_seconds]
+        for k in stale:
+            self._entries.pop(k, None)

--- a/server/backend/src/cq_server/transactional/routes.py
+++ b/server/backend/src/cq_server/transactional/routes.py
@@ -1,0 +1,364 @@
+"""``POST /api/v1/transactional/send`` — central transactional-mail service.
+
+Implements Decision 34 (agent#348). The route lives on the control-plane
+cq-server deployment (the one fronted by ``directory.8th-layer.ai``);
+every L2 routes its outbound transactional mail here instead of calling
+SES directly.
+
+# Request flow
+
+1. Read raw body bytes (needed for HMAC verification — Pydantic parsing
+   happens *after* the digest check).
+2. Resolve the per-L2 HMAC key from ``X-8L-L2-Id`` header.
+3. Verify ``X-8L-Signature`` over the raw body. Mismatch → 401.
+4. (Optional) Check ``Idempotency-Key`` header — return cached response
+   if seen within 60s.
+5. Pydantic-parse the body into ``TransactionalSendRequest``.
+6. Tenancy check: ``to`` must be a known user / pending-invitee of the
+   caller's tenant. Cross-tenant → 403.
+7. Suppression check: ``to`` in ``transactional_suppression`` → 409.
+8. SES dispatch through :class:`SesDispatcher`. Return 202 with handle.
+
+# Why dependency injection on the dispatcher / resolver / cache
+
+The route's three external collaborators (SES, HMAC key resolver,
+idempotency cache) all need to be swappable in tests. FastAPI deps
+give us that for free, and the production wiring is one
+``app.dependency_overrides`` line. The MockSesDispatcher case
+exercises every code path without touching AWS.
+
+# audit_ref
+
+The L2 may pass an ``audit_ref`` in the body (free-form string —
+typically a provisioning job id, an invite jti, etc.). It's echoed
+into the log line and used to deduplicate when ``Idempotency-Key`` is
+omitted — see :func:`_derive_idempotency_key`. Surfaces in
+operator-side debugging without forcing the L2 to think about HTTP
+header conventions.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from typing import Any, Literal
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response
+from pydantic import BaseModel, Field, field_validator
+
+from ..deps import get_store
+from ..store._sqlite import SqliteStore
+from .auth import HmacKeyResolver, StaticKeyResolver, verify_hmac_signature
+from .dispatcher import PERSONA_SENDERS, MockSesDispatcher, SesDispatcher
+from .idempotency import IdempotencyStore
+from .suppression import check_suppression
+from .tenancy import enforce_tenancy
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Pydantic shapes
+# ---------------------------------------------------------------------------
+
+
+class TransactionalSendRequest(BaseModel):
+    """``POST /api/v1/transactional/send`` body."""
+
+    from_persona: Literal["invites", "auth", "notifications"]
+    # ``to`` is a plain str with a minimal shape check — full RFC 5322
+    # would require email-validator. SES itself is the authoritative
+    # parser; we just guard against obvious garbage at the boundary.
+    to: str = Field(min_length=3, max_length=320)
+    subject: str = Field(min_length=1, max_length=998)  # RFC 5322 §2.1.1
+    text: str = Field(min_length=1)
+    html: str | None = None
+    category: Literal[
+        "invite_magic_link",
+        "password_reset",
+        "two_factor",
+        "account_event",
+        "security_alert",
+    ]
+    audit_ref: str | None = Field(default=None, max_length=128)
+
+    @field_validator("to")
+    @classmethod
+    def _lower_to(cls, value: str) -> str:
+        # Suppression keying is case-insensitive; lowercase at the
+        # boundary so every downstream comparison sees one canonical
+        # form. SES itself accepts mixed-case, so this is a normalise,
+        # not a constraint. The minimal "@" guard catches obvious
+        # garbage; SES is the authoritative parser.
+        value = value.strip().lower()
+        if "@" not in value or value.startswith("@") or value.endswith("@"):
+            raise ValueError("invalid email shape")
+        return value
+
+
+class TransactionalSendResponse(BaseModel):
+    """``202`` happy path."""
+
+    delivery_handle: str
+    ses_message_id: str | None
+    suppression_check: Literal["passed"]
+
+
+class TransactionalSuppressedResponse(BaseModel):
+    """``409`` body — address is suppressed; no dispatch."""
+
+    delivery_handle: None = None
+    suppression_check: Literal["blocked"] = "blocked"
+    reason: str
+
+
+# ---------------------------------------------------------------------------
+# Dependency wiring — process-wide singletons, overridden in tests.
+# ---------------------------------------------------------------------------
+
+
+_dispatcher: SesDispatcher | MockSesDispatcher | None = None
+_resolver: HmacKeyResolver | None = None
+_idempotency: IdempotencyStore | None = None
+
+
+def get_dispatcher() -> SesDispatcher | MockSesDispatcher:
+    """Resolve the process-wide SES dispatcher. Tests override.
+
+    Lazy singleton so import time is cheap and tests that never call
+    ``/transactional/send`` don't pay the boto3 import cost.
+    """
+    global _dispatcher
+    if _dispatcher is None:
+        _dispatcher = SesDispatcher()
+    return _dispatcher
+
+
+def get_resolver() -> HmacKeyResolver:
+    """Resolve the process-wide HMAC key resolver. Tests override.
+
+    Production wiring (set in :func:`cq_server.app.lifespan` when the
+    control-plane deployment boots) is :class:`SsmKeyResolver`. In its
+    absence we fall back to an empty static map — that fails-closed
+    (every request is 401), which is the right behaviour pre-config.
+    """
+    global _resolver
+    if _resolver is None:
+        _resolver = StaticKeyResolver(keys={})
+    return _resolver
+
+
+def get_idempotency_store() -> IdempotencyStore:
+    """Process-wide 60s dedup cache."""
+    global _idempotency
+    if _idempotency is None:
+        _idempotency = IdempotencyStore()
+    return _idempotency
+
+
+def _set_dispatcher(dispatcher: SesDispatcher | MockSesDispatcher) -> None:
+    """Override the singleton — used by tests + app startup."""
+    global _dispatcher
+    _dispatcher = dispatcher
+
+
+def _set_resolver(resolver: HmacKeyResolver) -> None:
+    global _resolver
+    _resolver = resolver
+
+
+def _set_idempotency_store(store: IdempotencyStore) -> None:
+    global _idempotency
+    _idempotency = store
+
+
+# ---------------------------------------------------------------------------
+# Route
+# ---------------------------------------------------------------------------
+
+
+router = APIRouter(prefix="/transactional", tags=["transactional"])
+
+
+def _new_delivery_handle() -> str:
+    """ULID-ish opaque handle. Format isn't load-bearing — opaque to L2s.
+
+    32 random hex chars is plenty unique; the ``tx_`` prefix makes
+    grep-friendly distinction from other ids in operator logs.
+    """
+    return f"tx_{secrets.token_hex(16)}"
+
+
+def _derive_idempotency_key(
+    header_key: str | None,
+    l2_id: str,
+    audit_ref: str | None,
+) -> str | None:
+    """Decide which idempotency key (if any) to dedup against.
+
+    Order:
+
+    * Explicit ``Idempotency-Key`` header — highest precedence.
+    * Otherwise, fall back to ``{l2_id}:{audit_ref}`` if the body
+      provided ``audit_ref``. This is the Decision-34 specified
+      behaviour: "keyed off ``audit_ref`` if the L2 provides one".
+    * Otherwise None — no dedup. The default for L2s that don't care
+      about retry semantics.
+    """
+    if header_key:
+        return f"{l2_id}:hdr:{header_key}"
+    if audit_ref:
+        return f"{l2_id}:ref:{audit_ref}"
+    return None
+
+
+@router.post("/send", status_code=202)
+async def send_transactional(
+    request: Request,
+    response: Response,
+    x_8l_l2_id: str | None = Header(default=None, alias="X-8L-L2-Id"),
+    x_8l_signature: str | None = Header(default=None, alias="X-8L-Signature"),
+    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    store: SqliteStore = Depends(get_store),
+    dispatcher: SesDispatcher | MockSesDispatcher = Depends(get_dispatcher),
+    resolver: HmacKeyResolver = Depends(get_resolver),
+    idempotency: IdempotencyStore = Depends(get_idempotency_store),
+) -> dict[str, Any]:
+    """Central transactional-send endpoint — see module docstring."""
+
+    # ---- 1. Raw body for HMAC verification --------------------------------
+    raw_body = await request.body()
+
+    # ---- 2/3. Auth: L2 id + signature ------------------------------------
+    if not x_8l_l2_id:
+        raise HTTPException(status_code=401, detail="missing X-8L-L2-Id header")
+    if "/" not in x_8l_l2_id:
+        # The l2_id MUST be ``<enterprise>/<group>``. Reject other shapes
+        # at the boundary so the tenancy check can rely on a clean split.
+        raise HTTPException(status_code=401, detail="malformed X-8L-L2-Id (expected enterprise/group)")
+    if not verify_hmac_signature(
+        body=raw_body,
+        signature_header=x_8l_signature,
+        l2_id=x_8l_l2_id,
+        resolver=resolver,
+    ):
+        raise HTTPException(status_code=401, detail="invalid signature")
+
+    enterprise_id, group_id = x_8l_l2_id.split("/", 1)
+
+    # ---- 5. Parse body ----------------------------------------------------
+    # (4 is below — we need the parsed audit_ref to compute the fallback key)
+    try:
+        payload = TransactionalSendRequest.model_validate_json(raw_body)
+    except Exception as exc:
+        # Pydantic's own error envelope leaks field-shape info that an
+        # attacker could probe; we keep the 422 path but trim the body.
+        log.info("transactional/send rejected as 422: %s", exc)
+        raise HTTPException(status_code=422, detail="invalid request body") from exc
+
+    # ---- 4. Idempotency check --------------------------------------------
+    dedup_key = _derive_idempotency_key(idempotency_key, x_8l_l2_id, payload.audit_ref)
+    if dedup_key is not None:
+        cached = idempotency.get(dedup_key)
+        if cached is not None:
+            log.info(
+                "transactional/send idempotent replay l2_id=%s key=%s",
+                x_8l_l2_id,
+                dedup_key,
+            )
+            # Replay the original status code as well — a 409 replay
+            # must NOT come back as 202.
+            response.status_code = cached.get("_status_code", 202)
+            return {k: v for k, v in cached.items() if not k.startswith("_")}
+
+    # ---- 6. Tenancy enforcement ------------------------------------------
+    if not enforce_tenancy(
+        store=store,
+        enterprise_id=enterprise_id,
+        group_id=group_id,
+        to=payload.to,
+        category=payload.category,
+    ):
+        log.warning(
+            "transactional/send tenancy_violation l2_id=%s to=%s category=%s audit_ref=%s",
+            x_8l_l2_id,
+            payload.to,
+            payload.category,
+            payload.audit_ref,
+        )
+        raise HTTPException(status_code=403, detail="recipient outside caller tenancy")
+
+    # ---- 7. Suppression check --------------------------------------------
+    suppression = check_suppression(store, payload.to)
+    if suppression is not None:
+        log.info(
+            "transactional/send blocked l2_id=%s to=%s reason=%s audit_ref=%s",
+            x_8l_l2_id,
+            payload.to,
+            suppression.reason,
+            payload.audit_ref,
+        )
+        suppressed = {
+            "delivery_handle": None,
+            "suppression_check": "blocked",
+            "reason": suppression.reason,
+        }
+        if dedup_key is not None:
+            idempotency.put(dedup_key, {**suppressed, "_status_code": 409})
+        # Use HTTPException so FastAPI emits the right Content-Type
+        # and the body shape matches the success path's JSON envelope.
+        raise HTTPException(status_code=409, detail=suppressed)
+
+    # ---- 8. Dispatch ------------------------------------------------------
+    try:
+        ses_resp = dispatcher.send(
+            from_persona=payload.from_persona,
+            to=payload.to,
+            subject=payload.subject,
+            text_body=payload.text,
+            html_body=payload.html,
+        )
+    except Exception as exc:
+        # SES errors translate to 502 — the caller's request was valid,
+        # we couldn't deliver. Don't surface boto3 internals.
+        log.exception("transactional/send SES dispatch failed l2_id=%s", x_8l_l2_id)
+        raise HTTPException(status_code=502, detail="downstream SES error") from exc
+
+    handle = _new_delivery_handle()
+    ses_message_id = ses_resp.get("MessageId") if isinstance(ses_resp, dict) else None
+    log.info(
+        "transactional/send ok l2_id=%s to=%s category=%s persona=%s handle=%s ses_id=%s audit_ref=%s",
+        x_8l_l2_id,
+        payload.to,
+        payload.category,
+        payload.from_persona,
+        handle,
+        ses_message_id,
+        payload.audit_ref,
+    )
+    body = {
+        "delivery_handle": handle,
+        "ses_message_id": ses_message_id,
+        "suppression_check": "passed",
+    }
+    if dedup_key is not None:
+        idempotency.put(dedup_key, {**body, "_status_code": 202})
+    return body
+
+
+# Re-export the persona map so external callers (tests, ops scripts)
+# can introspect the persona → sender wiring without importing
+# dispatcher directly.
+__all__ = [
+    "PERSONA_SENDERS",
+    "TransactionalSendRequest",
+    "TransactionalSendResponse",
+    "TransactionalSuppressedResponse",
+    "_set_dispatcher",
+    "_set_idempotency_store",
+    "_set_resolver",
+    "get_dispatcher",
+    "get_idempotency_store",
+    "get_resolver",
+    "router",
+]

--- a/server/backend/src/cq_server/transactional/sns_writer.py
+++ b/server/backend/src/cq_server/transactional/sns_writer.py
@@ -1,0 +1,137 @@
+"""SES → SNS bounce/complaint event → ``transactional_suppression`` writer.
+
+Subscribes to the two SNS topics in account ``124074140789``:
+
+* ``ses-bounces``
+* ``ses-complaints``
+
+SES emits a JSON envelope per event. We extract the recipient
+addresses and write one suppression row per address. Only **hard**
+bounces drive suppression — soft bounces are transient (mailbox full,
+greylisting, etc.) and shouldn't permanently block.
+
+# Where this runs
+
+Two deployment shapes work; pick at ops time:
+
+1. **Lambda** subscribed directly to the two SNS topics (cheapest;
+   the recommended path). Lambda calls ``handle_sns_record(record,
+   store)`` per record.
+2. **In-process worker** inside cq-server (polls SQS subscribed to
+   the SNS topics). Useful in dev where standing up a Lambda is
+   friction.
+
+This module is the *handler* — both deployment shapes import it.
+
+# Why hard-only
+
+Soft bounces (SES type ``Transient``) are recoverable: the receiver
+queue was full, the user was temporarily over quota, etc. Suppressing
+on soft would lock out users who recovered an hour later. Hard
+bounces (``Permanent``) and complaints are the right signal.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from .suppression import record_suppression
+
+log = logging.getLogger(__name__)
+
+
+def handle_sns_message(message_body: str, store: Any, *, event_id: str | None = None) -> int:
+    """Process one SNS-wrapped SES event. Returns the number of rows recorded.
+
+    ``message_body`` is the raw SNS ``Message`` field — itself a JSON
+    string containing the SES bounce/complaint envelope.
+
+    SNS envelope shape (from SES):
+
+    * Bounces: ``notificationType: "Bounce"`` with ``bounce.bounceType``
+      ∈ ``{"Permanent", "Transient", "Undetermined"}``. Recipients are
+      under ``bounce.bouncedRecipients[].emailAddress``.
+    * Complaints: ``notificationType: "Complaint"``. Recipients under
+      ``complaint.complainedRecipients[].emailAddress``.
+
+    A single SES message can hit multiple recipients, hence the per-
+    recipient loop. We swallow per-recipient failures (log + continue)
+    so one malformed entry doesn't stall the queue.
+    """
+    try:
+        envelope = json.loads(message_body)
+    except json.JSONDecodeError:
+        log.warning("sns_writer: non-JSON message body, skipping")
+        return 0
+
+    event_type = envelope.get("notificationType")
+    if event_type == "Bounce":
+        bounce = envelope.get("bounce", {})
+        bounce_type = bounce.get("bounceType", "Unknown")
+        if bounce_type != "Permanent":
+            log.info("sns_writer: skipping non-permanent bounce type=%s", bounce_type)
+            return 0
+        date = (bounce.get("timestamp", "") or "")[:10] or "unknown"
+        reason = f"hard_bounce_{date}"
+        recipients = bounce.get("bouncedRecipients", [])
+    elif event_type == "Complaint":
+        complaint = envelope.get("complaint", {})
+        date = (complaint.get("timestamp", "") or "")[:10] or "unknown"
+        reason = f"complaint_{date}"
+        recipients = complaint.get("complainedRecipients", [])
+    else:
+        log.info("sns_writer: ignoring notificationType=%s", event_type)
+        return 0
+
+    inserted = 0
+    for recipient in recipients:
+        address = (recipient or {}).get("emailAddress")
+        if not address:
+            continue
+        try:
+            ok = record_suppression(
+                store,
+                address=address,
+                reason=reason,
+                source_event_id=event_id,
+            )
+            if ok:
+                inserted += 1
+        except Exception:
+            log.exception("sns_writer: failed to record suppression for %s", address)
+    return inserted
+
+
+def handle_lambda_event(event: dict[str, Any], store: Any) -> dict[str, int]:
+    """Lambda entry-point — iterates SNS records.
+
+    Returns a small ``{"recorded": N, "skipped": M}`` dict for
+    CloudWatch Logs visibility. Lambda invokes this with the standard
+    SNS-event shape: ``{"Records": [{"Sns": {"Message": "...",
+    "MessageId": "..."}}]}``.
+
+    Designed to be invoked from a tiny Lambda shim:
+
+    ```python
+    def lambda_handler(event, _ctx):
+        store = _get_or_create_store()
+        return handle_lambda_event(event, store)
+    ```
+
+    The shim isn't in this repo — it lives with the Lambda deploy
+    artifact in ``8th-layer-core`` ops. The handler logic is here so
+    it's tested alongside the rest of the suppression code.
+    """
+    recorded = 0
+    skipped = 0
+    for record in event.get("Records", []):
+        sns = record.get("Sns", {})
+        message = sns.get("Message", "")
+        message_id = sns.get("MessageId")
+        n = handle_sns_message(message, store, event_id=message_id)
+        recorded += n
+        if n == 0:
+            skipped += 1
+    return {"recorded": recorded, "skipped": skipped}

--- a/server/backend/src/cq_server/transactional/suppression.py
+++ b/server/backend/src/cq_server/transactional/suppression.py
@@ -1,0 +1,104 @@
+"""``transactional_suppression`` read/write helpers (Decision 34).
+
+Two callers:
+
+* Send path (:mod:`transactional.routes`) — checks ``check_suppression``
+  before SES dispatch; 409s on a hit.
+* Bounce/complaint writer (Lambda or local worker subscribed to the
+  SES → SNS topics) — calls ``record_suppression`` from the
+  ``ses-bounces`` / ``ses-complaints`` topic handler.
+
+The reads/writes go through the existing ``SqliteStore`` ``_engine``
+so they share the same connection pool + PRAGMAs as the rest of
+``cq-server``. Plain SQLAlchemy ``text()`` — no ORM mapping for a
+4-column table.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import text
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class SuppressionEntry:
+    """One row of ``transactional_suppression``."""
+
+    address: str
+    reason: str
+    suppressed_at: str
+    source_event_id: str | None
+
+
+def check_suppression(store: Any, address: str) -> SuppressionEntry | None:
+    """Return the suppression row for ``address`` if any, else None.
+
+    ``address`` is lowercased before the lookup — the writer also
+    lowercases on insert, so the two converge on the same canonical
+    form.
+
+    Synchronous; the send path is itself sync code (the route is
+    ``async def`` but the SQLite I/O is sync). Keeping this as a
+    plain function avoids the async/sync seam adding noise for a
+    single-row PK lookup.
+    """
+    engine = store._engine  # noqa: SLF001 — direct engine access matches store conventions
+    with engine.connect() as conn:
+        row = conn.execute(
+            text(
+                "SELECT address, reason, suppressed_at, source_event_id "
+                "FROM transactional_suppression WHERE address = :a"
+            ),
+            {"a": address.lower()},
+        ).fetchone()
+    if row is None:
+        return None
+    return SuppressionEntry(
+        address=row[0],
+        reason=row[1],
+        suppressed_at=row[2],
+        source_event_id=row[3],
+    )
+
+
+def record_suppression(
+    store: Any,
+    *,
+    address: str,
+    reason: str,
+    source_event_id: str | None = None,
+    suppressed_at: str | None = None,
+) -> bool:
+    """Insert a suppression row. Returns True if inserted, False if dup.
+
+    Idempotent: the writer is subscribed to SNS, and SNS at-least-once
+    delivery means we will occasionally see duplicate events. PK on
+    ``address`` + ``INSERT OR IGNORE`` semantics means the second hit
+    is a clean no-op. First reason wins (see migration docstring).
+    """
+    suppressed_at = suppressed_at or datetime.now(UTC).isoformat()
+    engine = store._engine  # noqa: SLF001
+    with engine.begin() as conn:
+        result = conn.execute(
+            text(
+                "INSERT OR IGNORE INTO transactional_suppression "
+                "(address, reason, suppressed_at, source_event_id) "
+                "VALUES (:a, :r, :s, :e)"
+            ),
+            {
+                "a": address.lower(),
+                "r": reason,
+                "s": suppressed_at,
+                "e": source_event_id,
+            },
+        )
+    inserted = (result.rowcount or 0) > 0
+    if inserted:
+        log.info("suppression recorded address=%s reason=%s", address.lower(), reason)
+    return inserted

--- a/server/backend/src/cq_server/transactional/tenancy.py
+++ b/server/backend/src/cq_server/transactional/tenancy.py
@@ -1,0 +1,101 @@
+"""Tenancy enforcement for the central transactional-mail service.
+
+Decision 34 §"Tenancy enforcement" — every send must have a ``to``
+that the calling L2 is permitted to address:
+
+* Categories 1, 2, 3 (``invite_magic_link`` / ``password_reset`` /
+  ``two_factor``): the ``to`` must be (a) a known user of the
+  caller's tenancy, OR (b) a pending-invitee for the caller's
+  tenancy.
+* Categories 4, 5 (``account_event`` / ``security_alert``): the
+  ``to`` must be a known user of the caller's tenancy.
+
+The control plane's ``users`` and ``invites`` tables are the truth.
+A pending-invitee is an ``invites`` row where ``claimed_at IS NULL``
+and ``revoked_at IS NULL``.
+
+# Caveat — pending-invitee tenancy
+
+``invites`` has no direct ``enterprise_id`` / ``group_id`` columns.
+For pending invitees we look the issuer up in ``users`` and compare
+the issuer's tenancy to the caller's. This is the same join the
+``invites.py`` admin-list paths do.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sqlalchemy import text
+
+log = logging.getLogger(__name__)
+
+INVITE_CATEGORIES = {"invite_magic_link", "password_reset", "two_factor"}
+USER_ONLY_CATEGORIES = {"account_event", "security_alert"}
+
+
+def enforce_tenancy(
+    *,
+    store: Any,
+    enterprise_id: str,
+    group_id: str,
+    to: str,
+    category: str,
+) -> bool:
+    """Return True iff the caller may send to ``to`` for this category.
+
+    Returns False on every form of "not allowed" — the caller maps to
+    a 403. We deliberately do not distinguish "unknown user" from
+    "user belongs to a different tenancy", to avoid the response
+    becoming a user-existence oracle for a malicious L2.
+    """
+    address = to.lower()
+    engine = store._engine  # noqa: SLF001
+
+    with engine.connect() as conn:
+        # Step 1 — is the address a known user of this tenancy?
+        user_row = conn.execute(
+            text(
+                "SELECT enterprise_id, group_id FROM users "
+                "WHERE LOWER(email) = :e"
+            ),
+            {"e": address},
+        ).fetchone()
+        if user_row is not None:
+            user_ent, user_grp = user_row[0], user_row[1]
+            if user_ent == enterprise_id and user_grp == group_id:
+                return True
+            # Address belongs to a *different* tenancy. Categories 4/5
+            # require a known user; categories 1-3 fall through to the
+            # invite check (a cross-tenant user with a pending invite
+            # for THIS tenancy is still a valid recipient for the
+            # invite). The invite check is keyed by email + tenancy of
+            # the inviter, which excludes the foreign-tenancy user.
+            if category in USER_ONLY_CATEGORIES:
+                return False
+
+        # Step 2 — categories 4/5 reject if no user matched.
+        if category in USER_ONLY_CATEGORIES:
+            return False
+
+        # Step 3 — categories 1/2/3 also allow pending-invitee.
+        if category in INVITE_CATEGORIES:
+            invite_row = conn.execute(
+                text(
+                    "SELECT i.id FROM invites i "
+                    "JOIN users u ON u.id = i.issued_by "
+                    "WHERE LOWER(i.email) = :e "
+                    "  AND u.enterprise_id = :ent "
+                    "  AND u.group_id = :grp "
+                    "  AND i.claimed_at IS NULL "
+                    "  AND i.revoked_at IS NULL "
+                    "LIMIT 1"
+                ),
+                {"e": address, "ent": enterprise_id, "grp": group_id},
+            ).fetchone()
+            if invite_row is not None:
+                return True
+
+    # Unknown category or no matching tenancy/invite — fail closed.
+    return False

--- a/server/backend/tests/test_email_sender_http.py
+++ b/server/backend/tests/test_email_sender_http.py
@@ -1,0 +1,262 @@
+"""Tests for the L2-side HTTP-client ``EmailSender`` (Decision 34).
+
+The L2's ``EmailSender`` POSTs to the central transactional service
+instead of calling SES directly. These tests verify:
+
+* SES boto3 is not imported on the happy HTTP path.
+* HTTP body is HMAC-signed correctly (server-side verification round-trip).
+* 202 → ``status="sent"`` + delivery_handle / ses_message_id propagated.
+* 409 → ``status="suppressed"`` + reason propagated.
+* Missing ``TX_SEND_KEY`` → falls back to legacy SES when
+  ``CQ_EMAIL_LEGACY_SES=1``, errors otherwise.
+* The legacy fallback path emits a deprecation log line.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any
+
+import httpx
+import pytest
+
+from cq_server.email_sender import EmailSender, EmailSendOutcome
+from cq_server.transactional.auth import (
+    StaticKeyResolver,
+    verify_hmac_signature,
+)
+
+L2_ID = "acme/engineering"
+KEY = "test-hmac-key"  # pragma: allowlist secret
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CQ_ENTERPRISE", "acme")
+    monkeypatch.setenv("CQ_GROUP", "engineering")
+    monkeypatch.setenv("TX_SEND_KEY", KEY)
+    monkeypatch.setenv("TX_SEND_BASE_URL", "http://central.test")
+    monkeypatch.delenv("CQ_EMAIL_LEGACY_SES", raising=False)
+
+
+class _StubHttpClient:
+    """Minimal httpx-compatible stub. Returns scripted responses."""
+
+    def __init__(self, response: httpx.Response) -> None:
+        self._response = response
+        self.calls: list[dict[str, Any]] = []
+
+    def post(self, url: str, *, content: bytes, headers: dict[str, str]) -> httpx.Response:
+        self.calls.append({"url": url, "content": content, "headers": headers})
+        return self._response
+
+
+def _make_response(status_code: int, json_body: dict[str, Any]) -> httpx.Response:
+    return httpx.Response(
+        status_code=status_code,
+        content=json.dumps(json_body).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+
+
+def _make_sender(stub: _StubHttpClient) -> EmailSender:
+    sender = EmailSender()
+    sender._client = stub  # noqa: SLF001 — test injection
+    return sender
+
+
+def test_happy_path_202(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = _StubHttpClient(
+        _make_response(
+            202,
+            {
+                "delivery_handle": "tx_abc",
+                "ses_message_id": "ses-1",
+                "suppression_check": "passed",
+            },
+        )
+    )
+    sender = _make_sender(stub)
+
+    result = sender.send_invite(
+        to="alice@example.com",
+        jwt="JWT.STR.HERE",
+        inviter_name="Dirk",
+        enterprise_name="Acme",
+        expiry=datetime(2026, 5, 27, 0, 0, 0),
+    )
+    assert result["status"] == "sent"
+    assert result["delivery_handle"] == "tx_abc"
+    assert result["MessageId"] == "ses-1"
+
+    # One HTTP call, right URL, right headers.
+    assert len(stub.calls) == 1
+    call = stub.calls[0]
+    assert call["url"] == "http://central.test/api/v1/transactional/send"
+    assert call["headers"]["X-8L-L2-Id"] == L2_ID
+    assert call["headers"]["X-8L-Signature"].startswith("sha256=")
+    # Body is well-formed JSON with the right persona + category.
+    body = json.loads(call["content"])
+    assert body["from_persona"] == "invites"
+    assert body["category"] == "invite_magic_link"
+    assert body["to"] == "alice@example.com"
+    assert "audit_ref" in body  # auto-derived from jwt
+
+
+def test_signature_verifies_against_server_resolver() -> None:
+    """The client's signature must verify with the server's resolver."""
+    stub = _StubHttpClient(_make_response(202, {"delivery_handle": "h", "ses_message_id": "s", "suppression_check": "passed"}))
+    sender = _make_sender(stub)
+    sender.send_invite(
+        to="alice@example.com",
+        jwt="JWT.STR.HERE",
+        inviter_name="Dirk",
+        enterprise_name="Acme",
+        expiry=datetime(2026, 5, 27, 0, 0, 0),
+    )
+    call = stub.calls[0]
+    resolver = StaticKeyResolver(keys={L2_ID: KEY})
+    assert verify_hmac_signature(
+        body=call["content"],
+        signature_header=call["headers"]["X-8L-Signature"],
+        l2_id=L2_ID,
+        resolver=resolver,
+    )
+
+
+def test_suppression_409_propagates() -> None:
+    stub = _StubHttpClient(
+        _make_response(
+            409,
+            {
+                "detail": {
+                    "delivery_handle": None,
+                    "suppression_check": "blocked",
+                    "reason": "hard_bounce_2026-05-15",
+                }
+            },
+        )
+    )
+    sender = _make_sender(stub)
+    result = sender.send_invite(
+        to="bounced@example.com",
+        jwt="JWT.STR.HERE",
+        inviter_name="Dirk",
+        enterprise_name="Acme",
+        expiry=datetime(2026, 5, 27, 0, 0, 0),
+    )
+    assert result["status"] == "suppressed"
+    assert result["reason"] == "hard_bounce_2026-05-15"
+    assert result["MessageId"] is None
+    assert result["delivery_handle"] is None
+
+
+def test_send_invite_outcome_returns_envelope() -> None:
+    stub = _StubHttpClient(
+        _make_response(
+            202,
+            {"delivery_handle": "tx_x", "ses_message_id": "ses-x", "suppression_check": "passed"},
+        )
+    )
+    sender = _make_sender(stub)
+    outcome = sender.send_invite_outcome(
+        to="alice@example.com",
+        jwt="JWT",
+        inviter_name="Dirk",
+        enterprise_name="Acme",
+        expiry=datetime(2026, 5, 27),
+    )
+    assert isinstance(outcome, EmailSendOutcome)
+    assert outcome.ok
+    assert outcome.delivery_handle == "tx_x"
+
+
+def test_missing_key_no_legacy_returns_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TX_SEND_KEY", raising=False)
+    sender = EmailSender()
+    result = sender.send_invite(
+        to="x@example.com",
+        jwt="J",
+        inviter_name="D",
+        enterprise_name="A",
+        expiry=datetime(2026, 5, 27),
+    )
+    assert result["status"] == "error"
+    assert result["reason"] == "tx_send_key_missing"
+
+
+def test_missing_key_with_legacy_flag_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("TX_SEND_KEY", raising=False)
+    monkeypatch.setenv("CQ_EMAIL_LEGACY_SES", "1")
+    sender = EmailSender()
+
+    # Inject a fake legacy SES client to avoid touching boto3.
+    class _StubSes:
+        def __init__(self) -> None:
+            self.sent: list[Any] = []
+
+        def send_email(self, **kwargs: Any) -> dict[str, Any]:
+            self.sent.append(kwargs)
+            return {"MessageId": "legacy-1"}
+
+    stub_ses = _StubSes()
+    sender._legacy_ses_client = stub_ses  # noqa: SLF001
+
+    # Attach a stub handler directly to the email_sender logger so we
+    # capture the deprecation line regardless of pytest's caplog state
+    # (some test modules earlier in the run reconfigure root handlers).
+    import logging
+
+    captured: list[str] = []
+
+    class _CaptureHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record.getMessage())
+
+    logger = logging.getLogger("cq_server.email_sender")
+    handler = _CaptureHandler(level=logging.WARNING)
+    logger.addHandler(handler)
+    prev_level = logger.level
+    logger.setLevel(logging.WARNING)
+    try:
+        result = sender.send_invite(
+            to="x@example.com",
+            jwt="J",
+            inviter_name="D",
+            enterprise_name="A",
+            expiry=datetime(2026, 5, 27),
+        )
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(prev_level)
+
+    assert result["status"] == "sent"
+    assert result["MessageId"] == "legacy-1"
+    assert len(stub_ses.sent) == 1
+    # Deprecation log line fired.
+    joined = "\n".join(captured)
+    assert "TX_SEND_KEY missing" in joined
+    assert "legacy SES" in joined
+
+
+def test_no_ses_boto3_on_http_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The HTTP-happy path must not import boto3 SES.
+
+    The promise of Decision 34 is that customer L2s have zero SES
+    setup. If the L2 codebase ever auto-imports boto3 on the send
+    path, that promise leaks back to the customer (their task role
+    needs SES IAM, etc.). Guard with a sentinel.
+    """
+    stub = _StubHttpClient(_make_response(202, {"delivery_handle": "h", "ses_message_id": "s", "suppression_check": "passed"}))
+    sender = _make_sender(stub)
+    sender.send_invite(
+        to="alice@example.com",
+        jwt="J",
+        inviter_name="D",
+        enterprise_name="A",
+        expiry=datetime(2026, 5, 27),
+    )
+    # ``_legacy_ses_client`` MUST remain None — proves the legacy
+    # branch was not entered.
+    assert sender._legacy_ses_client is None  # noqa: SLF001

--- a/server/backend/tests/test_email_sender_http.py
+++ b/server/backend/tests/test_email_sender_http.py
@@ -214,11 +214,18 @@ def test_missing_key_with_legacy_flag_falls_back(monkeypatch: pytest.MonkeyPatch
         def emit(self, record: logging.LogRecord) -> None:
             captured.append(record.getMessage())
 
-    logger = logging.getLogger("cq_server.email_sender")
+    # Patch the module-level ``log`` attribute directly. Tests in
+    # other files have been observed to disable propagation on
+    # ``cq_server.*`` loggers via app-startup wiring; binding the
+    # handler to the module attribute bypasses that entirely.
+    import cq_server.email_sender as email_sender_mod
+
+    prev_log = email_sender_mod.log
+    logger = logging.getLogger("cq_server.email_sender.test_capture")
     handler = _CaptureHandler(level=logging.WARNING)
     logger.addHandler(handler)
-    prev_level = logger.level
     logger.setLevel(logging.WARNING)
+    email_sender_mod.log = logger
     try:
         result = sender.send_invite(
             to="x@example.com",
@@ -228,8 +235,8 @@ def test_missing_key_with_legacy_flag_falls_back(monkeypatch: pytest.MonkeyPatch
             expiry=datetime(2026, 5, 27),
         )
     finally:
+        email_sender_mod.log = prev_log
         logger.removeHandler(handler)
-        logger.setLevel(prev_level)
 
     assert result["status"] == "sent"
     assert result["MessageId"] == "legacy-1"

--- a/server/backend/tests/test_transactional_idempotency.py
+++ b/server/backend/tests/test_transactional_idempotency.py
@@ -1,0 +1,56 @@
+"""Unit tests for the in-memory ``IdempotencyStore`` (Decision 34)."""
+
+from __future__ import annotations
+
+import time
+
+from cq_server.transactional.idempotency import IdempotencyStore
+
+
+def test_put_then_get_returns_value() -> None:
+    s = IdempotencyStore(ttl_seconds=60)
+    s.put("k1", {"handle": "tx_1"})
+    assert s.get("k1") == {"handle": "tx_1"}
+
+
+def test_get_returns_none_for_unknown_key() -> None:
+    s = IdempotencyStore()
+    assert s.get("nope") is None
+
+
+def test_empty_key_is_noop() -> None:
+    s = IdempotencyStore()
+    s.put("", {"x": 1})
+    assert s.get("") is None
+
+
+def test_ttl_expiry_drops_entry() -> None:
+    s = IdempotencyStore(ttl_seconds=0.01)
+    s.put("k", {"v": 1})
+    time.sleep(0.02)
+    assert s.get("k") is None
+    # And lazy eviction means the entry was actually removed.
+    assert "k" not in s._entries
+
+
+def test_thread_safety_basic_smoke() -> None:
+    import threading
+
+    s = IdempotencyStore(ttl_seconds=10)
+    errors: list[Exception] = []
+
+    def worker(start: int) -> None:
+        try:
+            for i in range(100):
+                key = f"k{start + i}"
+                s.put(key, {"i": i})
+                assert s.get(key) == {"i": i}
+        except Exception as exc:  # pragma: no cover
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(i * 100,)) for i in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert not errors

--- a/server/backend/tests/test_transactional_send.py
+++ b/server/backend/tests/test_transactional_send.py
@@ -1,0 +1,368 @@
+"""End-to-end tests for ``POST /api/v1/transactional/send`` (Decision 34).
+
+Covers all six required scenarios from the implementation brief:
+
+1. HTTP send happy path (HMAC ok, tenancy ok, no suppression → 202 + SES call)
+2. Suppression block (pre-seeded suppression row → 409)
+3. Tenancy violation (foreign ``to`` → 403)
+4. Idempotency dedup (same key in <60s → single SES dispatch)
+5. HMAC signature mismatch → 401
+6. (L2-side) — covered in test_email_sender_http_client.py
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import bcrypt
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from cq_server.app import _get_store, app
+from cq_server.transactional.auth import StaticKeyResolver, compute_signature
+from cq_server.transactional.dispatcher import MockSesDispatcher
+from cq_server.transactional.idempotency import IdempotencyStore
+from cq_server.transactional.routes import (
+    _set_dispatcher,
+    _set_idempotency_store,
+    _set_resolver,
+)
+
+ENT = "acme"
+GRP = "engineering"
+L2_ID = f"{ENT}/{GRP}"
+HMAC_KEY = "test-hmac-key-thirty-two-chars-min"  # pragma: allowlist secret
+
+ADMIN_EMAIL = "admin@acme.example.com"
+KNOWN_USER_EMAIL = "alice@acme.example.com"
+PENDING_INVITEE_EMAIL = "carmen@acme.example.com"
+FOREIGN_USER_EMAIL = "evil@globex.example.com"
+SUPPRESSED_EMAIL = "bounced@acme.example.com"
+
+ADMIN_PASSWORD = "password123!"  # pragma: allowlist secret
+
+
+@pytest.fixture
+def mock_dispatcher() -> MockSesDispatcher:
+    return MockSesDispatcher()
+
+
+@pytest.fixture
+def client(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_dispatcher: MockSesDispatcher,
+) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "transactional.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+
+    # Override the three singletons before TestClient starts the lifespan.
+    _set_dispatcher(mock_dispatcher)
+    _set_resolver(StaticKeyResolver(keys={L2_ID: HMAC_KEY}))
+    _set_idempotency_store(IdempotencyStore())
+
+    with TestClient(app) as c:
+        store = _get_store()
+        pw = bcrypt.hashpw(ADMIN_PASSWORD.encode(), bcrypt.gensalt()).decode()
+        # Two users: admin (issuer) + alice (recipient). Tenancy on both.
+        store.sync.create_user("admin", pw)
+        store.sync.create_user("alice", pw)
+        store.sync.create_user("evil", pw)
+        with store._engine.begin() as conn:  # noqa: SLF001
+            conn.execute(
+                text(
+                    "UPDATE users SET email=:e, enterprise_id=:ent, group_id=:grp "
+                    "WHERE username='admin'"
+                ),
+                {"e": ADMIN_EMAIL, "ent": ENT, "grp": GRP},
+            )
+            conn.execute(
+                text(
+                    "UPDATE users SET email=:e, enterprise_id=:ent, group_id=:grp "
+                    "WHERE username='alice'"
+                ),
+                {"e": KNOWN_USER_EMAIL, "ent": ENT, "grp": GRP},
+            )
+            # Foreign tenancy
+            conn.execute(
+                text(
+                    "UPDATE users SET email=:e, enterprise_id='globex', group_id='engineering' "
+                    "WHERE username='evil'"
+                ),
+                {"e": FOREIGN_USER_EMAIL},
+            )
+            # Pending invite for carmen — issued by admin (acme/engineering)
+            conn.execute(
+                text(
+                    "INSERT INTO invites "
+                    "(jti, email, role, target_l2_id, issued_by, issued_at, expires_at) "
+                    "VALUES (:j, :e, 'user', NULL, "
+                    "  (SELECT id FROM users WHERE username='admin'), "
+                    "  '2026-05-20T00:00:00Z', '2026-05-27T00:00:00Z')"
+                ),
+                {"j": "test-jti-1", "e": PENDING_INVITEE_EMAIL},
+            )
+            # Pre-seed a suppression
+            conn.execute(
+                text(
+                    "INSERT INTO transactional_suppression "
+                    "(address, reason, suppressed_at, source_event_id) "
+                    "VALUES (:a, 'hard_bounce_2026-05-15', '2026-05-15T12:00:00Z', 'evt-1')"
+                ),
+                {"a": SUPPRESSED_EMAIL},
+            )
+        yield c
+
+
+def _valid_body(**over: object) -> dict[str, object]:
+    body: dict[str, object] = {
+        "from_persona": "invites",
+        "to": PENDING_INVITEE_EMAIL,
+        "subject": "Welcome to Acme",
+        "text": "Click here to claim your account: https://example.com/x",
+        "category": "invite_magic_link",
+    }
+    body.update(over)
+    return body
+
+
+def _signed_post(
+    client: TestClient,
+    body: dict[str, object],
+    *,
+    l2_id: str = L2_ID,
+    key: str = HMAC_KEY,
+    idempotency_key: str | None = None,
+) -> object:
+    import json
+
+    raw = json.dumps(body).encode("utf-8")
+    headers = {
+        "X-8L-L2-Id": l2_id,
+        "X-8L-Signature": compute_signature(key, raw),
+        "Content-Type": "application/json",
+    }
+    if idempotency_key:
+        headers["Idempotency-Key"] = idempotency_key
+    return client.post("/api/v1/transactional/send", content=raw, headers=headers)
+
+
+# ---------------------------------------------------------------------------
+# 1. Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_pending_invitee(
+    client: TestClient, mock_dispatcher: MockSesDispatcher
+) -> None:
+    resp = _signed_post(client, _valid_body())
+    assert resp.status_code == 202, resp.text
+    body = resp.json()
+    assert body["delivery_handle"].startswith("tx_")
+    assert body["suppression_check"] == "passed"
+    assert body["ses_message_id"] is not None
+    # One SES call landed with the right shape.
+    assert len(mock_dispatcher.sent) == 1
+    sent = mock_dispatcher.sent[0]
+    assert sent["from_persona"] == "invites"
+    assert sent["to"] == PENDING_INVITEE_EMAIL
+    assert sent["subject"] == "Welcome to Acme"
+
+
+def test_happy_path_known_user(
+    client: TestClient, mock_dispatcher: MockSesDispatcher
+) -> None:
+    body = _valid_body(
+        to=KNOWN_USER_EMAIL,
+        from_persona="auth",
+        category="password_reset",
+        subject="Reset your password",
+    )
+    resp = _signed_post(client, body)
+    assert resp.status_code == 202, resp.text
+    assert len(mock_dispatcher.sent) == 1
+
+
+def test_happy_path_security_alert_for_known_user(
+    client: TestClient, mock_dispatcher: MockSesDispatcher
+) -> None:
+    body = _valid_body(
+        to=KNOWN_USER_EMAIL,
+        from_persona="notifications",
+        category="security_alert",
+        subject="Security alert",
+    )
+    resp = _signed_post(client, body)
+    assert resp.status_code == 202, resp.text
+
+
+# ---------------------------------------------------------------------------
+# 2. Suppression block
+# ---------------------------------------------------------------------------
+
+
+def test_suppression_blocks_send(
+    client: TestClient, mock_dispatcher: MockSesDispatcher
+) -> None:
+    # Need to add suppressed user so tenancy check passes — then suppression
+    # should fire BEFORE the SES dispatch.
+    store = _get_store()
+    store.sync.create_user("bounced", "x")
+    with store._engine.begin() as conn:  # noqa: SLF001
+        conn.execute(
+            text(
+                "UPDATE users SET email=:e, enterprise_id=:ent, group_id=:grp "
+                "WHERE username='bounced'"
+            ),
+            {"e": SUPPRESSED_EMAIL, "ent": ENT, "grp": GRP},
+        )
+    body = _valid_body(to=SUPPRESSED_EMAIL, category="account_event", from_persona="notifications")
+    resp = _signed_post(client, body)
+    assert resp.status_code == 409, resp.text
+    # FastAPI wraps HTTPException.detail in {"detail": ...}.
+    detail = resp.json()["detail"]
+    assert detail["delivery_handle"] is None
+    assert detail["suppression_check"] == "blocked"
+    assert "hard_bounce" in detail["reason"]
+    # Zero SES dispatches.
+    assert len(mock_dispatcher.sent) == 0
+
+
+# ---------------------------------------------------------------------------
+# 3. Tenancy violation
+# ---------------------------------------------------------------------------
+
+
+def test_foreign_user_is_403(client: TestClient, mock_dispatcher: MockSesDispatcher) -> None:
+    body = _valid_body(
+        to=FOREIGN_USER_EMAIL,
+        category="security_alert",
+        from_persona="notifications",
+    )
+    resp = _signed_post(client, body)
+    assert resp.status_code == 403, resp.text
+    assert len(mock_dispatcher.sent) == 0
+
+
+def test_unknown_recipient_is_403(client: TestClient, mock_dispatcher: MockSesDispatcher) -> None:
+    body = _valid_body(
+        to="ghost@nowhere.example.com",
+        category="security_alert",
+        from_persona="notifications",
+    )
+    resp = _signed_post(client, body)
+    assert resp.status_code == 403, resp.text
+
+
+# ---------------------------------------------------------------------------
+# 4. Idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_idempotency_header_dedups_within_window(
+    client: TestClient, mock_dispatcher: MockSesDispatcher
+) -> None:
+    body = _valid_body()
+    resp1 = _signed_post(client, body, idempotency_key="abc-123")
+    assert resp1.status_code == 202
+    handle1 = resp1.json()["delivery_handle"]
+    # Second identical send should replay the cached response.
+    resp2 = _signed_post(client, body, idempotency_key="abc-123")
+    assert resp2.status_code == 202
+    assert resp2.json()["delivery_handle"] == handle1
+    # One SES dispatch total.
+    assert len(mock_dispatcher.sent) == 1
+
+
+def test_idempotency_audit_ref_fallback(
+    client: TestClient, mock_dispatcher: MockSesDispatcher
+) -> None:
+    body = _valid_body(audit_ref="fo2-job-7e3a")
+    resp1 = _signed_post(client, body)
+    resp2 = _signed_post(client, body)
+    assert resp1.json()["delivery_handle"] == resp2.json()["delivery_handle"]
+    assert len(mock_dispatcher.sent) == 1
+
+
+def test_no_idempotency_key_no_dedup(
+    client: TestClient, mock_dispatcher: MockSesDispatcher
+) -> None:
+    body = _valid_body()
+    _signed_post(client, body)
+    _signed_post(client, body)
+    # Both went through — different SES dispatches, different handles.
+    assert len(mock_dispatcher.sent) == 2
+
+
+# ---------------------------------------------------------------------------
+# 5. HMAC signature
+# ---------------------------------------------------------------------------
+
+
+def test_missing_l2_id_header_401(client: TestClient) -> None:
+    body = _valid_body()
+    import json
+
+    raw = json.dumps(body).encode()
+    resp = client.post(
+        "/api/v1/transactional/send",
+        content=raw,
+        headers={"X-8L-Signature": compute_signature(HMAC_KEY, raw)},
+    )
+    assert resp.status_code == 401
+
+
+def test_missing_signature_header_401(client: TestClient) -> None:
+    body = _valid_body()
+    import json
+
+    resp = client.post(
+        "/api/v1/transactional/send",
+        content=json.dumps(body).encode(),
+        headers={"X-8L-L2-Id": L2_ID},
+    )
+    assert resp.status_code == 401
+
+
+def test_wrong_signature_401(client: TestClient) -> None:
+    body = _valid_body()
+    resp = _signed_post(client, body, key="wrong-key")
+    assert resp.status_code == 401
+
+
+def test_unknown_l2_id_401(client: TestClient) -> None:
+    body = _valid_body()
+    resp = _signed_post(client, body, l2_id="unknown/l2")
+    assert resp.status_code == 401
+
+
+def test_malformed_l2_id_401(client: TestClient) -> None:
+    body = _valid_body()
+    resp = _signed_post(client, body, l2_id="no-slash")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Misc — bad input shapes
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_email_shape_422(client: TestClient) -> None:
+    body = _valid_body(to="not-an-email")
+    resp = _signed_post(client, body)
+    assert resp.status_code == 422
+
+
+def test_invalid_persona_422(client: TestClient) -> None:
+    body = _valid_body(from_persona="marketing")
+    resp = _signed_post(client, body)
+    assert resp.status_code == 422
+
+
+def test_invalid_category_422(client: TestClient) -> None:
+    body = _valid_body(category="newsletter")
+    resp = _signed_post(client, body)
+    assert resp.status_code == 422

--- a/server/backend/tests/test_transactional_sns_writer.py
+++ b/server/backend/tests/test_transactional_sns_writer.py
@@ -1,0 +1,122 @@
+"""Tests for the SNS → suppression writer (``transactional.sns_writer``).
+
+Real SES bounce/complaint JSON envelopes (sampled from AWS docs) are
+the fixtures; the writer should parse them and land rows in the
+suppression table.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cq_server.app import _get_store, app
+from cq_server.transactional.sns_writer import (
+    handle_lambda_event,
+    handle_sns_message,
+)
+from cq_server.transactional.suppression import check_suppression
+
+
+@pytest.fixture
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "sns_writer.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    with TestClient(app) as c:
+        yield c
+
+
+# Sampled from
+# https://docs.aws.amazon.com/ses/latest/dg/notification-contents.html
+PERMANENT_BOUNCE_ENVELOPE = json.dumps(
+    {
+        "notificationType": "Bounce",
+        "bounce": {
+            "bounceType": "Permanent",
+            "bounceSubType": "General",
+            "bouncedRecipients": [
+                {"emailAddress": "permanent-bounce@example.com"}
+            ],
+            "timestamp": "2026-05-19T14:32:00.000Z",
+        },
+    }
+)
+
+TRANSIENT_BOUNCE_ENVELOPE = json.dumps(
+    {
+        "notificationType": "Bounce",
+        "bounce": {
+            "bounceType": "Transient",
+            "bouncedRecipients": [{"emailAddress": "soft-bounce@example.com"}],
+            "timestamp": "2026-05-19T14:32:00.000Z",
+        },
+    }
+)
+
+COMPLAINT_ENVELOPE = json.dumps(
+    {
+        "notificationType": "Complaint",
+        "complaint": {
+            "complainedRecipients": [{"emailAddress": "annoyed@example.com"}],
+            "timestamp": "2026-05-19T14:32:00.000Z",
+        },
+    }
+)
+
+
+def test_permanent_bounce_records_suppression(client: TestClient) -> None:
+    store = _get_store()
+    n = handle_sns_message(PERMANENT_BOUNCE_ENVELOPE, store, event_id="sns-evt-1")
+    assert n == 1
+    entry = check_suppression(store, "permanent-bounce@example.com")
+    assert entry is not None
+    assert entry.reason == "hard_bounce_2026-05-19"
+    assert entry.source_event_id == "sns-evt-1"
+
+
+def test_transient_bounce_is_skipped(client: TestClient) -> None:
+    store = _get_store()
+    n = handle_sns_message(TRANSIENT_BOUNCE_ENVELOPE, store)
+    assert n == 0
+    assert check_suppression(store, "soft-bounce@example.com") is None
+
+
+def test_complaint_records_suppression(client: TestClient) -> None:
+    store = _get_store()
+    n = handle_sns_message(COMPLAINT_ENVELOPE, store)
+    assert n == 1
+    entry = check_suppression(store, "annoyed@example.com")
+    assert entry is not None
+    assert entry.reason == "complaint_2026-05-19"
+
+
+def test_non_json_payload_returns_zero(client: TestClient) -> None:
+    store = _get_store()
+    assert handle_sns_message("not json", store) == 0
+
+
+def test_unknown_notification_type_returns_zero(client: TestClient) -> None:
+    store = _get_store()
+    envelope = json.dumps({"notificationType": "DeliveryDelay"})
+    assert handle_sns_message(envelope, store) == 0
+
+
+def test_lambda_event_wraps_multiple_records(client: TestClient) -> None:
+    store = _get_store()
+    event = {
+        "Records": [
+            {"Sns": {"Message": PERMANENT_BOUNCE_ENVELOPE, "MessageId": "m-1"}},
+            {"Sns": {"Message": COMPLAINT_ENVELOPE, "MessageId": "m-2"}},
+            {"Sns": {"Message": TRANSIENT_BOUNCE_ENVELOPE, "MessageId": "m-3"}},
+        ]
+    }
+    result = handle_lambda_event(event, store)
+    assert result == {"recorded": 2, "skipped": 1}
+    # Both perma + complaint addresses now suppressed.
+    assert check_suppression(store, "permanent-bounce@example.com") is not None
+    assert check_suppression(store, "annoyed@example.com") is not None

--- a/server/backend/tests/test_transactional_suppression.py
+++ b/server/backend/tests/test_transactional_suppression.py
@@ -1,0 +1,63 @@
+"""Tests for ``transactional.suppression`` read/write helpers.
+
+Exercises the SNS-fed writer path without touching SNS — direct
+``record_suppression`` calls verify the table semantics.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cq_server.app import _get_store, app
+from cq_server.transactional.suppression import (
+    check_suppression,
+    record_suppression,
+)
+
+
+@pytest.fixture
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "suppression.db"))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    with TestClient(app) as c:
+        yield c
+
+
+def test_check_suppression_returns_none_for_unknown(client: TestClient) -> None:
+    store = _get_store()
+    assert check_suppression(store, "nobody@example.com") is None
+
+
+def test_record_then_check(client: TestClient) -> None:
+    store = _get_store()
+    inserted = record_suppression(
+        store,
+        address="bounced@example.com",
+        reason="hard_bounce_2026-05-19",
+        source_event_id="sns-evt-1",
+    )
+    assert inserted is True
+    entry = check_suppression(store, "bounced@example.com")
+    assert entry is not None
+    assert entry.address == "bounced@example.com"
+    assert entry.reason == "hard_bounce_2026-05-19"
+    assert entry.source_event_id == "sns-evt-1"
+    # Lookup is case-insensitive.
+    assert check_suppression(store, "BOUNCED@example.com") is not None
+
+
+def test_record_is_idempotent(client: TestClient) -> None:
+    store = _get_store()
+    first = record_suppression(store, address="dup@example.com", reason="hard_bounce_2026-05-19")
+    second = record_suppression(store, address="dup@example.com", reason="complaint_2026-05-20")
+    assert first is True
+    assert second is False  # PK conflict — no-op
+    # First reason wins.
+    entry = check_suppression(store, "dup@example.com")
+    assert entry is not None
+    assert entry.reason == "hard_bounce_2026-05-19"


### PR DESCRIPTION
Implements **Decision 34 — Central transactional-mail service** (closes #348).

Design doc: [`8th-layer-core/docs/decisions/34-central-transactional-mail-service.md`](https://github.com/OneZero1ai/8th-layer-core/blob/main/docs/decisions/34-central-transactional-mail-service.md)
(operator-approved 2026-05-20).

## What this delivers

Every L2 stops calling SES from its own AWS account. They post HMAC-signed JSON to `https://directory.8th-layer.ai/api/v1/transactional/send`; the control plane dispatches via SES from account `124074140789`, where DKIM + SPF + bounce/complaint handling are already wired. Customer L2s have **zero SES setup**, which is the whole point of marketplace one-click deploy.

The four design-doc open decisions were resolved by the operator before implementation:

1. **Host** — `directory.8th-layer.ai` (one control-plane surface, co-located with directory service).
2. **Dispatch** — synchronous 202 (caller knows quickly if suppression blocked).
3. **Idempotency** — optional `Idempotency-Key` header; falls back to `audit_ref` when present; 60s window.
4. **Webhook** — none in V1 (L2 polls if it needs status).

## Per-section breakdown

### 1. Control-plane service (`server/backend/src/cq_server/transactional/`)
- `routes.py` — `POST /api/v1/transactional/send` with full request flow: HMAC verify → idempotency check → tenancy enforce → suppression check → SES dispatch.
- `auth.py` — HMAC v0 (SHA-256 hex, `sha256=` prefix matching GitHub webhook convention). `StaticKeyResolver` for tests, `SsmKeyResolver` for production (60s TTL cache).
- `dispatcher.py` — SES v1 wrapper, persona → sender mapping (`invites@`, `auth@`, `notifications@8th-layer.ai`), pinned to `signup-events` configuration set.
- `suppression.py` — read/write helpers for the suppression table (lowercased addresses, idempotent INSERT OR IGNORE).
- `idempotency.py` — thread-safe in-memory 60s dedup cache (lazy eviction, no background sweeper).
- `tenancy.py` — recipient must be a known user OR (for invite categories) a pending-invitee of the calling L2's tenancy.
- `sns_writer.py` — SES → SNS bounce/complaint handler. Two entry points (`handle_sns_message` for in-process workers, `handle_lambda_event` for Lambda). Only `Permanent` bounces + `Complaint` events drive suppression; transient bounces are ignored.

### 2. Tenancy enforcement
Implemented in `tenancy.py`. Categories 1-3 (invite/reset/2FA) allow known users OR pending-invitees of the caller's tenancy; categories 4-5 (account_event/security_alert) require known users only. Cross-tenant or unknown recipient → 403 (we don't distinguish to avoid being a user-existence oracle).

### 3. Suppression table
New Alembic migration `0026_transactional_suppression` — `(address PK, reason, suppressed_at, source_event_id)` + suppressed_at index. `HEAD_REVISION` bumped accordingly.

### 4. SES dispatch
Account `124074140789`, configuration set `signup-events`. Three sender personas verified out-of-band. `SesDispatcher` is a thin boto3 wrapper; `MockSesDispatcher` for tests.

### 5. L2-side migration (`server/backend/src/cq_server/email_sender.py`)
- Boto3 SES → HTTP client (httpx). Signs body with HMAC from `TX_SEND_KEY` env.
- Preserved `send_invite(...)` signature; new `send_invite_outcome(...)` returns the structured `EmailSendOutcome` envelope.
- Suppression cleanly surfaces as `status="suppressed"` (not an exception).
- Backwards-compat fallback: `CQ_EMAIL_LEGACY_SES=1` + missing `TX_SEND_KEY` → legacy boto3 SES path with a clear deprecation log line. Lets the L2 image roll out ahead of the per-L2 SSM-key backfill.
- Admin invite route surfaces suppression as **409** (not 502) so the UI can render a meaningful message.

### 6. CFN template (`deploy/aws/marketplace-l2.yaml`)
- New `TxSendBaseUrl` parameter.
- `TX_SEND_BASE_URL` env var on the task.
- `TX_SEND_KEY` ECS task secret, sourced from SSM at `/8th-layer/l2/{EnterpriseSlug}/{CqGroupId}/tx_send_key`.
- `TaskExecutionRole` gains `ssm:GetParameters` + `kms:Decrypt` (via `ssm.*`) for task-startup secret resolution.
- `TaskRole` gains `ssm:GetParameter(s)` for runtime re-reads.
- **Removes** the `SesSendInvites` policy entirely.

> **Migration note:** this is a template-level change. Image-bump-only deploys won't apply it — needs `aws cloudformation update-stack` per L2.

### 7. Provisioning service change

Out of scope for this PR — that work lives in `8th-layer-directory` (the provisioning service). A sibling PR there will extend the SSM-write phase to also mint `tx_send_key`. For now, the `bin/backfill-tx-keys.py` script covers both existing L2s and (until that sibling PR lands) new L2s as a manual post-create step.

### 8. Tests

`server/backend/tests/`:
- `test_transactional_send.py` — 17 tests covering HMAC, tenancy, suppression, idempotency, malformed-input.
- `test_transactional_suppression.py` — 3 tests for the suppression read/write helpers.
- `test_transactional_idempotency.py` — 5 unit tests for the dedup store (incl. thread-safety smoke).
- `test_transactional_sns_writer.py` — 6 tests for the SES → SNS handler with real envelope fixtures from the AWS docs.
- `test_email_sender_http.py` — 7 tests for the L2-side HTTP client (happy/suppressed/error, HMAC round-trip, legacy fallback, no-boto3-on-HTTP-path sentinel).

**Total: 38 new tests, all passing.**

## Migration note for existing L2s

11 L2s deployed pre-Decision-34. Each needs:

1. `tx_send_key` minted via `bin/backfill-tx-keys.py` (writes to both the L2's AWS account AND control plane `124074140789`).
2. Image-bump update-stack to a Decision-34 cq-server build.
3. Template-change update-stack to bind `TX_SEND_KEY` from SSM + drop SES IAM.
4. Verify with a fresh invite send to an external recipient.

Full runbook: `docs/ops/transactional-mail-migration.md`.

**Estimated time per L2:** ~10 minutes (30s backfill, ~3min image bump, ~5min template change, ~1min verify).
**Total for 11 L2s:** ~1.5–2 hours of focused operator time (bulk backfill cuts it down).

L2s that have `CQ_EMAIL_LEGACY_SES=1` set will fall back to legacy SES with a deprecation log line during the migration window — safe to keep image-rolling ahead of the per-L2 backfill.

## Deviations from the design doc

None of substance. Two minor adaptations worth flagging:

- The design doc said "Lambda or background worker subscribed to SNS topics writes to a `transactional_suppression` table." Implemented as `handle_lambda_event` + `handle_sns_message` with both entry points exposed — Lambda is the recommended deploy shape, but in-process polling against SQS works for dev. The Lambda shim itself (~10 LOC) belongs in ops infra (`8th-layer-core`), not this repo.
- The design doc mentioned "Provisioning service extends FO-2's SSM-write phase." Since the provisioning service runs in `8th-layer-directory` and this PR is scoped to `8th-layer-agent`, that extension lands in a sibling PR. The backfill script covers existing L2s in the interim.

## Out of scope (intentionally)

- AAISN v1 auth (Ed25519 instead of HMAC) — design-doc roadmap item, follow-up PR.
- Marketing email — separate SES identity + pool + suppression list when/if needed.
- Customer-controlled sender identity — V2 feature flag.
- Provisioning-service auto-mint of `tx_send_key` — sibling PR in `8th-layer-directory`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
