### PR TITLE
feat(sdk): backward-compat reader for {data} envelope (#377 Phase 1)

### DIFF
--- a/sdk/go/remote.go
+++ b/sdk/go/remote.go
@@ -248,10 +248,21 @@ func (r *remoteClient) query(ctx context.Context, params QueryParams) []Knowledg
 		return nil
 	}
 
-	var enveloped struct {
-		Data []KnowledgeUnit `json:"data"`
-	}
-	if err := json.Unmarshal(raw, &enveloped); err == nil && enveloped.Data != nil {
+	// Probe the shape: leading `{` means envelope, leading `[` means bare list.
+	// Doing the probe before Unmarshal avoids the trap where {"data": null}
+	// decodes cleanly into a nil slice and silently masks a server bug.
+	trimmed := bytes.TrimLeft(raw, " \t\r\n")
+	if len(trimmed) > 0 && trimmed[0] == '{' {
+		var enveloped struct {
+			Data []KnowledgeUnit `json:"data"`
+		}
+		if err := json.Unmarshal(raw, &enveloped); err != nil {
+			return nil
+		}
+		// {"data": null} → empty result, not a parse error.
+		if enveloped.Data == nil {
+			return []KnowledgeUnit{}
+		}
 		return enveloped.Data
 	}
 

--- a/sdk/go/remote.go
+++ b/sdk/go/remote.go
@@ -239,8 +239,24 @@ func (r *remoteClient) query(ctx context.Context, params QueryParams) []Knowledg
 		return nil
 	}
 
