### PR TITLE
feat(tenancy): central resolve_tenancy() + migrate 3 write paths (#339 slice 1, closes #335)

### DIFF
--- a/server/backend/src/cq_server/activity_logger.py
+++ b/server/backend/src/cq_server/activity_logger.py
@@ -32,8 +32,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from . import aigrp
 from .activity import EVENT_TYPES, generate_activity_id, now_iso_z
+from .tenancy import resolve_tenancy
 
 if TYPE_CHECKING:
     from .store._sqlite import SqliteStore
@@ -98,29 +98,25 @@ async def log_activity(
         tenant_enterprise: str
         tenant_group: str | None
         persona: str | None
+        # agent#335 — resolve tenancy through the single resolver (agent#339)
+        # so a default-* user row on a CONFIGURED L2 stamps the env tenancy
+        # instead of the literal "default-enterprise". The old code did
+        # ``user.get("enterprise_id") or aigrp.enterprise()`` — but a
+        # "default-enterprise" row value is TRUTHY, so the ``or`` never
+        # consulted env and the audit row drifted to default-* even though
+        # the KU row (which already used the resolver) was stamped correctly.
         if username is None:
-            tenant_enterprise = aigrp.enterprise()
-            tenant_group = aigrp.group()
-            persona = None
+            ent, grp, _ = resolve_tenancy(None, context="activity_log")
+            tenant_enterprise, tenant_group, persona = ent, grp, None
         else:
+            # ``user`` may be None (deletion race between auth and this
+            # background task) — resolve_tenancy(None) then falls to env,
+            # same as the system-event path. ``persona`` is still the
+            # username the auth layer accepted.
             user = await store.get_user(username)
-            if user is None:
-                # The user row vanished between the auth check and the
-                # background-task run (deletion race). Fall back to
-                # this L2's own identity so the event is still
-                # recorded; persona is the username string the auth
-                # layer accepted.
-                tenant_enterprise = aigrp.enterprise()
-                tenant_group = aigrp.group()
-                persona = username
-            else:
-                tenant_enterprise = str(user.get("enterprise_id") or aigrp.enterprise())
-                # ``group_id`` is column-NOT-NULL on the users table per
-                # migration 0001_phase6_step1, but defensive cast keeps
-                # the helper safe if a future schema makes it nullable.
-                grp = user.get("group_id")
-                tenant_group = str(grp) if grp is not None else None
-                persona = username
+            ent, grp, _ = resolve_tenancy(user, context="activity_log")
+            tenant_enterprise, tenant_group = ent, grp
+            persona = username
 
         await store.append_activity(
             activity_id=generate_activity_id(),

--- a/server/backend/src/cq_server/agent_key_routes.py
+++ b/server/backend/src/cq_server/agent_key_routes.py
@@ -36,7 +36,7 @@ from .api_keys import encode_token, generate_secret, hash_secret, secret_prefix
 from .auth import ApiKeyPublic, _to_public, hash_password, require_admin
 from .deps import get_api_key_pepper, get_store
 from .store._sqlite import SqliteStore
-from .tables import DEFAULT_ENTERPRISE_ID, DEFAULT_GROUP_ID
+from .tenancy import resolve_tenancy
 from .ttl import parse_ttl
 
 log = logging.getLogger(__name__)
@@ -143,8 +143,11 @@ async def _resolve_admin_tenancy(store: SqliteStore, admin: str) -> tuple[str, s
     convention the rest of cq-server uses (see ``auth.scope_filter``).
     """
     admin_user = await store.get_user(admin)
-    enterprise_id = (admin_user or {}).get("enterprise_id") or DEFAULT_ENTERPRISE_ID
-    group_id = (admin_user or {}).get("group_id") or DEFAULT_GROUP_ID
+    # agent#339 — resolve through the single resolver so a minted agent
+    # inherits the L2's env tenancy even when the admin row carries the
+    # schema defaults (the #324/#333 class). A bare ``row or DEFAULT`` here
+    # would land the agent on default-* on a configured L2, the same bug.
+    enterprise_id, group_id, _ = resolve_tenancy(admin_user, context="agent_key_mint")
     return enterprise_id, group_id
 
 

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -52,7 +52,7 @@ from .review import router as review_router
 from .scoring import apply_confirmation, apply_flag
 from .store import normalize_domains
 from .store._sqlite import SqliteStore
-from .tables import DEFAULT_ENTERPRISE_ID, DEFAULT_GROUP_ID
+from .tenancy import resolve_tenancy
 from .theme_routes import router as theme_router
 from .tour_routes import router as tour_router
 from .transactional import transactional_router
@@ -1839,38 +1839,27 @@ def _resolve_write_tenancy(user: dict) -> tuple[str, str]:
     is missing the tenancy columns entirely (empty strings) — the
     legacy 500 branch in ``propose_unit`` still catches that.
     """
-    row_ent = (user.get("enterprise_id") or "").strip()
-    row_grp = (user.get("group_id") or "").strip()
-    # Treat the row as authoritative unless it carries the
-    # schema-level defaults — in which case the env is the
-    # tie-breaker so a configured L2 never silently writes into
-    # default-*.
-    row_is_default = row_ent in ("", DEFAULT_ENTERPRISE_ID) and row_grp in ("", DEFAULT_GROUP_ID)
-    if not row_is_default and row_ent and row_grp:
-        return row_ent, row_grp
-
-    env_ent = os.environ.get("CQ_ENTERPRISE", "").strip()
-    env_grp = os.environ.get("CQ_GROUP", "").strip()
-    if env_ent and env_grp:
-        return env_ent, env_grp
-
-    # Row is default and env is unset (or partial). On an
-    # unconfigured-but-functional dev L2 the row will carry the
-    # defaults non-empty — fall back to those rather than 400, so the
-    # local-dev workflow keeps working.
-    if row_ent and row_grp:
-        return row_ent, row_grp
-
-    raise HTTPException(
-        status_code=400,
-        detail=(
-            "L2 tenancy not configured: the authenticated user has no "
-            "enterprise/group tenancy on its row and CQ_ENTERPRISE / "
-            "CQ_GROUP are not set on this L2. Set both env vars on the "
-            "task definition and restart, or remint the agent key on a "
-            "configured-tenancy admin."
-        ),
-    )
+    # Delegate to the single resolver (agent#339). /propose is a STRICT
+    # caller: it rejects when resolution falls all the way to "default" AND
+    # the row carried no tenancy at all (the truly-unconfigured case) — a
+    # silent default-* KU write is the exact bug this guards. A fully
+    # default-but-populated row (unconfigured dev L2) keeps working.
+    ent, grp, source = resolve_tenancy(user, context="propose")
+    if source == "default":
+        row_ent = (user.get("enterprise_id") or "").strip()
+        row_grp = (user.get("group_id") or "").strip()
+        if not (row_ent and row_grp):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "L2 tenancy not configured: the authenticated user has no "
+                    "enterprise/group tenancy on its row and CQ_ENTERPRISE / "
+                    "CQ_GROUP are not set on this L2. Set both env vars on the "
+                    "task definition and restart, or remint the agent key on a "
+                    "configured-tenancy admin."
+                ),
+            )
+    return ent, grp
 
 
 @api_router.post("/propose", status_code=201)

--- a/server/backend/src/cq_server/tenancy.py
+++ b/server/backend/src/cq_server/tenancy.py
@@ -60,7 +60,8 @@ def resolve_tenancy(
     SCOPE: routing a write through this function eliminates the silent-default
     class FOR THAT path. As of #339 slice 1 the migrated paths are: KU propose
     (``_resolve_write_tenancy``), agent-key mint (``_resolve_admin_tenancy``),
-    and activity-log (``log_activity``). Still carrying ad-hoc default literals
+    and activity-log (``log_activity`` — see the #335 fix narrative in
+    ``activity_logger.py``'s tenancy block). Still carrying ad-hoc default literals
     and tracked for migration (#339):
       * ``consults._self_identity`` — WRITE-ADJACENT (stamps the ``from_l2_id``
         on outbound consult envelopes); migrate together with the

--- a/server/backend/src/cq_server/tenancy.py
+++ b/server/backend/src/cq_server/tenancy.py
@@ -49,21 +49,42 @@ def resolve_tenancy(
                          or the schema constants when the row is empty too.
 
     Runtime guard (agent#339): a *fully* configured L2 (both env vars set)
-    can NEVER resolve to ``default-*`` here — branch 2 returns env first. The
-    only way ``source == "default"`` arises with env present is a PARTIAL env
-    (one var set, the other not), which is a misconfiguration we warn on
-    loudly. Routing every write through this function therefore eliminates
-    the silent-default class; strict callers additionally reject ``source ==
-    "default"`` so a misconfigured L2 fails loud instead of mis-attributing.
+    can NEVER resolve to ``default-*`` here — neither in ``source`` NOR in the
+    returned value, because a real-or-partial-default row falls through to the
+    env branch (see the per-field real check above). The only way
+    ``source == "default"`` arises with env present is a PARTIAL env (one var
+    set, the other not), a misconfiguration we warn on loudly. Strict callers
+    additionally reject ``source == "default"`` so a misconfigured L2 fails
+    loud instead of mis-attributing.
+
+    SCOPE: routing a write through this function eliminates the silent-default
+    class FOR THAT path. As of #339 slice 1 the migrated paths are: KU propose
+    (``_resolve_write_tenancy``), agent-key mint (``_resolve_admin_tenancy``),
+    and activity-log (``log_activity``). Still carrying ad-hoc default literals
+    and tracked for migration (#339):
+      * ``consults._self_identity`` — WRITE-ADJACENT (stamps the ``from_l2_id``
+        on outbound consult envelopes); migrate together with the
+        cross-Enterprise gate at consults.py's ``self_enterprise`` compare so
+        the two stay consistent (gating is security-sensitive — do them as one
+        change, not piecemeal).
+      * cross-enterprise consents, raw api_keys, and the ``auth.scope_filter``
+        read-path.
 
     Never raises — see module docstring.
     """
     row_ent = ((user or {}).get("enterprise_id") or "").strip()
     row_grp = ((user or {}).get("group_id") or "").strip()
-    row_is_default = (
-        row_ent in ("", DEFAULT_ENTERPRISE_ID) and row_grp in ("", DEFAULT_GROUP_ID)
-    )
-    if not row_is_default and row_ent and row_grp:
+    # Per-field real check (8l-reviewer HIGH on PR #390): the row is
+    # authoritative only when BOTH fields carry a real (non-empty,
+    # non-default) value. A PARTIAL-default row — e.g. enterprise_id="acme",
+    # group_id="default-group" (bootstrap_admin.py's independent per-column
+    # `or "default-…"` fallbacks can produce these) — must NOT be returned
+    # as "row", or a configured L2 would write the literal "default-group"
+    # value (source="row" hides it) — the exact #324/#333/#335 leak with a
+    # half-default row. Such rows fall through to env below.
+    row_ent_real = bool(row_ent) and row_ent != DEFAULT_ENTERPRISE_ID
+    row_grp_real = bool(row_grp) and row_grp != DEFAULT_GROUP_ID
+    if row_ent_real and row_grp_real:
         return row_ent, row_grp, "row"
 
     env_ent = os.environ.get("CQ_ENTERPRISE", "").strip()

--- a/server/backend/src/cq_server/tenancy.py
+++ b/server/backend/src/cq_server/tenancy.py
@@ -1,0 +1,88 @@
+"""Single source of truth for write-path tenancy resolution (agent#339).
+
+Three bugs of one shape kept surfacing — a write path that doesn't consult
+the L2's configured ``CQ_ENTERPRISE`` / ``CQ_GROUP`` env when the caller row
+carries no real tenancy, so it silently writes ``default-enterprise`` /
+``default-group`` on a *configured* L2:
+
+  * #324 (fixed) — ``/propose`` stamped KU rows default-*.
+  * #333 (fixed via #384) — invite-claim ``ensure_user`` stamped admin users default-*.
+  * #335 — ``activity_log`` rows stamped ``tenant_enterprise=default-enterprise``.
+
+Every write that needs an ``(enterprise_id, group_id)`` should resolve it
+HERE so the bug class can't re-emerge as new writers are added. Callers that
+must be strict (e.g. ``/propose``) inspect the returned ``source`` and reject
+on ``"default"``; best-effort callers (e.g. activity logging) just use the
+resolved values — this function NEVER raises.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from .tables import DEFAULT_ENTERPRISE_ID, DEFAULT_GROUP_ID
+
+log = logging.getLogger(__name__)
+
+# What ``source`` the resolution came from — lets strict callers branch.
+TenancySource = str  # "row" | "env" | "default"
+
+
+def resolve_tenancy(
+    user: dict | None,
+    *,
+    context: str = "",
+) -> tuple[str, str, TenancySource]:
+    """Resolve ``(enterprise_id, group_id, source)`` for a write.
+
+    Priority:
+      1. ``"row"``     — the caller's row tenancy when it is non-default and
+                         fully populated (the common case: a principal minted
+                         on a configured L2 inherited that L2's tenancy).
+      2. ``"env"``     — ``CQ_ENTERPRISE`` + ``CQ_GROUP`` when BOTH are set
+                         (the configured L2's own identity). This is what
+                         rescues a default-* row on a configured L2 — the
+                         exact #324/#333/#335 bug.
+      3. ``"default"`` — neither row nor env carry real tenancy: a fully
+                         default-but-populated row (an unconfigured dev L2),
+                         or the schema constants when the row is empty too.
+
+    Runtime guard (agent#339): a *fully* configured L2 (both env vars set)
+    can NEVER resolve to ``default-*`` here — branch 2 returns env first. The
+    only way ``source == "default"`` arises with env present is a PARTIAL env
+    (one var set, the other not), which is a misconfiguration we warn on
+    loudly. Routing every write through this function therefore eliminates
+    the silent-default class; strict callers additionally reject ``source ==
+    "default"`` so a misconfigured L2 fails loud instead of mis-attributing.
+
+    Never raises — see module docstring.
+    """
+    row_ent = ((user or {}).get("enterprise_id") or "").strip()
+    row_grp = ((user or {}).get("group_id") or "").strip()
+    row_is_default = (
+        row_ent in ("", DEFAULT_ENTERPRISE_ID) and row_grp in ("", DEFAULT_GROUP_ID)
+    )
+    if not row_is_default and row_ent and row_grp:
+        return row_ent, row_grp, "row"
+
+    env_ent = os.environ.get("CQ_ENTERPRISE", "").strip()
+    env_grp = os.environ.get("CQ_GROUP", "").strip()
+    if env_ent and env_grp:
+        return env_ent, env_grp, "env"
+    if bool(env_ent) != bool(env_grp):
+        # Partial config is the dangerous case — a configured-looking L2 that
+        # silently defaults. Warn loudly (agent#339 "log loudly").
+        log.warning(
+            "resolve_tenancy[%s]: partial env (CQ_ENTERPRISE=%r CQ_GROUP=%r) — "
+            "falling back to default tenancy. Set BOTH or NEITHER.",
+            context,
+            env_ent,
+            env_grp,
+        )
+
+    # Unconfigured dev L2: the row carries the non-empty schema defaults and
+    # the operator opted into that by not setting env. Keep local dev working.
+    if row_ent and row_grp:
+        return row_ent, row_grp, "default"
+    return DEFAULT_ENTERPRISE_ID, DEFAULT_GROUP_ID, "default"

--- a/server/backend/tests/test_activity_log_instrumentation.py
+++ b/server/backend/tests/test_activity_log_instrumentation.py
@@ -367,3 +367,47 @@ class TestActivityLogFailureNeverBreaksResponse:
             assert all(r["event_type"] != "propose" for r in rows)
         finally:
             monkeypatch.setattr(store, "append_activity", original)
+
+
+# ---------------------------------------------------------------------------
+# agent#335 — activity_log tenancy must follow the configured-L2 env, not a
+# default-* user row (the bug: a "default-enterprise" row value is truthy, so
+# `user.get("enterprise_id") or aigrp.enterprise()` never consulted env).
+# ---------------------------------------------------------------------------
+
+
+def test_activity_log_uses_env_tenancy_for_default_row_user(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from cq_server.tables import DEFAULT_ENTERPRISE_ID, DEFAULT_GROUP_ID
+
+    db_path = tmp_path / "activity_env.db"
+    monkeypatch.setenv("CQ_DB_PATH", str(db_path))
+    monkeypatch.setenv("CQ_JWT_SECRET", "test-secret-thirty-two-chars-min!")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", "test-pepper")
+    # Configured L2 — but the user row carries the schema defaults (the
+    # #324/#333 pre-pin shape). Pre-fix the audit row drifted to default-*.
+    monkeypatch.setenv("CQ_ENTERPRISE", "s3-dirk")
+    monkeypatch.setenv("CQ_GROUP", "default")
+
+    with TestClient(app) as client:
+        _seed_user(
+            username="dirk@s3",
+            password="password123",  # pragma: allowlist secret
+            enterprise_id=DEFAULT_ENTERPRISE_ID,
+            group_id=DEFAULT_GROUP_ID,
+        )
+        jwt = _login_jwt(client, "dirk@s3", "password123")
+        api_key = _mint_api_key(client, jwt)
+        _propose_one(client, api_key)
+
+    rows = _activity_rows(db_path)
+    propose_rows = [r for r in rows if r["event_type"] == "propose"]
+    assert propose_rows, f"no propose activity row; saw {[r['event_type'] for r in rows]}"
+    row = propose_rows[0]
+    # The fix: env tenancy, NOT the literal default the row carried.
+    assert row["tenant_enterprise"] == "s3-dirk", (
+        f"activity_log tenant_enterprise={row['tenant_enterprise']!r} — expected the "
+        f"configured env 's3-dirk', not the default-* row value (agent#335 regression)"
+    )
+    assert row["tenant_enterprise"] != DEFAULT_ENTERPRISE_ID

--- a/server/backend/tests/test_tenancy.py
+++ b/server/backend/tests/test_tenancy.py
@@ -73,11 +73,40 @@ def test_partial_env_warns_and_defaults(
     assert any("partial env" in r.message for r in caplog.records)
 
 
-def test_configured_l2_can_never_resolve_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    # The agent#339 invariant: with BOTH env vars set, no input resolves to
-    # source 'default' — so a fully-configured L2 can't silently default.
+def test_partial_default_row_falls_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # 8l-reviewer HIGH (PR #390): a row with ONE real field + ONE default
+    # field must NOT be returned as "row" on a configured L2 — env wins, so
+    # the literal "default-group" never reaches the write.
     monkeypatch.setenv("CQ_ENTERPRISE", "acme")
     monkeypatch.setenv("CQ_GROUP", "eng")
-    for user in (None, {}, {"enterprise_id": DEFAULT_ENTERPRISE_ID, "group_id": DEFAULT_GROUP_ID}, {"enterprise_id": "", "group_id": ""}):
-        _, _, source = resolve_tenancy(user)
+    for partial in (
+        {"enterprise_id": "acme", "group_id": DEFAULT_GROUP_ID},
+        {"enterprise_id": DEFAULT_ENTERPRISE_ID, "group_id": "eng"},
+    ):
+        ent, grp, source = resolve_tenancy(partial)
+        assert (ent, grp, source) == ("acme", "eng", "env"), (
+            f"partial-default row {partial!r} leaked a default value: {(ent, grp, source)!r}"
+        )
+
+
+def test_configured_l2_can_never_resolve_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The agent#339 invariant: with BOTH env vars set, no input resolves to
+    # source 'default' AND no returned value is default-* — so a fully-
+    # configured L2 can't silently default. Includes the partial-default rows
+    # that triggered the reviewer HIGH.
+    monkeypatch.setenv("CQ_ENTERPRISE", "acme")
+    monkeypatch.setenv("CQ_GROUP", "eng")
+    inputs = (
+        None,
+        {},
+        {"enterprise_id": DEFAULT_ENTERPRISE_ID, "group_id": DEFAULT_GROUP_ID},
+        {"enterprise_id": "", "group_id": ""},
+        {"enterprise_id": "acme", "group_id": DEFAULT_GROUP_ID},
+        {"enterprise_id": DEFAULT_ENTERPRISE_ID, "group_id": "eng"},
+    )
+    for user in inputs:
+        ent, grp, source = resolve_tenancy(user)
         assert source != "default", f"configured L2 defaulted for user={user!r}"
+        assert ent != DEFAULT_ENTERPRISE_ID and grp != DEFAULT_GROUP_ID, (
+            f"configured L2 returned a default VALUE for user={user!r}: {(ent, grp)!r}"
+        )

--- a/server/backend/tests/test_tenancy.py
+++ b/server/backend/tests/test_tenancy.py
@@ -1,0 +1,83 @@
+"""Unit tests for the central write-path tenancy resolver (agent#339)."""
+
+from __future__ import annotations
+
+import pytest
+
+from cq_server.tables import DEFAULT_ENTERPRISE_ID, DEFAULT_GROUP_ID
+from cq_server.tenancy import resolve_tenancy
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CQ_ENTERPRISE", raising=False)
+    monkeypatch.delenv("CQ_GROUP", raising=False)
+
+
+def test_nondefault_row_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Even with env set, a real row tenancy is authoritative.
+    monkeypatch.setenv("CQ_ENTERPRISE", "env-ent")
+    monkeypatch.setenv("CQ_GROUP", "env-grp")
+    ent, grp, source = resolve_tenancy({"enterprise_id": "acme", "group_id": "eng"})
+    assert (ent, grp, source) == ("acme", "eng", "row")
+
+
+def test_default_row_falls_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The #324/#333/#335 bug case: a default-* row on a CONFIGURED L2 must
+    # resolve to env, not the literal defaults.
+    monkeypatch.setenv("CQ_ENTERPRISE", "acme")
+    monkeypatch.setenv("CQ_GROUP", "eng")
+    ent, grp, source = resolve_tenancy(
+        {"enterprise_id": DEFAULT_ENTERPRISE_ID, "group_id": DEFAULT_GROUP_ID}
+    )
+    assert (ent, grp, source) == ("acme", "eng", "env")
+
+
+def test_none_user_falls_to_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # System events / vanished-user race resolve to the L2's env identity.
+    monkeypatch.setenv("CQ_ENTERPRISE", "acme")
+    monkeypatch.setenv("CQ_GROUP", "eng")
+    assert resolve_tenancy(None) == ("acme", "eng", "env")
+
+
+def test_empty_row_no_env_returns_default_constants() -> None:
+    # Truly unconfigured: empty row + no env → schema constants, source default.
+    assert resolve_tenancy({"enterprise_id": "", "group_id": ""}) == (
+        DEFAULT_ENTERPRISE_ID,
+        DEFAULT_GROUP_ID,
+        "default",
+    )
+
+
+def test_default_row_no_env_is_dev_default() -> None:
+    # Unconfigured dev L2: row carries the non-empty defaults, no env →
+    # keep working on defaults (source default so strict callers can 400).
+    ent, grp, source = resolve_tenancy(
+        {"enterprise_id": DEFAULT_ENTERPRISE_ID, "group_id": DEFAULT_GROUP_ID}
+    )
+    assert (ent, grp, source) == (DEFAULT_ENTERPRISE_ID, DEFAULT_GROUP_ID, "default")
+
+
+def test_partial_env_warns_and_defaults(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # One env var set is a misconfiguration — must NOT half-wire; warns loud.
+    monkeypatch.setenv("CQ_ENTERPRISE", "acme")  # CQ_GROUP unset
+    with caplog.at_level("WARNING"):
+        ent, grp, source = resolve_tenancy(
+            {"enterprise_id": DEFAULT_ENTERPRISE_ID, "group_id": DEFAULT_GROUP_ID},
+            context="unit",
+        )
+    assert source == "default"
+    assert (ent, grp) == (DEFAULT_ENTERPRISE_ID, DEFAULT_GROUP_ID)
+    assert any("partial env" in r.message for r in caplog.records)
+
+
+def test_configured_l2_can_never_resolve_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The agent#339 invariant: with BOTH env vars set, no input resolves to
+    # source 'default' — so a fully-configured L2 can't silently default.
+    monkeypatch.setenv("CQ_ENTERPRISE", "acme")
+    monkeypatch.setenv("CQ_GROUP", "eng")
+    for user in (None, {}, {"enterprise_id": DEFAULT_ENTERPRISE_ID, "group_id": DEFAULT_GROUP_ID}, {"enterprise_id": "", "group_id": ""}):
+        _, _, source = resolve_tenancy(user)
+        assert source != "default", f"configured L2 defaulted for user={user!r}"


### PR DESCRIPTION
agent#339 slice 1 — the single tenancy resolver + the 3 core write paths routed through it. Closes #335 (activity_log default-* attribution); lays the foundation #339 tracks.

New `tenancy.resolve_tenancy(user|None) -> (ent, grp, source)`: row(non-default)→env(both set)→default; never raises; strict callers reject source='default'. Invariant: a fully-configured L2 can never resolve to default (eliminates the silent-default class). Partial env warns loud.

Migrated: `/propose` (`_resolve_write_tenancy`, behavior-preserving + keeps its 400), `activity_logger.log_activity` (**closes #335** — the truthy-default-string bug), `agent_key_routes._resolve_admin_tenancy` (agent inherits env tenancy).

Tests: 7 resolver units (incl. configured-L2-never-defaults + partial-env warn) + activity_log #335 regression. 47 green across tenancy/activity/propose/agent-key/isolation suites.

**Scope:** slice 1. Remaining write paths (consults, peer routes, consents, raw api_keys, auth.scope_filter read-path) still carry ad-hoc default literals — migrate next; #339 stays open for them. **Does NOT include the eng/sga live-row backfill** (operator-gated, real KU data — agent#385/core#133).

Deploy: CodeBuild builds the cq-server image; fresh provisions pick it up via the marketplace template tag bump (separate step).