### PR TITLE
chore(marketplace): bump CqServerImage default to git-b6d4c8747790 (#339 slice 1)

### DIFF
--- a/deploy/aws/marketplace-l2.yaml
+++ b/deploy/aws/marketplace-l2.yaml
@@ -138,7 +138,7 @@ Parameters:
 
   CqServerImage:
     Type: String
-    Default: public.ecr.aws/w2i0e4m6/cq-server:git-e9a0fe3ed2c3
+    Default: public.ecr.aws/w2i0e4m6/cq-server:git-b6d4c8747790
     Description: |
       cq-server image tag the L2 will run. Default points at the public
       ECR mirror of OneZero1ai/8th-layer-agent main, pinned to a known-


### PR DESCRIPTION
Template release-tag bump: CqServerImage -> git-b6d4c8747790 (the build with #339 slice-1 tenancy fixes). Already validated + published to the prod 929 provisioning bucket; this commit keeps repo↔S3 in sync. Existing L2s pick it up on next redeploy (operator-gated).