### PR TITLE
feat(mcp): quiet local-fallback warnings by default

### DIFF
--- a/FORK_DELTA.md
+++ b/FORK_DELTA.md
@@ -97,6 +97,21 @@ Fills an obvious gap in the upstream consults surface — previously only sub-ro
 - Upstream relationship: **bucket-2 (upstream this sprint)** — clean, self-contained, well-tested. Candidate to PR back to `mozilla-ai/cq` so the fork can stop carrying it as delta. Until then, watch the upstream consults module for a parallel thread-metadata endpoint that could land with a different schema name/shape.
 - Source issue: #260.
 
+### `CQ_QUIET_LOCAL_FALLBACK` — suppress per-candidate fallback warnings in MCP propose/propose_batch
+
+The MCP `propose` and `propose_batch` handlers historically echoed a per-call / per-candidate warning string whenever the remote API was unreachable or rejected the request (e.g. invalid API key) and the unit fell back to local storage. In a typical reflect-cycle with N candidates that produced N identical warnings burying the operator pane.
+
+This change adds an env-gated quiet mode (default ON) that:
+
+- Drops the per-candidate `Warning` field on `batchStored` entries (now `omitempty` and only populated when `CQ_QUIET_LOCAL_FALLBACK=false`).
+- Adds response-level `local_fallback_count` (int) and `local_fallback_reason` (string) to `batchResponse` so callers render the signal exactly once.
+- Replaces the legacy `"warning: <msg>\n<json>"` envelope on single `propose` with a structured JSON wrapper carrying `local_fallback_reason` alongside the unit, again only in quiet mode.
+
+Files: `cli/mcpserver/propose.go`, `cli/mcpserver/propose_batch.go`, `cli/mcpserver/propose_test.go`, `cli/mcpserver/propose_batch_test.go`, `cli/mcpserver/propose_quiet_test.go` (new).
+Env: `CQ_QUIET_LOCAL_FALLBACK` — accepts `false`, `0`, `no`, `off` to restore legacy behavior; anything else (including unset) keeps quiet mode active.
+Source issue: 8th-layer-core operator directive 2026-05-22 ("ensure our forked cq does not surface this in the foreground").
+Upstream relationship: **bucket-2 (upstream this sprint)** — clean UX-tightening change, response schema is backward-compatible for existing callers (new fields are `omitempty`, existing `warning` field still populated when env opts back into legacy mode). Candidate to PR back to `mozilla-ai/cq` once the skill-side `/8l-cq:reflect` rendering update lands.
+
 ## Sync discipline
 
 - **Fork base**: pinned at the cq commit at the time of fork creation (2026-04-26).

--- a/cli/mcpserver/propose.go
+++ b/cli/mcpserver/propose.go
@@ -77,15 +77,32 @@ func (s *Server) HandlePropose(ctx context.Context, req mcp.CallToolRequest) (*m
 	}
 
 	result, err := s.client.Propose(ctx, params)
