### PR TITLE
fix(invites): pin L2 tenancy on invite-claimed users (#133)

### DIFF
--- a/server/backend/src/cq_server/invites.py
+++ b/server/backend/src/cq_server/invites.py
@@ -437,7 +437,44 @@ async def ensure_user(
     existing = await store.get_user(username)
     if existing is not None:
         return int(existing["id"])
-    await store.create_user(username, hash_password(password), role=role)
+
+    # Tenancy (8th-layer-core#133): pin the L2's CQ_ENTERPRISE/CQ_GROUP
+    # onto the new user row, applying the same "pin only when BOTH set"
+    # rule bootstrap_admin uses (including the partial-config warning).
+    # Without this the invite-claimed admin landed on the schema default
+    # (default-enterprise/default-group). That default row was a latent
+    # split-brain: the WRITE path (`propose` -> `_resolve_write_tenancy`)
+    # rescues a default row by stamping KUs from env, but the REVIEW path
+    # (`approve`/`reject`/queue -> `_admin_scope`) trusts the row verbatim
+    # — so a freshly-provisioned admin could propose a KU (stamped under
+    # the env tenancy) yet get 404 trying to approve it (looked up under
+    # default-*). Pinning the row at creation makes every path agree.
+    # A partial config (one var set, the other not) is a misconfiguration
+    # — fall back to defaults rather than half-wiring, and warn so the
+    # operator notices rather than discovering it via a confused 404.
+    env_ent = os.environ.get("CQ_ENTERPRISE", "").strip()
+    env_grp = os.environ.get("CQ_GROUP", "").strip()
+    if bool(env_ent) != bool(env_grp):
+        log.warning(
+            "[INVITE_CLAIM] only one of CQ_ENTERPRISE/CQ_GROUP is set "
+            "(enterprise=%r group=%r); seeding claimer %r on the default "
+            "tenancy. Set both or neither.",
+            env_ent,
+            env_grp,
+            username,
+        )
+    enterprise_id: str | None = None
+    group_id: str | None = None
+    if env_ent and env_grp:
+        enterprise_id, group_id = env_ent, env_grp
+
+    await store.create_user(
+        username,
+        hash_password(password),
+        role=role,
+        enterprise_id=enterprise_id,
+        group_id=group_id,
+    )
     fresh = await store.get_user(username)
     if fresh is None:  # pragma: no cover — race that breaks the world
         raise RuntimeError("user creation succeeded but lookup returned None")

--- a/server/backend/tests/test_invites.py
+++ b/server/backend/tests/test_invites.py
@@ -576,3 +576,175 @@ class TestOpenAPIVisibility:
         assert "/api/v1/admin/invites/{invite_id}" in paths
         assert "/api/v1/invites/{token}" in paths
         assert "/api/v1/invites/{token}/claim" in paths
+
+
+class TestEnsureUserTenancy:
+    """8th-layer-core#133 — invite-claimed users must inherit the L2's
+    CQ_ENTERPRISE/CQ_GROUP, not land on default-* (which caused approve to
+    404 a KU the same admin had just proposed: the write path env-rescued
+    the default row, the review path trusted it verbatim)."""
+
+    def test_pins_l2_tenancy_when_both_env_set(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import asyncio
+
+        from cq_server.invites import ensure_user
+
+        monkeypatch.setenv("CQ_ENTERPRISE", "acme-corp")
+        monkeypatch.setenv("CQ_GROUP", "engineering")
+        store = _get_store()
+        uid = asyncio.run(
+            ensure_user(
+                store,
+                username="founder@acme",
+                password="password123",
+                email="founder@acme",
+                role="enterprise_admin",
+            )
+        )
+        assert uid > 0
+        row = asyncio.run(store.get_user("founder@acme"))
+        assert row is not None
+        assert row["enterprise_id"] == "acme-corp"
+        assert row["group_id"] == "engineering"
+
+    def test_falls_back_to_default_when_env_partial(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import asyncio
+
+        from cq_server.invites import ensure_user
+
+        # Only one of the two set — a misconfiguration; must NOT half-wire.
+        monkeypatch.setenv("CQ_ENTERPRISE", "acme-corp")
+        monkeypatch.delenv("CQ_GROUP", raising=False)
+        store = _get_store()
+        asyncio.run(
+            ensure_user(
+                store,
+                username="partial@acme",
+                password="password123",
+                email="partial@acme",
+                role="enterprise_admin",
+            )
+        )
+        row = asyncio.run(store.get_user("partial@acme"))
+        assert row is not None
+        # Schema server_default — never the half-wired "acme-corp"/None.
+        assert row["enterprise_id"] == "default-enterprise"
+        assert row["group_id"] == "default-group"
+
+
+class TestProposeApproveTenancyRoundTrip:
+    """8th-layer-core#133 end-to-end. The symptom: a freshly-provisioned
+    admin could propose a KU (201) but got 404 approving it, because the
+    WRITE path (_resolve_write_tenancy) env-stamped the KU while the
+    REVIEW path (_admin_scope) used the user row's default tenancy.
+
+    test_pinned_admin_round_trips proves the fix: an admin created via
+    ensure_user with CQ_ENTERPRISE/CQ_GROUP set round-trips propose ->
+    approve (200, was 404).
+
+    test_default_tenancy_admin_reproduces_404 is the control: the pre-fix
+    shape (admin row left on default tenancy while env is set) still 404s,
+    proving this test is actually sensitive to the regression rather than
+    passing vacuously.
+    """
+
+    @staticmethod
+    def _boot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+        monkeypatch.setenv("CQ_DB_PATH", str(tmp_path / "rt.db"))
+        monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+        monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+        monkeypatch.setenv("CQ_ENTERPRISE", "acme-corp")
+        monkeypatch.setenv("CQ_GROUP", "engineering")
+        # KU must land pending so approve is a real transition (not a no-op).
+        monkeypatch.delenv("CQ_AUTO_APPROVE_PROPOSE", raising=False)
+        return TestClient(app)
+
+    @staticmethod
+    def _login(client: TestClient, username: str, password: str) -> str:
+        r = client.post(
+            "/api/v1/auth/login",
+            json={"username": username, "password": password},
+        )
+        assert r.status_code == 200, r.text
+        return r.json()["token"]
+
+    @staticmethod
+    def _propose(client: TestClient, token: str) -> int:
+        body = {
+            "domains": ["e2e", "tenancy-roundtrip"],
+            "insight": {
+                "summary": "core#133 round-trip: a pinned admin proposes then approves its own KU.",
+                "detail": (
+                    "Proves the write path (_resolve_write_tenancy) and the review "
+                    "path (_admin_scope) resolve the same (enterprise, group) once "
+                    "the claimer's row carries the L2 tenancy."
+                ),
+                "action": "Pin CQ_ENTERPRISE/CQ_GROUP on the user row at claim time.",
+            },
+        }
+        r = client.post(
+            "/api/v1/propose",
+            headers={"Authorization": f"Bearer {token}"},
+            json=body,
+        )
+        assert r.status_code == 201, r.text
+        return r.json()["id"]
+
+    def test_pinned_admin_round_trips(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import asyncio
+
+        from cq_server.app import _get_store
+        from cq_server.invites import ensure_user
+
+        with self._boot(tmp_path, monkeypatch) as client:
+            store = _get_store()
+            # Create the admin through the SAME path the claim flow uses —
+            # this is the function under test. role=enterprise_admin is in
+            # _ADMIN_ROLES so it passes require_admin.
+            asyncio.run(
+                ensure_user(
+                    store,
+                    username="founder@acme",
+                    password="founder-pw-123",  # pragma: allowlist secret
+                    email="founder@acme",
+                    role="enterprise_admin",
+                )
+            )
+            token = self._login(client, "founder@acme", "founder-pw-123")
+            ku_id = self._propose(client, token)
+            approve = client.post(
+                f"/api/v1/review/{ku_id}/approve",
+                headers={"Authorization": f"Bearer {token}"},
+                json={},
+            )
+            # Pre-fix this was 404 "Knowledge unit not found".
+            assert approve.status_code == 200, approve.text
+
+    def test_default_tenancy_admin_reproduces_404(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from cq_server.app import _get_store
+
+        with self._boot(tmp_path, monkeypatch) as client:
+            store = _get_store()
+            # The pre-fix shape: admin row created WITHOUT tenancy (lands on
+            # default-*) even though CQ_ENTERPRISE/CQ_GROUP are set. This is
+            # exactly what ensure_user produced before #133.
+            store.sync.create_user("legacy@acme", hash_password("legacy-pw-123"))
+            store.sync.set_user_role("legacy@acme", "admin")
+            token = self._login(client, "legacy@acme", "legacy-pw-123")
+            # propose still 201 — the write path env-rescues the default row.
+            ku_id = self._propose(client, token)
+            approve = client.post(
+                f"/api/v1/review/{ku_id}/approve",
+                headers={"Authorization": f"Bearer {token}"},
+                json={},
+            )
+            # KU stamped under env tenancy, looked up under default-* -> 404.
+            assert approve.status_code == 404, approve.text


### PR DESCRIPTION
## #133 — invite-claimed admin lands on default tenancy → approve 404s its own KU

Layer 8 of the tier-create-and-use cascade (live-008: provision COMPLETE → claim 200 → propose **201** → approve **404** → query 0).

### Root cause — write/read tenancy split-brain
`invites.ensure_user` created the admin with no enterprise_id/group_id → default-enterprise/default-group. The WRITE path (`propose`→`_resolve_write_tenancy`, agent#324) env-rescues a default row by stamping KUs from CQ_ENTERPRISE/CQ_GROUP; the REVIEW path (`approve`→`_admin_scope`→`scope_filter`) trusts the row verbatim. KU written under env tenancy, looked up under default-* → 404.

### Fix
Pin CQ_ENTERPRISE/CQ_GROUP onto the user row at creation, applying bootstrap_admin's 'pin only when BOTH set' rule **and** its partial-config warning. Row becomes non-default → both paths agree.

### Tests — `test_invites.py`, 25 pass
- `TestEnsureUserTenancy` — both-env pins; partial-env → defaults.
- `TestProposeApproveTenancyRoundTrip` — **end-to-end HTTP**: pinned admin round-trips propose(201)→approve(200); a **control** with a default-tenancy admin reproduces the 404, proving the test is sensitive to the regression.

### 8l-reviewer findings — addressed
- **BLOCKER (PR scope)**: rebased onto origin/main — now exactly 2 files (the branch had inherited unsquashed SDK/snippet commits from a stale local main). Compare API: ahead 1, 2 files.
- **HIGH (warning/comment parity)**: added the `[INVITE_CLAIM]` partial-config warning + corrected the comment.
- **HIGH (no e2e test)**: added the propose→approve round-trip + sensitivity control above.
- **HIGH (live-L2 migration)**: NOT healed by this PR — `ensure_user` returns existing rows untouched. eng/sga/Carmen/dogfood admins were created pre-fix and need an **operator-gated** backfill (eng/sga hold real KU data — must not auto-touch). Tracked in #133.
- **MEDIUM (env-at-claim, target_l2_id assertion)**: follow-ups in #133.

### Deploy/verify
Build + push the cq-server marketplace image → re-run tier-create-and-use (live-009). Fresh L2s pick up the fix; expect the full chain green incl. causal-identity.