### PR TITLE
fix(marketplace): 3 drift defects in customer deploy-role snippet (#130)

### DIFF
--- a/docs/marketplace-customer-role-snippet.yaml
+++ b/docs/marketplace-customer-role-snippet.yaml
@@ -13,14 +13,18 @@ Description: |
 
   The trust policy is the security boundary. The permissions block is
   scoped to exactly what the L2 marketplace template creates: VPC +
-  networking, ECS + Fargate, EFS, ALB, IAM (for the L2's task roles),
-  CloudWatch Logs, and Secrets Manager.
+  networking, ECS-on-EC2 (EC2 launch type — a single EC2 container
+  host, no Fargate), a persistent EBS data volume + DLM snapshot
+  policy, ALB, IAM (the L2's task/instance/dlm roles + instance
+  profile), the public-SSM AMI lookup, CloudWatch Logs, and Secrets
+  Manager.
 
 Parameters:
   ProvisionerExternalId:
     Type: String
     NoEcho: true
     MinLength: 22
+    MaxLength: 1224  # AWS sts:ExternalId hard limit
     Description: >
       Paste the same value you set as "ExternalId" in the sign-up
       wizard. The wizard's Generate UUID button produces a value of
@@ -54,15 +58,26 @@ Resources:
           # the marketplace template creates. We previously enumerated
           # every action, but the enumeration is a maintenance trap —
           # !GetAtt-style resolutions can call non-obvious describe APIs
-          # (e.g. EFS::FileSystem.Arn calls
-          # elasticfilesystem:DescribeFileSystemPolicy, not just
-          # DescribeFileSystems) and every miss is a rollback. The
-          # service prefixes here all correspond to resource types
-          # present in the marketplace template — nothing broader.
+          # (e.g. an ALB's .Arn resolves elasticloadbalancing:Describe* you
+          # didn't list), and every miss is a rollback. The service
+          # prefixes here all correspond to resource types present in the
+          # marketplace template — nothing broader.
           #
-          # IAM is the one exception: scoped to role/8th-layer-l2-* so
-          # the role can ONLY manage roles we explicitly name with this
-          # prefix in the marketplace template.
+          # IAM is the one exception: scoped by NAME PREFIX to
+          # eighth-layer-l2-*. Note the template does NOT set an explicit
+          # RoleName/InstanceProfileName on its IAM resources — CFN
+          # auto-generates physical names as <StackName>-<LogicalId>-<hash>,
+          # and the provisioning service names the stack
+          # `eighth-layer-l2-<slug>` (see _assume_role_session_policy in
+          # 8th-layer-directory). So every auto-generated role/instance-
+          # profile name BEGINS WITH `eighth-layer-l2-`, which is exactly
+          # what this prefix matches. (Checking the template for a literal
+          # RoleName: eighth-layer-l2-* will find none — the match is via
+          # the stack-name prefix, not an explicit name. The directory's
+          # session policy uses the identical scope; both are proven by the
+          # tier-create-and-use live E2E.) If this scope ever stops matching
+          # the auto-generated names, iam:CreateRole is denied and the stack
+          # rolls back.
           # ---------------------------------------------------------------
           PolicyDocument:
             Version: "2012-10-17"
@@ -72,7 +87,6 @@ Resources:
                   - ec2:*
                   - ecs:*
                   - elasticloadbalancing:*
-                  - elasticfilesystem:*
                   - logs:*
                   - secretsmanager:*
                 Resource: "*"
@@ -94,17 +108,16 @@ Resources:
               - Effect: Allow
                 Action: dlm:*
                 Resource: "*"
-              # IAM scoped by name pattern. The marketplace template
-              # explicitly names task roles `eighth-layer-l2-<slug>-*`
-              # (the "eighth-" prefix — CFN logical/stack names must start
-              # with a letter, not "8"). This MUST match the actual role
-              # names or iam:CreateRole is denied and the stack rolls back.
+              # IAM role lifecycle, scoped to the eighth-layer-l2-* name
+              # prefix (see the prefix-matching note above — the names are
+              # CFN-auto-generated from the stack name, not explicit). Note
+              # iam:PassRole is intentionally NOT in this statement; it gets
+              # its own PassedToService-conditioned statement below.
               - Effect: Allow
                 Action:
                   - iam:CreateRole
                   - iam:DeleteRole
                   - iam:GetRole
-                  - iam:PassRole
                   - iam:AttachRolePolicy
                   - iam:DetachRolePolicy
                   - iam:PutRolePolicy
@@ -116,6 +129,28 @@ Resources:
                   - iam:UntagRole
                 Resource:
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/eighth-layer-l2-*"
+              # iam:PassRole, separated so it can carry an
+              # iam:PassedToService guard. Without the condition, CreateRole
+              # + PutRolePolicy + PassRole on the same prefix lets the
+              # provisioner craft and pass an arbitrarily-privileged role to
+              # ANY service principal — a cross-service privilege-escalation
+              # surface on the one role billed as the security boundary. The
+              # three services below are EXACTLY the principals the L2
+              # template's roles trust (TaskRole/TaskExecutionRole ->
+              # ecs-tasks, InstanceRole -> ec2, DlmRole -> dlm), verified
+              # against deploy/aws/marketplace-l2.yaml — so this is tight,
+              # not merely defensive, and cannot deny a legitimate deploy.
+              - Effect: Allow
+                Action:
+                  - iam:PassRole
+                Resource:
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/eighth-layer-l2-*"
+                Condition:
+                  StringEquals:
+                    iam:PassedToService:
+                      - ecs-tasks.amazonaws.com
+                      - ec2.amazonaws.com
+                      - dlm.amazonaws.com
               # The EBS-on-EC2 host attaches its role via an
               # AWS::IAM::InstanceProfile. Instance-profile ARNs are a
               # SEPARATE namespace from role/ — a role-only scope denies

--- a/docs/marketplace-customer-role-snippet.yaml
+++ b/docs/marketplace-customer-role-snippet.yaml
@@ -87,6 +87,13 @@ Resources:
                   - ssm:GetParameter
                   - ssm:GetParameters
                 Resource: "arn:aws:ssm:*::parameter/aws/service/*"
+              # The EBS-on-EC2 template snapshots the L2 data volume via an
+              # AWS::DLM::LifecyclePolicy. dlm:CreateLifecyclePolicy can't be
+              # ARN-scoped at create time, so dlm is granted on "*". Without
+              # it the stack rolls back at the lifecycle-policy resource.
+              - Effect: Allow
+                Action: dlm:*
+                Resource: "*"
               # IAM scoped by name pattern. The marketplace template
               # explicitly names task roles `eighth-layer-l2-<slug>-*`
               # (the "eighth-" prefix — CFN logical/stack names must start
@@ -109,6 +116,23 @@ Resources:
                   - iam:UntagRole
                 Resource:
                   - !Sub "arn:aws:iam::${AWS::AccountId}:role/eighth-layer-l2-*"
+              # The EBS-on-EC2 host attaches its role via an
+              # AWS::IAM::InstanceProfile. Instance-profile ARNs are a
+              # SEPARATE namespace from role/ — a role-only scope denies
+              # CreateInstanceProfile/AddRoleToInstanceProfile on create and
+              # RemoveRoleFromInstanceProfile/DeleteInstanceProfile on
+              # rollback (the latter leaves the stack in ROLLBACK_FAILED).
+              - Effect: Allow
+                Action:
+                  - iam:CreateInstanceProfile
+                  - iam:DeleteInstanceProfile
+                  - iam:GetInstanceProfile
+                  - iam:AddRoleToInstanceProfile
+                  - iam:RemoveRoleFromInstanceProfile
+                  - iam:TagInstanceProfile
+                  - iam:UntagInstanceProfile
+                Resource:
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:instance-profile/eighth-layer-l2-*"
 
 Outputs:
   RoleArn:

--- a/docs/marketplace-customer-role-snippet.yaml
+++ b/docs/marketplace-customer-role-snippet.yaml
@@ -6,7 +6,7 @@ Description: |
   ProvisionerExternalId parameter below MUST match.
 
   The role grants the 8th-Layer.ai provisioning service (running as
-  arn:aws:iam::124074140789:role/cq-directory-TaskRole-bSrWDXFvmr1q)
+  arn:aws:iam::929812812027:role/cq-directory-task-role)
   permission to instantiate a single CloudFormation stack — the L2
   marketplace template — in your account. AssumeRole is gated by the
   ExternalId confused-deputy protection.
@@ -34,13 +34,13 @@ Resources:
       RoleName: 8thLayerL2Provisioner
       Description: |
         8th-Layer.ai marketplace L2 deploy role. Assumed by the 8th-Layer
-        provisioning service (account 124074140789) to stand up your L2.
+        provisioning service (account 929812812027) to stand up your L2.
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
           - Effect: Allow
             Principal:
-              AWS: arn:aws:iam::124074140789:role/cq-directory-TaskRole-bSrWDXFvmr1q
+              AWS: arn:aws:iam::929812812027:role/cq-directory-task-role
             Action: sts:AssumeRole
             Condition:
               StringEquals:
@@ -76,9 +76,22 @@ Resources:
                   - logs:*
                   - secretsmanager:*
                 Resource: "*"
+              # The EBS-on-EC2 L2 template resolves the ECS-optimized AMI
+              # id from AWS's PUBLIC SSM parameter
+              # (/aws/service/ecs/optimized-ami/.../image_id). Without
+              # ssm:GetParameters the CFN deploy rolls back at the EC2
+              # host launch. Scoped to AWS's public service-parameter
+              # namespace (account-less ARN) — never your own SSM params.
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                  - ssm:GetParameters
+                Resource: "arn:aws:ssm:*::parameter/aws/service/*"
               # IAM scoped by name pattern. The marketplace template
-              # explicitly names task roles `8th-layer-l2-<slug>-task*`
-              # so this prefix is sufficient.
+              # explicitly names task roles `eighth-layer-l2-<slug>-*`
+              # (the "eighth-" prefix — CFN logical/stack names must start
+              # with a letter, not "8"). This MUST match the actual role
+              # names or iam:CreateRole is denied and the stack rolls back.
               - Effect: Allow
                 Action:
                   - iam:CreateRole
@@ -95,7 +108,7 @@ Resources:
                   - iam:TagRole
                   - iam:UntagRole
                 Resource:
-                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/8th-layer-l2-*"
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/eighth-layer-l2-*"
 
 Outputs:
   RoleArn:

--- a/sdk/go/remote.go
+++ b/sdk/go/remote.go
@@ -248,10 +248,21 @@ func (r *remoteClient) query(ctx context.Context, params QueryParams) []Knowledg
 		return nil
 	}
 