-	// Remote unreachable/rejected: unit was stored locally. Surface the unit
-	// alongside a warning so the caller can summarise the partial success.
+	// Remote unreachable/rejected: unit was stored locally. In quiet mode
+	// (the default) we attach `local_fallback_reason` as a structured JSON
+	// field instead of the legacy "warning: X\n{...}" string envelope, so
+	// callers can ignore it cleanly when expected (no API key) and still
+	// see it when present. Set CQ_QUIET_LOCAL_FALLBACK=false to restore
+	// the legacy string envelope.
 	var fb *cq.FallbackError
 	if errors.As(err, &fb) {
+		if quietLocalFallback() {
+			wrapper := struct {
+				cq.KnowledgeUnit
+				LocalFallbackReason string `json:"local_fallback_reason"`
+			}{
+				KnowledgeUnit:       fb.LocalUnit,
+				LocalFallbackReason: fb.Error(),
+			}
+			data, mErr := json.Marshal(wrapper)
+			if mErr != nil {
+				return nil, fmt.Errorf("encoding result: %w", mErr)
+			}
+			return mcp.NewToolResultText(string(data)), nil
+		}
 		data, mErr := json.Marshal(fb.LocalUnit)
 		if mErr != nil {
 			return nil, fmt.Errorf("encoding result: %w", mErr)
 		}
-
 		return mcp.NewToolResultText(fmt.Sprintf("warning: %s\n%s", fb, data)), nil
 	}
 	if err != nil {

--- a/cli/mcpserver/propose_batch.go
+++ b/cli/mcpserver/propose_batch.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 
@@ -84,7 +86,11 @@ type batchStored struct {
 	Summary string `json:"summary"`
 	Tier    string `json:"tier"`
 	// Warning is set when the unit was stored locally after a remote
-	// failure (cq.FallbackError). Empty when the propose succeeded cleanly.
+	// failure (cq.FallbackError) AND quiet-fallback mode is OFF. In quiet
+	// mode (the default) the per-candidate Warning is suppressed; the
+	// response-level LocalFallbackCount + LocalFallbackReason carry the
+	// signal once. Set CQ_QUIET_LOCAL_FALLBACK=false to restore the legacy
+	// per-candidate warning behavior.
 	Warning string `json:"warning,omitempty"`
 }
 
@@ -99,6 +105,15 @@ type batchError struct {
 type batchResponse struct {
 	Stored []batchStored `json:"stored"`
 	Errors []batchError  `json:"errors"`
+	// LocalFallbackCount is the number of candidates that fell back to local
+	// storage (non-zero implies the remote was unreachable or rejected the
+	// request — typically an invalid/missing API key). Zero when omitted.
+	LocalFallbackCount int `json:"local_fallback_count,omitempty"`
+	// LocalFallbackReason is the human-readable reason captured from the
+	// first FallbackError encountered. Empty when no fallbacks occurred.
+	// Callers should render this once at the response level rather than
+	// per-candidate.
+	LocalFallbackReason string `json:"local_fallback_reason,omitempty"`
 }
 
 // HandleProposeBatch creates multiple knowledge units from a single MCP call.
@@ -120,6 +135,8 @@ func (s *Server) HandleProposeBatch(ctx context.Context, req mcp.CallToolRequest
 		Stored: []batchStored{},
 		Errors: []batchError{},
 	}
+
+	quiet := quietLocalFallback()
 
 	for i, raw := range candList {
 		cand, ok := raw.(map[string]any)
@@ -190,13 +207,23 @@ func (s *Server) HandleProposeBatch(ctx context.Context, req mcp.CallToolRequest
 		ku, err := s.client.Propose(ctx, params)
 		var fb *cq.FallbackError
 		if errors.As(err, &fb) {
-			resp.Stored = append(resp.Stored, batchStored{
+			stored := batchStored{
 				Index:   i,
 				ID:      fb.LocalUnit.ID,
 				Summary: summary,
 				Tier:    string(fb.LocalUnit.Tier),
-				Warning: fb.Error(),
-			})
+			}
+			// Roll up to response-level. In quiet mode (default) the
+			// per-candidate Warning stays empty; non-quiet preserves the
+			// legacy per-candidate string for callers that opted in.
+			resp.LocalFallbackCount++
+			if resp.LocalFallbackReason == "" {
+				resp.LocalFallbackReason = fb.Error()
+			}
+			if !quiet {
+				stored.Warning = fb.Error()
+			}
+			resp.Stored = append(resp.Stored, stored)
 			continue
 		}
 		if err != nil {
@@ -222,6 +249,28 @@ func (s *Server) HandleProposeBatch(ctx context.Context, req mcp.CallToolRequest
 	}
 
 	return mcp.NewToolResultText(string(data)), nil
+}
+
+// quietLocalFallback reports whether the MCP server should suppress
+// per-candidate / per-call warnings when a propose falls back to local
+// storage because the remote was unreachable or rejected the request.
+//
+// Default behavior is QUIET (true): typical operator UX is a single
+// concluding note ("9 stored locally; check API key") rather than N
+// identical warnings carved into the response shape. Set
+// CQ_QUIET_LOCAL_FALLBACK=false to restore the legacy per-candidate
+// warning string for tools that parse it.
+//
+// Accepted "off" values: "false", "0", "no", "off" (case-insensitive).
+// Any other value (including unset) keeps quiet mode active.
+func quietLocalFallback() bool {
+	v := strings.TrimSpace(strings.ToLower(os.Getenv("CQ_QUIET_LOCAL_FALLBACK")))
+	switch v {
+	case "false", "0", "no", "off":
+		return false
+	default:
+		return true
+	}
 }
 
 // requireBatchString extracts a required string field from a candidate map.

--- a/cli/mcpserver/propose_batch_test.go
+++ b/cli/mcpserver/propose_batch_test.go
@@ -293,12 +293,56 @@ func TestHandleProposeBatch(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		// Quiet mode (default): per-candidate Warning is suppressed in favor
+		// of response-level LocalFallbackCount + LocalFallbackReason rolled
+		// up once. Callers render a single concluding note instead of N
+		// identical warnings.
 		resp := decodeBatchResult(t, result)
 		require.Len(t, resp.Stored, 1)
 		require.Empty(t, resp.Errors)
 		require.Equal(t, "ku_local", resp.Stored[0].ID)
 		require.Equal(t, "local", resp.Stored[0].Tier)
-		require.Contains(t, resp.Stored[0].Warning, "stored locally after remote failure")
+		require.Empty(t, resp.Stored[0].Warning, "per-candidate warning should be suppressed in quiet mode")
+		require.Equal(t, 1, resp.LocalFallbackCount)
+		require.Contains(t, resp.LocalFallbackReason, "stored locally after remote failure")
+	})
+
+	t.Run("multiple fallback candidates collapse to single response-level reason", func(t *testing.T) {
+		t.Parallel()
+
+		// Default quiet mode. Verify three FallbackError candidates produce
+		// LocalFallbackCount=3 and a single LocalFallbackReason — not three
+		// identical strings on each Stored entry.
+		s := New(&mockClient{
+			proposeFn: func(_ context.Context, _ cq.ProposeParams) (cq.KnowledgeUnit, error) {
+				return cq.KnowledgeUnit{}, &cq.FallbackError{
+					LocalUnit: cq.KnowledgeUnit{ID: "ku_local", Tier: cq.Local},
+					Err:       &cq.RemoteError{StatusCode: 401, Detail: "Invalid API key"},
+				}
+			},
+		}, "test")
+
+		result, err := s.HandleProposeBatch(context.Background(), mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "propose_batch",
+				Arguments: map[string]any{
+					"candidates": []any{
+						map[string]any{"summary": "a", "detail": "d", "action": "a", "domains": []any{"x"}},
+						map[string]any{"summary": "b", "detail": "d", "action": "a", "domains": []any{"x"}},
+						map[string]any{"summary": "c", "detail": "d", "action": "a", "domains": []any{"x"}},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		resp := decodeBatchResult(t, result)
+		require.Len(t, resp.Stored, 3)
+		for _, s := range resp.Stored {
+			require.Empty(t, s.Warning)
+		}
+		require.Equal(t, 3, resp.LocalFallbackCount)
+		require.Contains(t, resp.LocalFallbackReason, "Invalid API key")
 	})
 
 	t.Run("non-string domain item is reported", func(t *testing.T) {

--- a/cli/mcpserver/propose_quiet_test.go
+++ b/cli/mcpserver/propose_quiet_test.go
@@ -1,0 +1,108 @@
+package mcpserver
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	cq "github.com/mozilla-ai/cq/sdk/go"
+)
+
+// These tests mutate process env via t.Setenv and therefore cannot run in
+// parallel with the rest of the propose/propose_batch tests (which set
+// t.Parallel on the outer test). Keeping them in a dedicated test function
+// avoids the panic Go's testing package raises when t.Setenv is called from
+// a parallel-marked test tree.
+
+func TestProposeQuietFallback_LegacyEnvelopeWhenDisabled(t *testing.T) {
+	t.Setenv("CQ_QUIET_LOCAL_FALLBACK", "false")
+
+	localUnit := cq.KnowledgeUnit{ID: "ku_legacy_envelope_1234567890abcdef"}
+	s := New(&mockClient{
+		proposeFn: func(_ context.Context, _ cq.ProposeParams) (cq.KnowledgeUnit, error) {
+			return cq.KnowledgeUnit{}, &cq.FallbackError{
+				LocalUnit: localUnit,
+				Err:       errors.New("remote API unreachable: connection refused"),
+			}
+		},
+	}, "test")
+
+	result, err := s.HandlePropose(context.Background(), mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "propose",
+			Arguments: map[string]any{
+				"summary": "s", "detail": "d", "action": "a",
+				"domains": []any{"api"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	text := result.Content[0].(mcp.TextContent).Text
+	require.Contains(t, text, "warning: stored locally after remote failure")
+	require.Contains(t, text, "ku_legacy_envelope_1234567890abcdef")
+}
+
+func TestProposeBatchQuietFallback_LegacyWarningWhenDisabled(t *testing.T) {
+	t.Setenv("CQ_QUIET_LOCAL_FALLBACK", "false")
+
+	s := New(&mockClient{
+		proposeFn: func(_ context.Context, _ cq.ProposeParams) (cq.KnowledgeUnit, error) {
+			return cq.KnowledgeUnit{}, &cq.FallbackError{
+				LocalUnit: cq.KnowledgeUnit{ID: "ku_legacy_warn", Tier: cq.Local},
+				Err:       errors.New("remote API unreachable: connection refused"),
+			}
+		},
+	}, "test")
+
+	result, err := s.HandleProposeBatch(context.Background(), mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "propose_batch",
+			Arguments: map[string]any{
+				"candidates": []any{
+					map[string]any{"summary": "x", "detail": "d", "action": "a", "domains": []any{"x"}},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	resp := decodeBatchResult(t, result)
+	require.Len(t, resp.Stored, 1)
+	require.Contains(t, resp.Stored[0].Warning, "stored locally after remote failure")
+	// Roll-up fields populate regardless of quiet mode so the caller always
+	// knows how many candidates fell back.
+	require.Equal(t, 1, resp.LocalFallbackCount)
+	require.Contains(t, resp.LocalFallbackReason, "stored locally after remote failure")
+}
+
+func TestQuietLocalFallback_EnvVarParsing(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{"unset", "", true},
+		{"empty", "", true},
+		{"true", "true", true},
+		{"True", "True", true},
+		{"1", "1", true},
+		{"yes", "yes", true},
+		{"false", "false", false},
+		{"FALSE", "FALSE", false},
+		{"0", "0", false},
+		{"no", "no", false},
+		{"off", "off", false},
+		{"random", "banana", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("CQ_QUIET_LOCAL_FALLBACK", tc.value)
+			require.Equal(t, tc.want, quietLocalFallback())
+		})
+	}
+}

--- a/cli/mcpserver/propose_test.go
+++ b/cli/mcpserver/propose_test.go
@@ -142,10 +142,14 @@ func TestHandlePropose(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, result.IsError)
 
+		// Quiet mode (default): the legacy "warning: ..." string envelope is
+		// replaced by a structured `local_fallback_reason` JSON field so the
+		// successful local store doesn't bury the operator pane.
 		text := result.Content[0].(mcp.TextContent).Text
-		require.Contains(t, text, "warning: stored locally after remote failure")
+		require.Contains(t, text, `"local_fallback_reason":"stored locally after remote failure`)
 		require.Contains(t, text, "remote API unreachable: connection refused")
 		require.Contains(t, text, "ku_0123456789abcdef0123456789abcdef")
+		require.NotContains(t, text, "warning: stored locally")
 	})
 
 	t.Run("surfaces fallback warning when remote rejects with RemoteError", func(t *testing.T) {
@@ -175,10 +179,13 @@ func TestHandlePropose(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, result.IsError)
 
+		// Quiet mode (default): the structured `local_fallback_reason` field
+		// carries the same information without the noisy string envelope.
 		text := result.Content[0].(mcp.TextContent).Text
-		require.Contains(t, text, "warning: stored locally after remote failure")
+		require.Contains(t, text, `"local_fallback_reason":"stored locally after remote failure`)
 		require.Contains(t, text, "remote API rejected request (401): Invalid API key")
 		require.Contains(t, text, "ku_fedcba9876543210fedcba9876543210")
+		require.NotContains(t, text, "warning: stored locally")
 	})
 
 	t.Run("empty domains slice yields distinct message", func(t *testing.T) {

--- a/server/backend/src/cq_server/email_sender.py
+++ b/server/backend/src/cq_server/email_sender.py
@@ -77,6 +77,7 @@ class EmailSendOutcome:
 
     @property
     def ok(self) -> bool:
+        """Return True when the send status indicates a successful delivery."""
         return self.status == "sent"
 
 
@@ -212,9 +213,15 @@ class EmailSender:
         l2_id: str | None = None,
         timeout_sec: float = DEFAULT_HTTP_TIMEOUT_SEC,
     ) -> None:
-        # ``from_email`` + ``region`` retained for backwards-compat with
-        # any test fixtures that still pass them — central service
-        # ignores them (sender is persona-keyed).
+        """Initialise the transactional-mail HTTP sender.
+
+        All parameters are optional; missing values resolve from env at
+        first-send time so import-time cost stays low and test fixtures
+        can construct without setting AWS env vars. ``from_email`` and
+        ``region`` are retained for backwards-compat with fixtures that
+        still pass them — the central service ignores them (sender is
+        persona-keyed). See ``_resolve_*`` helpers for defaulting rules.
+        """
         self._from_email = from_email or _from_email()
         self._region = region or _aws_region()
         self._public_host = public_host
@@ -276,9 +283,7 @@ class EmailSender:
                 "email_sender: TX_SEND_KEY missing and legacy SES not enabled; "
                 "cannot deliver email (set TX_SEND_KEY or CQ_EMAIL_LEGACY_SES=1)"
             )
-            return EmailSendOutcome(
-                status="error", reason="tx_send_key_missing"
-            )
+            return EmailSendOutcome(status="error", reason="tx_send_key_missing")
 
         body: dict[str, Any] = {
             "from_persona": from_persona,
@@ -517,6 +522,7 @@ class MockEmailSender:
         enterprise_name: str,
         expiry: datetime,
     ) -> dict[str, Any]:
+        """Capture an invite send in-memory for tests and return a mock receipt."""
         claim_url = _claim_url(jwt, host=self.public_host)
         expiry_iso = expiry.isoformat()
         subject = _render_subject(inviter_name, enterprise_name)
@@ -547,12 +553,8 @@ class MockEmailSender:
         )
         outcome = EmailSendOutcome(
             status=self.next_outcome,
-            delivery_handle=f"mock-handle-{len(self.sent)}"
-            if self.next_outcome == "sent"
-            else None,
-            ses_message_id=f"mock-{len(self.sent)}"
-            if self.next_outcome == "sent"
-            else None,
+            delivery_handle=f"mock-handle-{len(self.sent)}" if self.next_outcome == "sent" else None,
+            ses_message_id=f"mock-{len(self.sent)}" if self.next_outcome == "sent" else None,
             reason=self.next_reason,
         )
         return _outcome_to_legacy_dict(outcome)

--- a/server/backend/tests/test_default_enterprise_backfill.py
+++ b/server/backend/tests/test_default_enterprise_backfill.py
@@ -409,4 +409,4 @@ class TestIdempotencyAndChain:
         """
         # The current chain head. Update this whenever a new migration
         # lands — this test failing IS the reminder to bump HEAD_REVISION.
-        assert HEAD_REVISION == "0025_activity_log_aigrp_lookup_event"
+        assert HEAD_REVISION == "0026_transactional_suppression"

--- a/server/backend/tests/test_migration_0011_activity_log.py
+++ b/server/backend/tests/test_migration_0011_activity_log.py
@@ -475,7 +475,7 @@ class TestHeadRevisionAndHistory:
 
         # The current chain head. Each new migration MUST move this
         # constant; this test failing is the reminder.
-        assert HEAD_REVISION == "0025_activity_log_aigrp_lookup_event"
+        assert HEAD_REVISION == "0026_transactional_suppression"
 
     @pytest.mark.parametrize("invalid_dir", [None])
     def test_alembic_history_includes_0011(self, invalid_dir: object) -> None:

--- a/server/backend/tests/test_migration_0015_aigrp_peers_pair_secret_ref.py
+++ b/server/backend/tests/test_migration_0015_aigrp_peers_pair_secret_ref.py
@@ -271,7 +271,7 @@ class TestHeadRevisionAndHistory:
     def test_head_revision_constant_was_bumped(self) -> None:
         from cq_server.migrations import HEAD_REVISION
 
-        assert HEAD_REVISION == "0025_activity_log_aigrp_lookup_event"
+        assert HEAD_REVISION == "0026_transactional_suppression"
 
     def test_alembic_history_includes_0015(self) -> None:
         repo_root = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary

- MCP `propose` + `propose_batch` were emitting per-call/per-candidate warnings whenever the remote rejected (e.g. invalid `CQ_API_KEY`) → fallback to local storage. For an N-candidate batch this produced N identical warnings burying the operator pane in `/8l-cq:reflect` cycles
- Default to quiet mode (`CQ_QUIET_LOCAL_FALLBACK` env, accepts `false`/`0`/`no`/`off` to restore legacy)
- Replace per-candidate `Warning` field with response-level `local_fallback_count` + `local_fallback_reason` so the signal travels once
- Replace `propose` single-shot `"warning: <msg>\n<json>"` string envelope with structured JSON wrapper carrying `local_fallback_reason` alongside the unit
- Update FORK_DELTA.md (bucket-2 — candidate to upstream once skill-side rendering lands)

## Test plan
- [x] `go test ./mcpserver/` passes
- [x] Legacy mode preserved when `CQ_QUIET_LOCAL_FALLBACK=false`
- [x] Roll-up fields populate regardless of mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)