### PR TITLE
feat(api): /api/v1/knowledge alias for /api/v1/query (#377)

### DIFF
--- a/FORK_DELTA.md
+++ b/FORK_DELTA.md
@@ -98,6 +98,18 @@ Fills an obvious gap in the upstream consults surface — previously only sub-ro
 - Upstream relationship: **bucket-2 (upstream this sprint)** — clean, self-contained, well-tested. Candidate to PR back to `mozilla-ai/cq` so the fork can stop carrying it as delta. Until then, watch the upstream consults module for a parallel thread-metadata endpoint that could land with a different schema name/shape.
 - Source issue: #260.
 
+### `/api/v1/knowledge` alias for `/api/v1/query` + envelope-shape divergence note
+
+Upstream `mozilla-ai/cq` PR #372 (merged 2026-05-15) renamed the knowledge-search endpoint to `/api/v1/knowledge` and unified list responses on a `{data: [...]}` envelope. Our fork carries `/api/v1/query` (returning a bare `list[KnowledgeUnit]`) — diverged from upstream at the URL layer AND the response shape.
+
+This entry registers the divergence and adds a URL alias so upstream `cli/v0.10.0+` clients pointed at our L2 hit the same handler instead of 404'ing.
+
+- Files: `server/backend/src/cq_server/app.py` (stacked `@api_router.get("/knowledge")` decorator on `query_units`), `server/backend/tests/test_app.py` (`test_knowledge_alias_returns_same_results`).
+- Endpoint: `GET /api/v1/knowledge` — same handler as `/api/v1/query`, same response shape (bare list).
+- Upstream relationship: **HOLD + COORDINATE**. URL parity is now achieved, but response shape still differs (bare list vs upstream's `{data, count}` envelope). Adopting the envelope is a coordinated SDK + server change — both our Python and Go SDKs parse the bare array in `sdk/python/src/cq/client.py:420` and `sdk/go/remote.go:227`; flipping the server response shape without lock-step SDK bumps would silently break every plugin/v0.1.0 in the field across the 10-L2 fleet. The api-keys half of upstream #372 was already done in our fork (commit `fe91491`, `ApiKeysPublic(data=..., count=...)` in `auth.py:639`).
+- Suggested next move when we're ready to converge: ship SDKs with a backward-compat reader (try `data` field, fall back to bare array), wait for fleet plugin rebuild, then wrap the server response. Tracked at agent#377.
+- Surfaced by: cq-fanboy crosstalk thread `197ae3491e5dcebd` (2026-05-27 fresh upstream pull).
+
 ### `CQ_QUIET_LOCAL_FALLBACK` — suppress per-candidate fallback warnings in MCP propose/propose_batch
 
 The MCP `propose` and `propose_batch` handlers historically echoed a per-call / per-candidate warning string whenever the remote API was unreachable or rejected the request (e.g. invalid API key) and the unit fell back to local storage. In a typical reflect-cycle with N candidates that produced N identical warnings burying the operator pane.

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -1756,8 +1756,8 @@ async def query_semantic(
     return [SemanticHit(knowledge_unit=u, similarity=s) for u, s in hits]
 
 
-@api_router.get("/query")
-@api_router.get("/knowledge")
+@api_router.get("/query", operation_id="query_knowledge_units")
+@api_router.get("/knowledge", operation_id="list_knowledge_units")
 async def query_units(
     background_tasks: BackgroundTasks,
     domains: Annotated[list[str], Query()],

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -1757,6 +1757,7 @@ async def query_semantic(
 
 
 @api_router.get("/query")
+@api_router.get("/knowledge")
 async def query_units(
     background_tasks: BackgroundTasks,
     domains: Annotated[list[str], Query()],

--- a/server/backend/tests/test_app.py
+++ b/server/backend/tests/test_app.py
@@ -204,6 +204,14 @@ class TestQuery:
         assert len(results) == 1
         assert results[0]["domains"] == ["databases"]
 
+    def test_knowledge_alias_returns_same_results(self, client: TestClient) -> None:
+        self._insert_unit(client, domains=["databases"])
+        resp = client.get("/knowledge", params={"domains": ["databases"]})
+        assert resp.status_code == 200
+        results = resp.json()
+        assert len(results) == 1
+        assert results[0]["domains"] == ["databases"]
+
     def test_query_returns_empty_for_no_match(self, client: TestClient) -> None:
         self._insert_unit(client, domains=["databases"])
         resp = client.get("/query", params={"domains": ["networking"]})


### PR DESCRIPTION
## Summary

- Stack `@api_router.get("/knowledge")` decorator on top of `@api_router.get("/query")` so `GET /api/v1/knowledge` resolves to the same handler.
- Add `test_knowledge_alias_returns_same_results` to lock the alias contract.
- Register the divergence in `FORK_DELTA.md` with the full rationale + suggested convergence path.

## Why

Upstream `mozilla-ai/cq` PR #372 (merged 2026-05-15) renamed the knowledge-search endpoint to `/api/v1/knowledge` and changed the response shape to `{data: [...]}`. Without an alias, upstream `cli/v0.10.0+` clients pointed at our L2 cq-server get a hard 404 on every query.

This PR is the **URL-only** half — a cheap, no-fleet-risk move. The envelope-shape adopt is a coordinated SDK+server change deferred to a future PR (tracked at #377).

## What this PR does NOT do

- Does NOT change response shape (still bare `list[KnowledgeUnit]`)
- Does NOT touch SDK code
- Does NOT bounce the fleet

Existing fork clients keep working; new upstream clients now get an answer instead of 404.

## Test plan

- [x] `pytest tests/test_app.py::TestQuery::test_knowledge_alias_returns_same_results` passes
- [x] `pytest tests/test_app.py::TestQuery::test_query_returns_matching_units` still passes (no regression on the original path)
- [ ] Smoke test against a deployed L2 after merge: `curl https://<l2>/api/v1/knowledge?domains=test`

Surfaced by cq-fanboy crosstalk thread \`197ae3491e5dcebd\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)