-	var enveloped struct {
-		Data []KnowledgeUnit `json:"data"`
-	}
-	if err := json.Unmarshal(raw, &enveloped); err == nil && enveloped.Data != nil {
+	// Probe the shape: leading `{` means envelope, leading `[` means bare list.
+	// Doing the probe before Unmarshal avoids the trap where {"data": null}
+	// decodes cleanly into a nil slice and silently masks a server bug.
+	trimmed := bytes.TrimLeft(raw, " \t\r\n")
+	if len(trimmed) > 0 && trimmed[0] == '{' {
+		var enveloped struct {
+			Data []KnowledgeUnit `json:"data"`
+		}
+		if err := json.Unmarshal(raw, &enveloped); err != nil {
+			return nil
+		}
+		// {"data": null} → empty result, not a parse error.
+		if enveloped.Data == nil {
+			return []KnowledgeUnit{}
+		}
 		return enveloped.Data
 	}
 

--- a/sdk/go/remote.go
+++ b/sdk/go/remote.go
@@ -239,8 +239,24 @@ func (r *remoteClient) query(ctx context.Context, params QueryParams) []Knowledg
 		return nil
 	}
 
+	// Backward-compat reader for upstream PR #372: list endpoints may emit
+	// `{data: [...]}` (upstream cli/v0.10.0+) OR a bare array (this fork).
+	// Accept both so the SDK works against either server shape during the
+	// transition window — see #377.
+	raw, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return nil
+	}
+
+	var enveloped struct {
+		Data []KnowledgeUnit `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &enveloped); err == nil && enveloped.Data != nil {
+		return enveloped.Data
+	}
+
 	var units []KnowledgeUnit
-	if err := json.NewDecoder(resp.Body).Decode(&units); err != nil {
+	if err := json.Unmarshal(raw, &units); err != nil {
 		// Query degrades gracefully; log-worthy but not a hard error.
 		return nil
 	}

--- a/sdk/go/remote_test.go
+++ b/sdk/go/remote_test.go
@@ -48,6 +48,23 @@ func TestRemoteQueryAcceptsDataEnvelope(t *testing.T) {
 	require.Equal(t, "ku_00000000000000000000000000000003", units[0].ID)
 }
 
+func TestRemoteQueryAcceptsDataNullEnvelope(t *testing.T) {
+	// {"data": null} envelope means empty result, not silent nil (#377 review).
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data": null}`))
+	}))
+	defer srv.Close()
+
+	rc := newRemoteClient(srv.URL, "", 5*time.Second)
+	units := rc.query(context.Background(), QueryParams{Domains: []string{"api"}})
+	// Should return an empty slice (non-nil) representing "explicit empty result"
+	// — distinguishable from `nil` which signals a transport/parse failure.
+	require.NotNil(t, units)
+	require.Empty(t, units)
+}
+
 func TestRemoteQueryWithAuth(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/sdk/go/remote_test.go
+++ b/sdk/go/remote_test.go
@@ -31,6 +31,23 @@ func TestRemoteQuery(t *testing.T) {
 	require.Equal(t, "S", units[0].Insight.Summary)
 }
 
+func TestRemoteQueryAcceptsDataEnvelope(t *testing.T) {
+	// SDK accepts the upstream `{data: [...]}` envelope shape (#377).
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{testRemoteKUJSON("ku_00000000000000000000000000000003")},
+		})
+	}))
+	defer srv.Close()
+
+	rc := newRemoteClient(srv.URL, "", 5*time.Second)
+	units := rc.query(context.Background(), QueryParams{Domains: []string{"api"}})
+	require.Len(t, units, 1)
+	require.Equal(t, "ku_00000000000000000000000000000003", units[0].ID)
+}
+
 func TestRemoteQueryWithAuth(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/sdk/python/src/cq/client.py
+++ b/sdk/python/src/cq/client.py
@@ -427,7 +427,11 @@ class Client:
         if isinstance(payload, dict) and "data" in payload:
             # Server explicitly returned a `data: null` envelope — treat as
             # empty result rather than raising an opaque iteration error.
-            items = payload["data"] or []
+            # Use `is None` rather than `or []` — the latter would silently
+            # coerce schema-violating falsy values (`{}`, `0`, `""`) into an
+            # empty list instead of letting model_validate raise a catchable
+            # ValidationError that surfaces as a warning to the caller.
+            items = payload["data"] if payload["data"] is not None else []
         else:
             items = payload
         return [KnowledgeUnit.model_validate(item) for item in items]

--- a/sdk/python/src/cq/client.py
+++ b/sdk/python/src/cq/client.py
@@ -424,7 +424,12 @@ class Client:
         # `{data: [...]}` (upstream cli/v0.10.0+) OR a bare array (this fork).
         # Accept both so the SDK works against either server shape during the
         # transition window — see #377.
-        items = payload["data"] if isinstance(payload, dict) and "data" in payload else payload
+        if isinstance(payload, dict) and "data" in payload:
+            # Server explicitly returned a `data: null` envelope — treat as
+            # empty result rather than raising an opaque iteration error.
+            items = payload["data"] or []
+        else:
+            items = payload
         return [KnowledgeUnit.model_validate(item) for item in items]
 
     def _remote_propose(self, unit: KnowledgeUnit) -> KnowledgeUnit:

--- a/sdk/python/src/cq/client.py
+++ b/sdk/python/src/cq/client.py
@@ -419,7 +419,13 @@ class Client:
             params["pattern"] = pattern
         resp = self._http.get("/query", params=params)
         resp.raise_for_status()
-        return [KnowledgeUnit.model_validate(item) for item in resp.json()]
+        payload = resp.json()
+        # Backward-compat reader for upstream PR #372: list endpoints may emit
+        # `{data: [...]}` (upstream cli/v0.10.0+) OR a bare array (this fork).
+        # Accept both so the SDK works against either server shape during the
+        # transition window — see #377.
+        items = payload["data"] if isinstance(payload, dict) and "data" in payload else payload
+        return [KnowledgeUnit.model_validate(item) for item in items]
 
     def _remote_propose(self, unit: KnowledgeUnit) -> KnowledgeUnit:
         """Push a unit to the remote API.

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -370,6 +370,19 @@ class TestRemoteIntegration:
         assert result.units[0].id == "ku_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb02"
         c.close()
 
+    def test_remote_query_accepts_data_null_envelope(self, tmp_path: Path, httpx_mock):
+        """`{data: null}` envelope means empty result, not an error (#377 review)."""
+        httpx_mock.add_response(
+            url=httpx.URL("http://test-remote/query", params={"domains": ["api"], "limit": "5"}),
+            json={"data": None},
+        )
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        result = c.query(["api"])
+        assert result.warnings == [], f"unexpected warnings: {result.warnings}"
+        assert result.source == "remote"
+        assert result.units == []
+        c.close()
+
     def test_remote_query_sends_plural_language_and_framework_params(self, tmp_path: Path, httpx_mock):
         """Remote query sends plural 'languages'/'frameworks' keys, not singular."""
         remote_unit = {

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -344,6 +344,32 @@ class TestRemoteIntegration:
         assert "ku_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa01" in ids
         c.close()
 
+    def test_remote_query_accepts_data_envelope_shape(self, tmp_path: Path, httpx_mock):
+        """SDK accepts the upstream `{data: [...]}` envelope shape (#377)."""
+        remote_unit = {
+            "id": "ku_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb02",
+            "domains": ["api"],
+            "insight": {"summary": "Enveloped", "detail": "D", "action": "A"},
+            "evidence": {
+                "confidence": 0.8,
+                "confirmations": 5,
+                "first_observed": "2025-01-01T00:00:00Z",
+                "last_confirmed": "2025-01-01T00:00:00Z",
+            },
+            "tier": "private",
+        }
+        httpx_mock.add_response(
+            url=httpx.URL("http://test-remote/query", params={"domains": ["api"], "limit": "5"}),
+            json={"data": [remote_unit]},
+        )
+        c = Client(addr="http://test-remote", local_db_path=tmp_path / "test.db")
+        result = c.query(["api"])
+        assert result.warnings == [], f"unexpected warnings: {result.warnings}"
+        assert result.source == "remote"
+        assert len(result.units) == 1
+        assert result.units[0].id == "ku_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb02"
+        c.close()
+
     def test_remote_query_sends_plural_language_and_framework_params(self, tmp_path: Path, httpx_mock):
         """Remote query sends plural 'languages'/'frameworks' keys, not singular."""
         remote_unit = {


### PR DESCRIPTION
Customer deploy-role snippet drifted from the live provisioning path: (1) trust principal still dev/124 — post-Decision-39 must be prod/929; (2) missing ssm:GetParameters for the EBS-on-EC2 AMI lookup; (3) IAM scope 8th-layer-l2-* should be eighth-layer-l2-*. All three silently block real customer onboarding; the 525 test role's admin masked them. Caught by tier-create-and-use E2E (8th-layer-core#130). 🤖 Generated with [Claude Code](https://claude.com/claude-code)