+	// Backward-compat reader for upstream PR #372: list endpoints may emit
+	// `{data: [...]}` (upstream cli/v0.10.0+) OR a bare array (this fork).
+	// Accept both so the SDK works against either server shape during the
+	// transition window — see #377.
+	raw, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil
+	}
+
+	var enveloped struct {
+		Data []KnowledgeUnit `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &enveloped); err == nil && enveloped.Data != nil {
+		return enveloped.Data
+	}
+
 	var units []KnowledgeUnit
-	if err := json.NewDecoder(resp.Body).Decode(&units); err != nil {
+	if err := json.Unmarshal(raw, &units); err != nil {
 		// Query degrades gracefully; log-worthy but not a hard error.
 		return nil
 	}

--- a/sdk/go/remote_test.go
+++ b/sdk/go/remote_test.go
@@ -48,6 +48,23 @@ func TestRemoteQueryAcceptsDataEnvelope(t *testing.T) {
 	require.Equal(t, "ku_00000000000000000000000000000003", units[0].ID)
 }
 
+func TestRemoteQueryAcceptsDataNullEnvelope(t *testing.T) {
+	// {"data": null} envelope means empty result, not silent nil (#377 review).
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data": null}`))
+	}))
+	defer srv.Close()
+
+	rc := newRemoteClient(srv.URL, "", 5*time.Second)
+	units := rc.query(context.Background(), QueryParams{Domains: []string{"api"}})
+	// Should return an empty slice (non-nil) representing "explicit empty result"
+	// — distinguishable from `nil` which signals a transport/parse failure.
+	require.NotNil(t, units)
+	require.Empty(t, units)
+}
+
 func TestRemoteQueryWithAuth(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/sdk/go/remote_test.go
+++ b/sdk/go/remote_test.go
@@ -31,6 +31,23 @@ func TestRemoteQuery(t *testing.T) {
 	require.Equal(t, "S", units[0].Insight.Summary)
 }
 
+func TestRemoteQueryAcceptsDataEnvelope(t *testing.T) {
+	// SDK accepts the upstream `{data: [...]}` envelope shape (#377).
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{testRemoteKUJSON("ku_00000000000000000000000000000003")},
+		})
+	}))
+	defer srv.Close()
+
+	rc := newRemoteClient(srv.URL, "", 5*time.Second)
+	units := rc.query(context.Background(), QueryParams{Domains: []string{"api"}})
+	require.Len(t, units, 1)
+	require.Equal(t, "ku_00000000000000000000000000000003", units[0].ID)
+}
+
 func TestRemoteQueryWithAuth(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/sdk/python/src/cq/client.py
+++ b/sdk/python/src/cq/client.py
@@ -427,7 +427,11 @@ class Client:
         if isinstance(payload, dict) and "data" in payload:
             # Server explicitly returned a `data: null` envelope — treat as
             # empty result rather than raising an opaque iteration error.
-            items = payload["data"] or []
+            # Use `is None` rather than `or []` — the latter would silently
+            # coerce schema-violating falsy values (`{}`, `0`, `""`) into an
+            # empty list instead of letting model_validate raise a catchable
+            # ValidationError that surfaces as a warning to the caller.
+            items = payload["data"] if payload["data"] is not None else []
         else:
             items = payload
         return [KnowledgeUnit.model_validate(item) for item in items]

--- a/sdk/python/src/cq/client.py
+++ b/sdk/python/src/cq/client.py
@@ -424,7 +424,12 @@ class Client:
         # `{data: [...]}` (upstream cli/v0.10.0+) OR a bare array (this fork).
         # Accept both so the SDK works against either server shape during the
         # transition window — see #377.
-        items = payload["data"] if isinstance(payload, dict) and "data" in payload else payload
+        if isinstance(payload, dict) and "data" in payload:
+            # Server explicitly returned a `data: null` envelope — treat as
+            # empty result rather than raising an opaque iteration error.
+            items = payload["data"] or []
+        else:
+            items = payload
         return [KnowledgeUnit.model_validate(item) for item in items]
 
     def _remote_propose(self, unit: KnowledgeUnit) -> KnowledgeUnit:

--- a/sdk/python/src/cq/client.py
+++ b/sdk/python/src/cq/client.py
@@ -419,7 +419,13 @@ class Client:
             params["pattern"] = pattern
         resp = self._http.get("/query", params=params)
         resp.raise_for_status()
-        return [KnowledgeUnit.model_validate(item) for item in resp.json()]
+        payload = resp.json()
+        # Backward-compat reader for upstream PR #372: list endpoints may emit
+        # `{data: [...]}` (upstream cli/v0.10.0+) OR a bare array (this fork).
+        # Accept both so the SDK works against either server shape during the
+        # transition window — see #377.
+        items = payload["data"] if isinstance(payload, dict) and "data" in payload else payload
+        return [KnowledgeUnit.model_validate(item) for item in items]
 
     def _remote_propose(self, unit: KnowledgeUnit) -> KnowledgeUnit:
         """Push a unit to the remote API.

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -370,6 +370,19 @@ class TestRemoteIntegration:
         assert result.units[0].id == "ku_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb02"
         c.close()
 
+    def test_remote_query_accepts_data_null_envelope(self, tmp_path: Path, httpx_mock):
+        """`{data: null}` envelope means empty result, not an error (#377 review)."""
+        httpx_mock.add_response(
+            url=httpx.URL("http://test-remote/query", params={"domains": ["api"], "limit": "5"}),
+            json={"data": None},
+        )
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        result = c.query(["api"])
+        assert result.warnings == [], f"unexpected warnings: {result.warnings}"
+        assert result.source == "remote"
+        assert result.units == []
+        c.close()
+
     def test_remote_query_sends_plural_language_and_framework_params(self, tmp_path: Path, httpx_mock):
         """Remote query sends plural 'languages'/'frameworks' keys, not singular."""
         remote_unit = {

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -344,6 +344,32 @@ class TestRemoteIntegration:
         assert "ku_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa01" in ids
         c.close()
 
+    def test_remote_query_accepts_data_envelope_shape(self, tmp_path: Path, httpx_mock):
+        """SDK accepts the upstream `{data: [...]}` envelope shape (#377)."""
+        remote_unit = {
+            "id": "ku_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb02",
+            "domains": ["api"],
+            "insight": {"summary": "Enveloped", "detail": "D", "action": "A"},
+            "evidence": {
+                "confidence": 0.8,
+                "confirmations": 5,
+                "first_observed": "2025-01-01T00:00:00Z",
+                "last_confirmed": "2025-01-01T00:00:00Z",
+            },
+            "tier": "private",
+        }
+        httpx_mock.add_response(
+            url=httpx.URL("http://test-remote/query", params={"domains": ["api"], "limit": "5"}),
+            json={"data": [remote_unit]},
+        )
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        result = c.query(["api"])
+        assert result.warnings == [], f"unexpected warnings: {result.warnings}"
+        assert result.source == "remote"
+        assert len(result.units) == 1
+        assert result.units[0].id == "ku_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb02"
+        c.close()
+
     def test_remote_query_sends_plural_language_and_framework_params(self, tmp_path: Path, httpx_mock):
         """Remote query sends plural 'languages'/'frameworks' keys, not singular."""
         remote_unit = {


### PR DESCRIPTION
## Summary

Teach both Python and Go SDKs to accept either response shape on the \`/query\` endpoint:
- New: \`{data: [...]}\` (upstream cq cli/v0.10.0+, PR #372 envelope shape)
- Old: bare \`[...]\` (this fork's current server behavior)

Pure additive — no existing behavior changes. Sets up Phase 2 (server-side envelope adopt) to ship later without coupling.

## Why phased

The full \`{data}\` adopt is a coordinated SDK + server change. Shipping both in one PR would mean every plugin/v0.1.0 deployment in the field breaks the moment the server flips its response shape. By splitting:

- **Phase 1 (this PR)**: SDK accepts both. Zero-risk additive. Plugin rebuild + fleet bounce can roll out at operator pace.
- **Phase 2 (deferred)**: Server wraps \`/query\` response in \`{data, count}\`. Cannot ship until Phase 1 is everywhere, otherwise old SDKs break.
- **Phase 3 (future)**: Drop the bare-array fallback in SDK once Phase 2 has fully propagated.

## Implementation

### Python (\`sdk/python/src/cq/client.py:_remote_query\`)

\`\`\`python
payload = resp.json()
items = payload["data"] if isinstance(payload, dict) and "data" in payload else payload
return [KnowledgeUnit.model_validate(item) for item in items]
\`\`\`

### Go (\`sdk/go/remote.go:query\`)

Reads body once, tries enveloped struct decode first, falls back to bare slice decode.

## Test plan

- [x] Python: \`pytest tests/test_client.py::TestRemoteIntegration\` — 29 tests pass including new \`test_remote_query_accepts_data_envelope_shape\`
- [x] Go: \`go test -run TestRemoteQuery\` — 7 tests pass including new \`TestRemoteQueryAcceptsDataEnvelope\`
- [ ] Regression sweep on \`make test\` (CI)

## Related

- agent#377 (envelope adopt umbrella, this is Phase 1)
- Upstream PR #372 (cli/v0.10.0+ behavior)
- cq-fanboy crosstalk thread \`197ae3491e5dcebd\` (intel that surfaced this)
- PR #380 (\`/knowledge\` URL alias — sister change, URL parity vs envelope parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)