### PR TITLE
Land cold→Quick + signup-audit fixes + Decision-43 A1 onto main (11 commits)

### DIFF
--- a/MODIFICATIONS.md
+++ b/MODIFICATIONS.md
@@ -8,71 +8,220 @@ For project-level rationale and the upstream-vs-fork delta narrative, see
 [`FORK_DELTA.md`](FORK_DELTA.md). For per-PR detail, see this repository's
 [git log](https://github.com/OneZero1ai/8th-layer-agent/commits/main).
 
+_Generated 2026-06-01 from `git ls-files server/backend/src/cq_server/ server/backend/tests/`
+classified against upstream `563d0e93cf4676bdf64c21a55ad5e54c94d6d0ca`._
+
 ## Fork base
 
 - Forked from `mozilla-ai/cq` on **2026-04-26**.
-- The exact upstream commit pinned at fork creation is recorded in
-  [`FORK_DELTA.md`](FORK_DELTA.md).
+- Upstream commit pinned at fork creation: **`563d0e93cf4676bdf64c21a55ad5e54c94d6d0ca`**
+  (`server: add SQLAlchemy + Alembic dependencies and skeleton`, #321).
+- Recorded in [`FORK_DELTA.md`](FORK_DELTA.md) sync discipline; derived from
+  the parent of the first fork-marker commit (`21af2bc`).
 
 ## Apache-2.0 §4(b) compliance posture
 
 Apache-2.0 §4(b) requires that "any modified files" carry "prominent notices
 stating that You changed the files." This document is the prominent notice
-covering all modified files in this repository. We do not maintain per-file
-modification headers; this manifest is exhaustive and is updated whenever a
-file's status changes.
+covering all tracked source files under `server/backend/src/cq_server/` and
+`server/backend/tests/`. We do not maintain per-file modification headers;
+this manifest is exhaustive for those paths and is updated whenever a file's
+status changes. Other fork changes (plugins, deploy templates, docs) are
+described in [`FORK_DELTA.md`](FORK_DELTA.md).
+
+**Coverage:** 150 files — 127 new, 15 modified,
+8 unchanged from fork base.
 
 ## New files (entirely OneZero1.ai)
 
-These files do not exist in upstream `mozilla-ai/cq` and are wholly authored
-by OneZero1.ai:
+These files do not exist in upstream at the fork-base commit and are wholly
+authored by OneZero1.ai:
 
 | File | Purpose |
 |---|---|
-| `server/backend/src/cq_server/aigrp.py` | AIGRP (Agent Intelligence Graph Routing Protocol) — intra-Enterprise peer-mesh routing |
-| `server/backend/src/cq_server/network.py` | DSN (Distributed Semantic Network) intent resolution + topology |
-| `server/backend/src/cq_server/consults.py` | L3 live consults — same-L2 + cross-L2 routing |
-| `server/backend/src/cq_server/directory_client.py` | Sprint 3 client for the public 8th-Layer Directory |
-| `server/backend/src/cq_server/quality.py` | Propose-quality guards (candidate to upstream) |
-| `server/backend/src/cq_server/embed.py` | Bedrock Titan v2 embeddings (8th-Layer-specific embedding setup) |
-| `server/backend/src/cq_server/tables.py` | Multi-tenant + AIGRP schema additions |
-| `server/backend/tests/test_aigrp_*.py` | AIGRP test suites |
-| `server/backend/tests/test_network_*.py` | DSN test suites |
-| `server/backend/tests/test_consults.py`, `test_cross_l2_routing.py`, `test_forward_query.py` | Consults + forward-query tests |
-| `server/backend/tests/test_directory_client.py` | Directory client tests |
-| `server/local-demo/**` | Local Docker mesh demo |
-| `FORK_DELTA.md`, `MODIFICATIONS.md`, `NOTICE` | This fork's documentation |
+| `server/backend/src/cq_server/activity.py` | Activity log of record — shared module for #108 Stage 1 substrate. |
+| `server/backend/src/cq_server/activity_logger.py` | Non-blocking activity-log writer for #108 Stage 2 instrumentation. |
+| `server/backend/src/cq_server/activity_routes.py` | Activity-log read endpoint (#108 Stage 2 — Workstream D). |
+| `server/backend/src/cq_server/admin_routes.py` | Admin routes — xgroup_consent propose/cosign/ratify/revoke (Phase 1.0b). |
+| `server/backend/src/cq_server/agent_key_routes.py` | FO-4: Self-service Add Agent — admin routes for minting agent keys. |
+| `server/backend/src/cq_server/aigrp/__init__.py` | AIGRP package. |
+| `server/backend/src/cq_server/aigrp/_legacy.py` | AIGRP — peer-to-peer mesh inside an Enterprise (EIGRP-shaped). |
+| `server/backend/src/cq_server/aigrp/enterprise_root.py` | Enterprise AIGRP root: SSM-backed, CMK-encrypted, in-process cached. |
+| `server/backend/src/cq_server/aigrp/envelope.py` | AIGRP message envelope: HMAC-SHA256 sign + verify with replay protection. |
+| `server/backend/src/cq_server/aigrp/federation.py` | Cross-L2 AIGRP federation — outbound forward-query client (agent#316). |
+| `server/backend/src/cq_server/aigrp/pair_secret.py` | Per-pair AIGRP secret derivation (Decision 28 §1.1). |
+| `server/backend/src/cq_server/aigrp/runtime.py` | AIGRP runtime wiring — bridges enterprise_root + pair_secret into HTTP auth. |
+| `server/backend/src/cq_server/aigrp_directory_peer_routes.py` | Admin route — manual cross-Enterprise directory-peering announce (agent#347). |
+| `server/backend/src/cq_server/aigrp_peer_routes.py` | Admin route — manual AIGRP peer announcement (agent#337). |
+| `server/backend/src/cq_server/bootstrap_admin.py` | First-admin bootstrap for fresh-from-marketplace L2s (P2.5, task #218). |
+| `server/backend/src/cq_server/claim_page.py` | Server-rendered HTML claim page for invite acceptance (FO-1c, #191). |
+| `server/backend/src/cq_server/consults.py` | L3 consults — agent-to-agent live consult endpoints. |
+| `server/backend/src/cq_server/crosstalk_routes.py` | Crosstalk endpoints (#124) — L2-mediated inter-session messaging. |
+| `server/backend/src/cq_server/crypto.py` | Shared Ed25519 + RFC 8785 primitives. |
+| `server/backend/src/cq_server/daily_root.py` | Daily Merkle root computation + persistence (task #108 sub-task 3). |
+| `server/backend/src/cq_server/directory_client.py` | 8th-Layer Directory client — sprint 3. |
+| `server/backend/src/cq_server/email_sender.py` | Email sending — L2-side client for the central transactional-mail service. |
+| `server/backend/src/cq_server/embed.py` | Embedding generation via AWS Bedrock Titan. |
+| `server/backend/src/cq_server/forward_sign.py` | Per-L2 Ed25519 keypair management + forward-* request signing. |
+| `server/backend/src/cq_server/invite_routes.py` | Invite HTTP routes — FO-1b magic-link surface. |
+| `server/backend/src/cq_server/invites.py` | Invite minting / validation / claim — FO-1b. |
+| `server/backend/src/cq_server/l2_provision_routes.py` | FO-3 Phase 2 — cq-server L2-provision proxy + SSE passthrough (agent#193). |
+| `server/backend/src/cq_server/merkle.py` | SHA-256 Merkle tree over reputation event hashes (task #108 sub-task 3). |
+| `server/backend/src/cq_server/migrations.py` | Run Alembic migrations at server startup. |
+| `server/backend/src/cq_server/network.py` | Network-demo proxy endpoints — Lane H/I/J support. |
+| `server/backend/src/cq_server/passkey.py` | WebAuthn / passkey ceremony helpers (FO-1a, #191). |
+| `server/backend/src/cq_server/passkey_routes.py` | FastAPI router for passkey enrollment + login (FO-1a, #191). |
+| `server/backend/src/cq_server/persona_routes.py` | AS-1: Personas tab — admin routes for Human persona management. |
+| `server/backend/src/cq_server/quality.py` | Propose-time content quality guards. |
+| `server/backend/src/cq_server/reflect.py` | Server-side batch-reflect endpoints (#67). |
+| `server/backend/src/cq_server/reputation.py` | Reputation log v1 — Ed25519-signed append-only hash chain. |
+| `server/backend/src/cq_server/reputation_routes.py` | Reputation reader endpoints (task #108 sub-tasks 6 + admin trigger). |
+| `server/backend/src/cq_server/reputation_verifier.py` | Reputation chain + root verifier (task #108 sub-task 7). |
+| `server/backend/src/cq_server/store/_normalize.py` | Domain-tag normalisation shared between concrete stores. |
+| `server/backend/src/cq_server/store/_queries.py` | Shared SQLAlchemy Core query helpers for portable cq server queries. |
+| `server/backend/src/cq_server/store/_sqlite.py` | SqliteStore: SQLite-backed implementation of the async Store protocol. |
+| `server/backend/src/cq_server/tenancy.py` | Single source of truth for write-path tenancy resolution (agent#339). |
+| `server/backend/src/cq_server/theme.py` | Theme resolver — 3-tier brand hierarchy (FO-1d, Decision 30). |
+| `server/backend/src/cq_server/theme_routes.py` | FastAPI router for ``GET /api/v1/theme`` (FO-1d, Decision 30). |
+| `server/backend/src/cq_server/tour_routes.py` | Founder-tour persistence — per-user `tour_state` read/write. |
+| `server/backend/src/cq_server/transactional/__init__.py` | Central transactional-mail service — Decision 34 (agent#348). |
+| `server/backend/src/cq_server/transactional/auth.py` | HMAC v0 auth for the central transactional-mail service (Decision 34). |
+| `server/backend/src/cq_server/transactional/dispatcher.py` | SES dispatcher — the central service's SES boto3 wrapper. |
+| `server/backend/src/cq_server/transactional/idempotency.py` | In-memory idempotency cache for ``Idempotency-Key`` headers (Decision 34). |
+| `server/backend/src/cq_server/transactional/routes.py` | ``POST /api/v1/transactional/send`` — central transactional-mail service. |
+| `server/backend/src/cq_server/transactional/sns_writer.py` | SES → SNS bounce/complaint event → ``transactional_suppression`` writer. |
+| `server/backend/src/cq_server/transactional/suppression.py` | ``transactional_suppression`` read/write helpers (Decision 34). |
+| `server/backend/src/cq_server/transactional/tenancy.py` | Tenancy enforcement for the central transactional-mail service. |
+| `server/backend/src/cq_server/web_session.py` | Cookie-bound web-session bearer (FO-1c, #191). |
+| `server/backend/src/cq_server/xgroup_consent.py` | Intra-Enterprise xgroup_consent — 2-of-2 admin co-signed grants. |
+| `server/backend/tests/test_activity_log_instrumentation.py` | Activity-log instrumentation — #108 Stage 2 Workstream A. |
+| `server/backend/tests/test_activity_log_read_path.py` | Activity-log read-path instrumentation — agent#284. |
+| `server/backend/tests/test_activity_read_endpoint.py` | ``GET /api/v1/activity`` — #108 Stage 2 Workstream D. |
+| `server/backend/tests/test_admin_delete.py` | Tests for the admin DELETE /review/{ku_id} endpoint. |
+| `server/backend/tests/test_admin_routes_xgroup_consent.py` | HTTP-level tests for /api/v1/admin/xgroup_consent/* (Phase 1.0b). |
+| `server/backend/tests/test_agent_key_routes.py` | Tests for FO-4 Self-service Add Agent endpoints (agent#194). |
+| `server/backend/tests/test_aigrp_directory_peer_routes.py` | HTTP-level tests for ``POST /api/v1/admin/aigrp/directory-peerings`` (agent#347). |
+| `server/backend/tests/test_aigrp_enterprise_root.py` | Tests for the SSM-backed Enterprise AIGRP root (Decision 28 §1.2). |
+| `server/backend/tests/test_aigrp_envelope.py` | AIGRP HMAC envelope tests (Decision 28 §1.6). |
+| `server/backend/tests/test_aigrp_federation.py` | Cross-L2 AIGRP federation — outbound forward-query fan-out (agent#316). |
+| `server/backend/tests/test_aigrp_pair_secret.py` | KAT + property tests for AIGRP pair-secret derivation (Decision 28 §1.1). |
+| `server/backend/tests/test_aigrp_peer_routes.py` | HTTP-level tests for ``POST /api/v1/admin/aigrp/peers`` (agent#337). |
+| `server/backend/tests/test_aigrp_runtime.py` | Phase 1.0d (Decision 28) — AIGRP runtime wiring tests. |
+| `server/backend/tests/test_aud_discriminant.py` | Tests for FO-1c JWT aud-claim discriminant on /auth/me. |
+| `server/backend/tests/test_auto_approve_propose.py` | Regression tests for #123 — CQ_AUTO_APPROVE_PROPOSE env flag. |
+| `server/backend/tests/test_bloom_prefilter.py` | Issue #22 — Bloom prefilter at DSN query time. |
+| `server/backend/tests/test_bootstrap_admin.py` | Tests for the password-login admin bootstrap (agent#165). |
+| `server/backend/tests/test_bootstrap_liaison.py` | Tests for ``bootstrap_liaison_key_if_needed`` (decision 42 / W2). |
+| `server/backend/tests/test_consents_revoke.py` | Phase 6 step 3 / Lane D: DELETE /consents/{consent_id} tests. |
+| `server/backend/tests/test_consents_sign.py` | Phase 6 step 3 / Lane D: POST /consents/sign tests. |
+| `server/backend/tests/test_consults.py` | Sprint 2 / Issue #20 — L3 consults · same-L2 path. |
+| `server/backend/tests/test_cross_l2_routing.py` | Sprint 2 part 2 — cross-L2 consult routing via AIGRP. |
+| `server/backend/tests/test_crosstalk_routes.py` | Tests for crosstalk endpoints (#124). |
+| `server/backend/tests/test_daily_root.py` | Tests for daily Merkle root computation (task #108 sub-task 3). |
+| `server/backend/tests/test_default_enterprise_backfill.py` | Backfill migration 0013 — legacy default-enterprise KUs (#121 finding 3). |
+| `server/backend/tests/test_demo_scenarios.py` | Phase 6 step 4 / Lane J: POST /network/demo/{scenario} tests. |
+| `server/backend/tests/test_directory_client.py` | Tests for the L2-side 8th-Layer Directory client (sprint 3). |
+| `server/backend/tests/test_dsn_resolve.py` | Phase 6 step 4 / Lane I: POST /network/dsn/resolve tests. |
+| `server/backend/tests/test_ed25519_forward_signing.py` | Sprint 4 — Ed25519 per-L2 forward-signing tests (#44 / full CRIT #34 close). |
+| `server/backend/tests/test_email_sender_http.py` | Tests for the L2-side HTTP-client ``EmailSender`` (Decision 34). |
+| `server/backend/tests/test_forward_query.py` | Phase 6 step 2: cross-L2 /aigrp/forward-query endpoint tests. |
+| `server/backend/tests/test_invites.py` | Tests for FO-1b magic-link invites. |
+| `server/backend/tests/test_l2_provision_routes.py` | HTTP-level tests for FO-3 Phase 2 — the cq-server L2-provision proxy. |
+| `server/backend/tests/test_l2_tenancy_scope.py` | agent#303 — an FO-2-provisioned L2 must run in its own tenancy scope. |
+| `server/backend/tests/test_merkle.py` | Tests for the SHA-256 Merkle tree (task #108 sub-task 3). |
+| `server/backend/tests/test_migration_0002_xgroup_consent.py` | Phase 6 step 2: Alembic migration smoke-test. |
+| `server/backend/tests/test_migration_0003_presence.py` | Phase 6 step 3: Alembic migration smoke-test. |
+| `server/backend/tests/test_migration_0011_activity_log.py` | Stage 1 of #108 — activity-log Alembic migration smoke-tests. |
+| `server/backend/tests/test_migration_0015_aigrp_peers_pair_secret_ref.py` | Phase 1.0c — ``aigrp_peers.pair_secret_ref`` migration smoke-tests. |
+| `server/backend/tests/test_migrations.py` | Tests for Alembic baseline migration + stamp-on-startup logic. |
+| `server/backend/tests/test_network_dsn_cache.py` | Issue #23 — DSN routed-hop · in-memory signature cache. |
+| `server/backend/tests/test_network_topology.py` | Phase 6 step 4 / Lane J: POST /network/topology aggregator tests. |
+| `server/backend/tests/test_passkey.py` | End-to-end tests for the FO-1a passkey enrollment substrate (#191). |
+| `server/backend/tests/test_peers_active.py` | Phase 6 step 3 / Lane C: GET /peers/active scoping + filter tests. |
+| `server/backend/tests/test_peers_heartbeat.py` | Phase 6 step 3 / Lane C: presence heartbeat upsert tests. |
+| `server/backend/tests/test_pending_review_concurrency.py` | Optimistic-concurrency control on review-status transitions. |
+| `server/backend/tests/test_pending_review_tier.py` | Pending-review tier (#103) — store + route tests. |
+| `server/backend/tests/test_pending_review_ttl.py` | Read-time TTL enforcement on pending_review queries. |
+| `server/backend/tests/test_per_l2_isolation.py` | Tests for Decision 27 — per-L2 isolation read-path migration. |
+| `server/backend/tests/test_persona_routes.py` | Tests for AS-1 persona management endpoints. |
+| `server/backend/tests/test_propose_tenancy_env_fallback.py` | agent#324 regression — propose stamps KU tenancy from env when the |
+| `server/backend/tests/test_propose_tenancy_regression.py` | Regression tests for #89 — KU tenancy must come from auth claims. |
+| `server/backend/tests/test_propose_tier.py` | Regression tests for #90 — /propose tier resolution. |
+| `server/backend/tests/test_quality.py` | Tests for the propose-time content quality guards. |
+| `server/backend/tests/test_queries.py` | Tests for the shared SQLAlchemy Core query helpers in ``store._queries``. |
+| `server/backend/tests/test_reflect.py` | Tests for the batch-reflect endpoints (#67). |
+| `server/backend/tests/test_reputation.py` | Tests for reputation log v1-alpha (task #99). |
+| `server/backend/tests/test_reputation_verifier.py` | Tests for the reputation verifier library (task #108 sub-task 7). |
+| `server/backend/tests/test_sqlite_store.py` | Tests for SqliteStore-only behaviour: engine wiring, PRAGMAs, threadpool shim, lifecycle. |
+| `server/backend/tests/test_sqlite_store_e2e.py` | End-to-end smoke for the cq server against a temporary SQLite database. |
+| `server/backend/tests/test_sqlite_store_fork_delta.py` | Tests for fork-delta methods ported to async SqliteStore (#105 PR-A). |
+| `server/backend/tests/test_tenancy.py` | Unit tests for the central write-path tenancy resolver (agent#339). |
+| `server/backend/tests/test_tenancy_columns.py` | Phase 6 step 1: regression tests for additive tenancy columns. |
+| `server/backend/tests/test_theme.py` | Tests for FO-1d ``GET /api/v1/theme`` (Decision 30). |
+| `server/backend/tests/test_tour_routes.py` | Tests for the founder-tour persistence endpoints. |
+| `server/backend/tests/test_transactional_idempotency.py` | Unit tests for the in-memory ``IdempotencyStore`` (Decision 34). |
+| `server/backend/tests/test_transactional_send.py` | End-to-end tests for ``POST /api/v1/transactional/send`` (Decision 34). |
+| `server/backend/tests/test_transactional_sns_writer.py` | Tests for the SNS → suppression writer (``transactional.sns_writer``). |
+| `server/backend/tests/test_transactional_suppression.py` | Tests for ``transactional.suppression`` read/write helpers. |
+| `server/backend/tests/test_web_session.py` | Tests for the cookie-bound web-session module (FO-1c, #191). |
+| `server/backend/tests/test_x_enterprise_consult.py` | Sprint 4 Track A — cross-Enterprise consult forward (sender side). |
+| `server/backend/tests/test_xgroup_consent.py` | Round-trip + revocation + lineage tests for xgroup_consent (Phase 1.0b). |
 
 ## Modified files (additions on top of upstream)
 
-These files exist in upstream `mozilla-ai/cq` and have been modified by
-OneZero1.ai. The git diff against the fork-base commit is the authoritative
+These files exist in upstream at the fork-base commit and have been modified
+by OneZero1.ai. The git diff against the fork-base commit is the authoritative
 record of changes.
 
 | File | Nature of modification |
 |---|---|
-| `server/backend/src/cq_server/app.py` | Multi-tenant scope params on `/query`, `/review/*`, `/stats`; AIGRP forward-query handler; directory-client lifespan task; security fixes (CRIT #32/#33/#34, HIGH #35/#37/#39) |
-| `server/backend/src/cq_server/store/__init__.py` | Tenant scoping on existing CRUD methods; new methods for AIGRP peers, consults, directory peerings, cross-L2 audit |
-| `server/backend/src/cq_server/auth.py` | Admin role; tenant scope resolution from user row |
-| `server/backend/src/cq_server/review.py` | Admin gate (`require_admin`) on every route; tenant scoping on aggregate methods |
-| `server/backend/src/cq_server/deps.py` | Tenant scope helpers |
-| `server/backend/tests/test_app.py`, `test_review.py`, `test_admin_delete.py` | Tests adapted for the multi-tenant surface |
-| `server/backend/pyproject.toml` | Added `cryptography`, `rfc8785`, `httpx` for the directory client |
-| `server/scripts/seed-users.py`, `server/local-demo/bin/seed-admin.sh` | Set `role='admin'` (post-CRIT #32) |
-| `plugins/cq/.claude-plugin/plugin.json` | Renamed plugin to `8l-cq`; OneZero1.ai authorship; updated description, repository, keywords |
-| `README.md` | Prepended 8th-Layer.ai fork-disclosure header (upstream cq README preserved verbatim below the separator) |
+| `server/backend/src/cq_server/app.py` | Multi-tenant scope on query/review/stats; AIGRP forward-query; directory-client lifespan; security gates; `/knowledge` alias |
+| `server/backend/src/cq_server/auth.py` | Admin role; tenant scope from user row; versioned API-key list envelope |
+| `server/backend/src/cq_server/db_url.py` | SQLite + Alembic URL resolution for SqliteStore startup |
+| `server/backend/src/cq_server/deps.py` | Tenant-scope helpers; API-key and admin dependencies |
+| `server/backend/src/cq_server/review.py` | Admin gate on all routes; tenant scoping on aggregates |
+| `server/backend/src/cq_server/store/__init__.py` | Re-exports SqliteStore; tenant-scoped CRUD; AIGRP/consults/directory methods |
+| `server/backend/src/cq_server/store/_protocol.py` | Extended async Store protocol for fork-delta store methods |
+| `server/backend/src/cq_server/tables.py` | Multi-tenant + AIGRP + activity/reputation schema tables |
+| `server/backend/tests/test_app.py` | Multi-tenant API tests; knowledge alias; forward-query coverage |
+| `server/backend/tests/test_auth.py` | Admin role and tenant-scope auth tests |
+| `server/backend/tests/test_db_url.py` | Database URL resolution tests for fork startup path |
+| `server/backend/tests/test_deps.py` | Tenant-scope and require_api_key dependency tests |
+| `server/backend/tests/test_review.py` | Admin-gated review queue tests with tenant scoping |
+| `server/backend/tests/test_store.py` | SqliteStore CRUD and fork-delta store method tests |
+| `server/backend/tests/test_store_protocol.py` | SqliteStore satisfies extended Store protocol |
 
-## Files unchanged from upstream (the open standard)
+## Files unchanged from upstream fork base
 
-These are the open-protocol portions we explicitly preserve unchanged:
+These tracked backend files are byte-identical to upstream at the fork-base
+commit — preserved open-protocol portions with no OneZero1.ai edits:
+
+| File | Purpose |
+|---|---|
+| `server/backend/src/cq_server/__init__.py` | Package marker; unchanged from fork base |
+| `server/backend/src/cq_server/api_keys.py` | API key token encoding and hashing.; unchanged from fork base |
+| `server/backend/src/cq_server/scoring.py` | Confidence scoring and relevance functions for knowledge units.; unchanged from fork base |
+| `server/backend/src/cq_server/ttl.py` | Duration-string parser for API key TTLs.; unchanged from fork base |
+| `server/backend/tests/__init__.py` | Package marker; unchanged from fork base |
+| `server/backend/tests/test_api_keys.py` | Tests for API key token encoding and hashing.; unchanged from fork base |
+| `server/backend/tests/test_scoring.py` | Tests for confidence scoring and relevance functions.; unchanged from fork base |
+| `server/backend/tests/test_ttl.py` | Tests for the TTL duration parser.; unchanged from fork base |
+
+## Other fork modifications (outside backend source tree)
+
+Additional changes not enumerated in the tables above include plugin rebranding
+(`plugins/cq/`), deploy templates, SDK packaging, and root documentation
+(`README.md`, `FORK_DELTA.md`, `NOTICE`). See [`FORK_DELTA.md`](FORK_DELTA.md)
+and the git log for those surfaces.
+
+## Open standard preserved elsewhere
+
+These protocol portions remain upstream-aligned and are not modified in this fork:
 
 - `LICENSE` (Apache-2.0, verbatim)
 - `schema/knowledge-unit.schema.json` (the open KU schema)
-- The MCP server name `cq` inside the renamed `8l-cq` plugin (kept for protocol compatibility — agent code calling `mcp__cq__*` continues to work)
-- DID/KERI identity model
-- Tier model semantics (Local / Remote / Global Commons)
-- SDK APIs (`sdk/`)
-- Cq's MCP tool surface (`propose`, `query`, `confirm`, `flag`, `reflect`, `status`, `health`)
+- DID/KERI identity model and tier model semantics
+- SDK APIs (`sdk/`) and the core MCP tool surface
 
 ## Source-of-truth references
 
@@ -81,3 +230,4 @@ These are the open-protocol portions we explicitly preserve unchanged:
 - **Project decisions**: https://github.com/OneZero1ai/crosstalk-enterprise/tree/main/docs/decisions
 - **Per-PR change history**: this repository's git log
 - **Trademark posture**: see [`NOTICE`](NOTICE) — Apache-2.0 §6 acknowledged; references to "cq" / "Mozilla.ai" are factual attribution only
+

--- a/deploy/aws/marketplace-l2.yaml
+++ b/deploy/aws/marketplace-l2.yaml
@@ -231,6 +231,14 @@ Parameters:
       is created. See docs/ops/l2-substrate-recovery.md for the full
       procedure.
 
+  CertificateArn:
+    Type: String
+    Default: ""
+    Description: |
+      ACM certificate ARN for this L2's <slug>.8th-layer.ai HTTPS:443
+      listener (Decision 43). Empty = HTTP:80 only (Cloudflare-fronted,
+      legacy).
+
   LiaisonKeySsmPath:
     Type: String
     Default: ""
@@ -258,6 +266,8 @@ Conditions:
   # decision 42 — only mount CQ_INITIAL_LIAISON_KEY when the worker passed an
   # SSM path (Quick-enabled provision). Keeps non-Quick L2 updates clean.
   MountLiaisonKey: !Not [!Equals [!Ref LiaisonKeySsmPath, ""]]
+  # Decision 43 — optional ALB TLS termination when provisioning passes an ACM cert.
+  HasCertificate: !Not [!Equals [!Ref CertificateArn, ""]]
 
 Resources:
   # =====================================================================
@@ -920,6 +930,20 @@ Resources:
       LoadBalancerArn: !Ref Alb
       Port: 80
       Protocol: HTTP
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref TargetGroup
+
+  HttpsListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Condition: HasCertificate
+    Properties:
+      LoadBalancerArn: !Ref Alb
+      Port: 443
+      Protocol: HTTPS
+      Certificates:
+        - CertificateArn: !Ref CertificateArn
+      SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
       DefaultActions:
         - Type: forward
           TargetGroupArn: !Ref TargetGroup

--- a/deploy/aws/marketplace-l2.yaml
+++ b/deploy/aws/marketplace-l2.yaml
@@ -231,6 +231,20 @@ Parameters:
       is created. See docs/ops/l2-substrate-recovery.md for the full
       procedure.
 
+  LiaisonKeySsmPath:
+    Type: String
+    Default: ""
+    Description: |
+      Optional (decision 42 / Quick-enablement). Full SSM parameter ARN
+      holding the Liaison Server's cqa.v1.* service key, seeded by the
+      provisioning worker before this stack deploys. When non-empty the
+      cq-server task mounts it as CQ_INITIAL_LIAISON_KEY, and the first-boot
+      bootstrap_liaison_key_if_needed inserts it as a full-capability agent
+      key so the co-deployed Liaison Server can authenticate. Empty (the
+      default) = no Quick sidecar; the secret is omitted entirely so existing
+      L2 stacks update-stack cleanly without a phantom-secret resolution
+      failure. Gated via the MountLiaisonKey condition + AWS::NoValue.
+
 Conditions:
   HasAdminEmail: !Not [!Equals [!Ref AdminEmail, ""]]
   AutoApproveOn: !Equals [!Ref AutoApprovePropose, "true"]
@@ -241,6 +255,9 @@ Conditions:
   # agent#323 — toggles SnapshotId on CqDataVolume between absent
   # (fresh L2) and the restore-from id (recovery path).
   RestoreFromSnapshot: !Not [!Equals [!Ref RestoreFromSnapshotId, ""]]
+  # decision 42 — only mount CQ_INITIAL_LIAISON_KEY when the worker passed an
+  # SSM path (Quick-enabled provision). Keeps non-Quick L2 updates clean.
+  MountLiaisonKey: !Not [!Equals [!Ref LiaisonKeySsmPath, ""]]
 
 Resources:
   # =====================================================================
@@ -805,6 +822,15 @@ Resources:
             # full SSM parameter ARN for cross-account-safe resolution.
             - Name: TX_SEND_KEY
               ValueFrom: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/8th-layer/l2/${EnterpriseSlug}/${CqGroupId}/tx_send_key"
+            # decision 42 / Quick-enablement — the Liaison Server's service key,
+            # seeded by the provisioning worker. Mounted ONLY when the worker
+            # passed LiaisonKeySsmPath (Quick-enabled provision); AWS::NoValue
+            # removes the entry otherwise so non-Quick L2 updates don't fail on
+            # a missing SSM parameter.
+            - !If
+              - MountLiaisonKey
+              - { Name: CQ_INITIAL_LIAISON_KEY, ValueFrom: !Ref LiaisonKeySsmPath }
+              - !Ref "AWS::NoValue"
           # Container-level health check uses python (urllib) rather than
           # curl because the cq-server image (Python slim base) doesn't
           # ship curl/wget. The image already declares the same probe in

--- a/deploy/aws/marketplace-l2.yaml
+++ b/deploy/aws/marketplace-l2.yaml
@@ -459,6 +459,23 @@ Resources:
                 Condition:
                   StringEquals:
                     "kms:ViaService": !Sub "ssm.${AWS::Region}.amazonaws.com"
+        # decision 42 — when Quick-enabled, ECS must ALSO read the liaison_key
+        # SSM param at task start to inject CQ_INITIAL_LIAISON_KEY. The KMS
+        # decrypt is already covered by the kms:ViaService=ssm statement above;
+        # only the ssm:GetParameters grant on the liaison_key path is needed.
+        # Gated on MountLiaisonKey so non-Quick L2s never carry the grant (and
+        # so the task doesn't fail to start on a missing-param/AccessDenied —
+        # the exact failure the M1 live run caught).
+        - !If
+          - MountLiaisonKey
+          - PolicyName: LiaisonKeySsmReadAtStart
+            PolicyDocument:
+              Version: "2012-10-17"
+              Statement:
+                - Effect: Allow
+                  Action: [ssm:GetParameters]
+                  Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/8th-layer/l2/${EnterpriseSlug}/${CqGroupId}/liaison_key"
+          - !Ref "AWS::NoValue"
 
   TaskRole:
     Type: AWS::IAM::Role

--- a/deploy/aws/quick-stack.yaml
+++ b/deploy/aws/quick-stack.yaml
@@ -141,11 +141,25 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/bedrock-agentcore/*"
+              # ECR Public (the V1 default image location) ...
               - Effect: Allow
                 Action:
                   - ecr-public:GetAuthorizationToken
                   - sts:GetServiceBearerToken
                 Resource: "*"
+              # ... and private ECR (same-account image, e.g. a test/private
+              # registry or an enterprise mirror). GetAuthorizationToken needs
+              # Resource "*"; the layer/image reads are scoped to this account's
+              # registry.
+              - Effect: Allow
+                Action: ecr:GetAuthorizationToken
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - ecr:BatchGetImage
+                  - ecr:GetDownloadUrlForLayer
+                  - ecr:BatchCheckLayerAvailability
+                Resource: !Sub "arn:aws:ecr:${AWS::Region}:${AWS::AccountId}:repository/*"
 
   # ── The Liaison Server on AgentCore Runtime ───────────────────────────────
   LiaisonRuntime:

--- a/deploy/aws/quick-stack.yaml
+++ b/deploy/aws/quick-stack.yaml
@@ -175,12 +175,16 @@ Resources:
         NetworkMode: PUBLIC
       ProtocolConfiguration: MCP
       EnvironmentVariables:
-        L2_BASE_URL: !Sub "https://${L2DirectOrigin}"
+        # The marketplace L2 ALB serves HTTP/80 only — TLS is terminated by
+        # Cloudflare in front of it (443 is reserved/unbound in v1, no ACM cert
+        # on the ALB). So the co-located LS reaches the L2 at its DIRECT ALB
+        # origin over HTTP, exactly as Cloudflare reaches the origin (decision 42,
+        # W1 corrected by the M1 live run: there is no TLS to the raw ALB, so no
+        # SNI/cert handling is needed — the earlier https+SNI design was moot).
+        L2_BASE_URL: !Sub "http://${L2DirectOrigin}"
         L2_AUTH_MODE: "bearer"
         L2_AUTH_TOKEN: !Ref L2AuthToken
-        # The ALB cert is for *.8th-layer.ai, not the raw ALB DNS, so a direct
-        # https call to L2DirectOrigin needs SNI/Host=<slug>.8th-layer.ai and
-        # cert handling on the LS side (decision 42, wrinkle W1).
+        # Host header the cq-server sees (matches what it gets via Cloudflare).
         L2_TLS_SERVER_NAME: !Sub "${EnterpriseSlug}.8th-layer.ai"
         AWS_REGION: !Ref AWS::Region
       AuthorizerConfiguration:

--- a/deploy/aws/quick-stack.yaml
+++ b/deploy/aws/quick-stack.yaml
@@ -1,0 +1,218 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  8th-Layer Quick-enablement stack ("phase 6"). Co-deploys, into the SAME
+  customer account as a freshly-provisioned L2, the Liaison Server (LS) on
+  Bedrock AgentCore Runtime behind a Cognito client-credentials OAuth ingress —
+  the exact shape Amazon Quick's Action connector requires. The LS talks to the
+  L2 at its DIRECT origin (the ALB DNS), never the Cloudflare-fronted public URL
+  (ku_d56a1ca7 — Cloudflare challenges AWS-source IPs, so an LS->Cloudflare->L2
+  hop transport-fails from the runtime). Deployed by the provisioning worker's
+  _phase6_quick_enable via cross-account AssumeRole + CFN, mirroring phase 4
+  (L2_STANDUP). A failure here is COMPLETED_DEGRADED, not FAILED: the L2 is the
+  product; Quick-enable is an add-on, and a healthy L2 must not be rolled back
+  because the Quick wrapper could not stand up.
+
+# ---------------------------------------------------------------------------
+# Contract with src/directory/provisioning_worker.py :: _phase6_quick_enable
+# Every Parameter without a Default MUST be supplied by the worker's
+# create_stack Parameters list. Keep this contract in sync with that handler.
+# ---------------------------------------------------------------------------
+Parameters:
+  EnterpriseSlug:
+    Type: String
+    Description: The L2/Enterprise slug — used for resource naming, the Cognito
+      domain prefix, and cost-allocation tags. May contain hyphens.
+    AllowedPattern: "^[a-z][a-z0-9-]{2,30}$"
+
+  RuntimeName:
+    Type: String
+    Description: >-
+      AgentCore AgentRuntimeName. MUST be [A-Za-z][A-Za-z0-9_]* (NO hyphens) —
+      AgentCore rejects hyphens, but slugs contain them, so the worker passes a
+      sanitized name (slug hyphens -> underscores, e.g. acme-corp -> liaison_acme_corp).
+    AllowedPattern: "^[A-Za-z][A-Za-z0-9_]{2,47}$"
+
+  L2DirectOrigin:
+    Type: String
+    Description: >-
+      The L2's DIRECT origin host (the marketplace-l2 stack's AlbDnsName output),
+      WITHOUT scheme. The LS sets L2_BASE_URL=https://<this>. Bypasses Cloudflare.
+
+  L2AuthToken:
+    Type: String
+    NoEcho: true
+    Description: >-
+      The LS's L2 bearer API key (a service key minted on the L2 by phase 6).
+      V1: delivered as a plain AgentCore EnvironmentVariable — acceptable because
+      this stack lives in the customer's OWN account and the key is scoped to
+      their own L2. Hardening to SSM SecureString + runtime fetch is tracked in
+      decision 42 (open wrinkle W2).
+
+  LiaisonServerImage:
+    Type: String
+    Description: >-
+      The Liaison Server container image URI (ECR Public, ARM64 — AgentCore
+      Runtime is ARM64). Single source of truth for the known-good LS image.
+    Default: "public.ecr.aws/onezero1/8th-layer-liaison:latest"
+
+  AwsRegion:
+    Type: String
+    Default: ""
+    Description: Echoed for cross-account correlation; runtime uses AWS::Region.
+
+Resources:
+  # ── Cognito client-credentials OAuth ingress ──────────────────────────────
+  # Machine-to-machine only (Quick's Action connector authenticates as a
+  # confidential client). No human users, no hosted-UI sign-in flow.
+  LiaisonUserPool:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      UserPoolName: !Sub "8l-liaison-${EnterpriseSlug}"
+      AdminCreateUserConfig:
+        AllowAdminCreateUserOnly: true   # no self-signup — m2m only
+      Policies:
+        PasswordPolicy:
+          MinimumLength: 16
+      UserPoolTags:
+        8th-layer:enterprise: !Ref EnterpriseSlug
+        8th-layer:managed-by: provisioning-service
+        8th-layer:component: liaison-oauth
+
+  # The resource server defines the audience + the scope Quick requests.
+  LiaisonResourceServer:
+    Type: AWS::Cognito::UserPoolResourceServer
+    Properties:
+      UserPoolId: !Ref LiaisonUserPool
+      Identifier: "8th-layer-liaison"
+      Name: "8th-Layer Liaison"
+      Scopes:
+        - ScopeName: "invoke"
+          ScopeDescription: "Invoke the Liaison Server MCP tools"
+
+  # Confidential client (has a secret) using the client_credentials grant.
+  LiaisonAppClient:
+    Type: AWS::Cognito::UserPoolClient
+    DependsOn: LiaisonResourceServer
+    Properties:
+      ClientName: !Sub "8l-liaison-${EnterpriseSlug}-quick"
+      UserPoolId: !Ref LiaisonUserPool
+      GenerateSecret: true
+      AllowedOAuthFlows:
+        - client_credentials
+      AllowedOAuthFlowsUserPoolClient: true
+      AllowedOAuthScopes:
+        - "8th-layer-liaison/invoke"
+      SupportedIdentityProviders:
+        - COGNITO
+      ExplicitAuthFlows:
+        - ALLOW_REFRESH_TOKEN_AUTH
+
+  # Hosted domain — required so the OAuth token endpoint exists at
+  # https://<domain>.auth.<region>.amazoncognito.com/oauth2/token
+  LiaisonUserPoolDomain:
+    Type: AWS::Cognito::UserPoolDomain
+    Properties:
+      UserPoolId: !Ref LiaisonUserPool
+      Domain: !Sub "8l-liaison-${EnterpriseSlug}"
+
+  # ── AgentCore Runtime exec role ───────────────────────────────────────────
+  LiaisonExecRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "8l-liaison-exec-${EnterpriseSlug}"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: bedrock-agentcore.amazonaws.com
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
+      Policies:
+        - PolicyName: liaison-runtime-logs
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/bedrock-agentcore/*"
+              - Effect: Allow
+                Action:
+                  - ecr-public:GetAuthorizationToken
+                  - sts:GetServiceBearerToken
+                Resource: "*"
+
+  # ── The Liaison Server on AgentCore Runtime ───────────────────────────────
+  LiaisonRuntime:
+    Type: AWS::BedrockAgentCore::Runtime
+    Properties:
+      AgentRuntimeName: !Ref RuntimeName
+      Description: !Sub "8th-Layer Liaison Server for ${EnterpriseSlug} (Quick enablement)"
+      AgentRuntimeArtifact:
+        ContainerConfiguration:
+          ContainerUri: !Ref LiaisonServerImage
+      RoleArn: !GetAtt LiaisonExecRole.Arn
+      NetworkConfiguration:
+        NetworkMode: PUBLIC
+      ProtocolConfiguration: MCP
+      EnvironmentVariables:
+        L2_BASE_URL: !Sub "https://${L2DirectOrigin}"
+        L2_AUTH_MODE: "bearer"
+        L2_AUTH_TOKEN: !Ref L2AuthToken
+        # The ALB cert is for *.8th-layer.ai, not the raw ALB DNS, so a direct
+        # https call to L2DirectOrigin needs SNI/Host=<slug>.8th-layer.ai and
+        # cert handling on the LS side (decision 42, wrinkle W1).
+        L2_TLS_SERVER_NAME: !Sub "${EnterpriseSlug}.8th-layer.ai"
+        AWS_REGION: !Ref AWS::Region
+      AuthorizerConfiguration:
+        CustomJWTAuthorizer:
+          DiscoveryUrl: !Sub "https://cognito-idp.${AWS::Region}.amazonaws.com/${LiaisonUserPool}/.well-known/openid-configuration"
+          AllowedClients:
+            - !Ref LiaisonAppClient
+      Tags:
+        8th-layer:enterprise: !Ref EnterpriseSlug
+        8th-layer:managed-by: provisioning-service
+        8th-layer:component: liaison-runtime
+
+Outputs:
+  LiaisonRuntimeArn:
+    Description: ARN of the Liaison Server AgentCore runtime.
+    Value: !GetAtt LiaisonRuntime.AgentRuntimeArn
+
+  LiaisonInvokeUrl:
+    Description: >-
+      The OAuth-fronted MCP endpoint Quick's Action connector targets. AgentCore
+      invoke URL derived from the runtime ARN (url-encoded) — the worker stamps
+      this into the provision job result as the reachable LS URL (M1 close
+      condition).
+    Value: !Sub
+      - "https://bedrock-agentcore.${AWS::Region}.amazonaws.com/runtimes/${EncodedArn}/invocations?qualifier=DEFAULT"
+      - EncodedArn: !Join ["%2F", !Split ["/", !GetAtt LiaisonRuntime.AgentRuntimeArn]]
+
+  CognitoTokenUrl:
+    Description: OAuth2 token endpoint (client_credentials grant) for the runbook/M2 harness.
+    Value: !Sub "https://8l-liaison-${EnterpriseSlug}.auth.${AWS::Region}.amazoncognito.com/oauth2/token"
+
+  CognitoClientId:
+    Description: The confidential client id Quick / the M2 harness authenticates as.
+    Value: !Ref LiaisonAppClient
+
+  CognitoClientSecret:
+    Description: >-
+      The client secret. GetAtt ClientSecret on UserPoolClient is supported by
+      CFN; if a deploy ever reports it unsupported, fall back to the worker
+      calling cognito-idp describe-user-pool-client post-deploy (decision 42 W3).
+    Value: !GetAtt LiaisonAppClient.ClientSecret
+
+  CognitoUserPoolId:
+    Description: Cognito user pool id (for the runtime's CUSTOM_JWT discoveryUrl).
+    Value: !Ref LiaisonUserPool
+
+  OAuthScope:
+    Description: The scope Quick requests in the client_credentials token call.
+    Value: "8th-layer-liaison/invoke"

--- a/docs/marketplace-customer-role-snippet.yaml
+++ b/docs/marketplace-customer-role-snippet.yaml
@@ -101,6 +101,34 @@ Resources:
                   - ssm:GetParameter
                   - ssm:GetParameters
                 Resource: "arn:aws:ssm:*::parameter/aws/service/*"
+              # The provisioning service SEEDS, and the L2 task READS, per-L2
+              # secrets stored under THIS account's own SSM namespace
+              # /8th-layer/l2/<slug>/<group>/* — currently tx_send_key (the
+              # central-mail HMAC secret, Decision 34) and, for Quick-enabled
+              # Enterprises, liaison_key. Without ssm write+read here the
+              # provision session's seed step fails with AccessDenied and the L2
+              # ECS task can never fetch its secret — the stack then hangs at
+              # L2_STANDUP with no CFN failure event. The per-provision session
+              # policy narrows this to the one slug being provisioned; the role
+              # itself allows the whole namespace because it is reused across
+              # provisions. SecureString ⇒ kms (next statement) is also required.
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                  - ssm:GetParameters
+                  - ssm:PutParameter
+                  - ssm:DeleteParameter
+                  - ssm:AddTagsToResource
+                Resource: !Sub "arn:aws:ssm:*:${AWS::AccountId}:parameter/8th-layer/l2/*"
+              - Effect: Allow
+                Action:
+                  - kms:Encrypt
+                  - kms:Decrypt
+                  - kms:GenerateDataKey
+                Resource: "*"
+                Condition:
+                  StringLike:
+                    kms:ViaService: "ssm.*.amazonaws.com"
               # The EBS-on-EC2 template snapshots the L2 data volume via an
               # AWS::DLM::LifecyclePolicy. dlm:CreateLifecyclePolicy can't be
               # ARN-scoped at create time, so dlm is granted on "*". Without

--- a/docs/marketplace-customer-role-snippet.yaml
+++ b/docs/marketplace-customer-role-snippet.yaml
@@ -196,6 +196,46 @@ Resources:
                   - iam:UntagInstanceProfile
                 Resource:
                   - !Sub "arn:aws:iam::${AWS::AccountId}:instance-profile/eighth-layer-l2-*"
+              # Quick-enablement (decision 42): for a Quick-enabled cold
+              # provision the service ALSO deploys the quick-stack (Liaison
+              # Server on Bedrock AgentCore + Cognito client-credentials OAuth)
+              # into this account, in a separate `eighth-layer-quick-<slug>`
+              # stack. CloudFormation itself is covered by the
+              # AWSCloudFormationFullAccess managed policy above; these are the
+              # resource-create actions that aren't, plus the Liaison exec role
+              # the quick-stack creates and passes to the AgentCore runtime.
+              # Without these a Quick-enabled provision fails at phase 6 (the
+              # L2 still stands up; phase 6 degrades to COMPLETED_DEGRADED).
+              - Effect: Allow
+                Action:
+                  - bedrock-agentcore:*
+                  - cognito-idp:*
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - iam:CreateRole
+                  - iam:DeleteRole
+                  - iam:GetRole
+                  - iam:PutRolePolicy
+                  - iam:DeleteRolePolicy
+                  - iam:GetRolePolicy
+                  - iam:AttachRolePolicy
+                  - iam:DetachRolePolicy
+                  - iam:ListRolePolicies
+                  - iam:ListAttachedRolePolicies
+                  - iam:TagRole
+                  - iam:UntagRole
+                Resource:
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/8l-liaison-exec-*"
+              - Effect: Allow
+                Action:
+                  - iam:PassRole
+                Resource:
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/8l-liaison-exec-*"
+                Condition:
+                  StringEquals:
+                    iam:PassedToService:
+                      - bedrock-agentcore.amazonaws.com
 
 Outputs:
   RoleArn:

--- a/server/backend/src/cq_server/app.py
+++ b/server/backend/src/cq_server/app.py
@@ -379,6 +379,7 @@ async def lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
     # Idempotent: skipped when any non-system user already exists.
     from .bootstrap_admin import (
         bootstrap_first_admin_if_needed,
+        bootstrap_liaison_key_if_needed,
         bootstrap_password_admin_if_needed,
     )
 
@@ -403,6 +404,21 @@ async def lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
 
         _logging.getLogger("bootstrap_admin").exception(
             "bootstrap_password_admin_if_needed raised; continuing without password admin"
+        )
+
+    # Decision 42 / W2 — Quick-enablement. On a first boot with
+    # CQ_INITIAL_LIAISON_KEY set (the provisioning worker seeds the same
+    # cqa.v1.* token here and into the co-deployed Liaison Server), insert it
+    # as a full-capability agent key so the LS can authenticate to this L2
+    # without an admin principal (which does not exist at cold boot in the
+    # founder path). Idempotent + NOT mutually exclusive with the admin paths.
+    try:
+        await bootstrap_liaison_key_if_needed(_store)
+    except Exception:  # noqa: BLE001
+        import logging as _logging
+
+        _logging.getLogger("bootstrap_admin").exception(
+            "bootstrap_liaison_key_if_needed raised; continuing without liaison key"
         )
 
     # Provisioning crash recovery moved to 8th-layer-directory per

--- a/server/backend/src/cq_server/bootstrap_admin.py
+++ b/server/backend/src/cq_server/bootstrap_admin.py
@@ -20,11 +20,13 @@ The flow this enables (P2 demo path):
   1. Founder fills wizard, hits Provision.
   2. Provisioning service stands up the L2.
   3. THIS HOOK on first boot: creates 'system' user (no password / no
-     passkey — never logs in), mints invite for AdminEmail, logs
-     ``[BOOTSTRAP_ADMIN] magic_link=https://<slug>.8th-layer.ai/invite/<token>``.
-  4. Operator copies that URL from CloudWatch and emails it (or
-     in-process the wizard could surface it directly on the
-     "you're done" screen — that's a follow-up).
+     passkey — never logs in), mints invite for AdminEmail, and logs ONLY
+     that an invite was minted (invite_id + expiry) — NOT the token
+     (security audit 2026-06-01: the magic-link embeds a founder-identity
+     bearer; CloudWatch read is too broad an audience for it).
+  4. The link is delivered to the founder by email (provisioning phase 5,
+     SES) and surfaced on the wizard "you're done" screen (job result
+     magic_link_url). It is no longer recoverable from CloudWatch.
   5. Founder clicks → /invite/<token> → registers passkey → lands
      in admin UI → goes to Invites tab → sends teammate #2 invite.
 
@@ -97,7 +99,7 @@ async def bootstrap_first_admin_if_needed(store: SqliteStore) -> None:
         return
 
     try:
-        invite, token = mint_invite(
+        invite, _token = mint_invite(  # _token: link delivered via email/wizard, never logged
             store,
             email=admin_email,
             role="enterprise_admin",
@@ -109,19 +111,20 @@ async def bootstrap_first_admin_if_needed(store: SqliteStore) -> None:
         log.exception("bootstrap_first_admin: mint_invite failed for %s", admin_email)
         return
 
-    public_url_base = os.environ.get("CQ_PUBLIC_BASE_URL", "").rstrip("/")
-    if public_url_base:
-        magic_link = f"{public_url_base}/invite/{token}"
-    else:
-        magic_link = f"/invite/{token}  (set CQ_PUBLIC_BASE_URL to surface the absolute URL)"
-
-    # Bracketed sentinel makes it greppable in CloudWatch Logs Insights.
+    # SECURITY (audit 2026-06-01): do NOT log the full magic-link — its URL embeds
+    # a single-use bearer token that grants the founder identity for the invite
+    # TTL (7d), and CloudWatch read is a much broader audience than the founder.
+    # The link is now delivered to the founder via email (provisioning phase 5,
+    # SES) and surfaced on the wizard done-screen (job result magic_link_url), so
+    # the CloudWatch copy was pure exposure with no remaining delivery role. We
+    # log only that an invite was minted (greppable sentinel + invite_id), never
+    # the token.
     log.warning(
-        "[BOOTSTRAP_ADMIN] First-admin invite minted for %s (invite_id=%d, expires=%s). magic_link=%s",
+        "[BOOTSTRAP_ADMIN] First-admin invite minted for %s (invite_id=%d, expires=%s) — "
+        "magic-link delivered via email + wizard done-screen; token NOT logged.",
         admin_email,
         invite.id,
         invite.expires_at,
-        magic_link,
     )
 
 

--- a/server/backend/src/cq_server/bootstrap_admin.py
+++ b/server/backend/src/cq_server/bootstrap_admin.py
@@ -53,6 +53,15 @@ _INVITE_TTL_HOURS = 24 * 7  # 7 days for the first admin; longer than
 # the default 24h because the operator may need a window to hand the
 # URL off, and the bearer is single-use anyway.
 
+# Decision 42 / W2 — the dedicated agent user that owns the Liaison Server's
+# service key. Like _bootstrap_system it is a marker row, excluded from
+# _users_exist so it can never make the founder/password admin bootstrap think
+# real users already exist (regardless of lifespan call order).
+_LIAISON_USERNAME = "_liaison_service"
+_DEFAULT_LIAISON_TTL = "365d"  # the system's MAX_TTL (ttl.parse_ttl caps at 365d).
+# The Quick sidecar key therefore needs annual rotation — the provisioning
+# worker re-seeds it on redeploy, and an expiry monitor is an M3 follow-up.
+
 
 async def bootstrap_first_admin_if_needed(store: SqliteStore) -> None:
     """If no users exist and env is set, mint the founder's invite.
@@ -224,19 +233,132 @@ async def bootstrap_password_admin_if_needed(store: SqliteStore) -> None:
     )
 
 
-async def _users_exist(store: SqliteStore) -> bool:
-    """Return True iff at least one row in users (excluding the system row).
+async def bootstrap_liaison_key_if_needed(store: SqliteStore) -> None:
+    """Seed the Liaison Server's agent API key on first boot (decision 42, W2).
 
-    We let the SqliteStore expose this via raw text since there's no
-    count-users helper today and this is one query at boot.
+    The Quick-enablement stack co-deploys a Liaison Server (LS) sidecar that must
+    authenticate to THIS L2 with a ``cqa.v1.*`` bearer. In the founder onboarding
+    path there is NO admin principal at cold boot, so the LS can neither mint
+    itself a key via the admin route (``require_admin``) nor consume the founder's
+    one-time magic-link. Instead the provisioning worker generates the bearer ONCE
+    and seeds it symmetrically: into the LS (as ``L2_AUTH_TOKEN``) and into THIS L2
+    via ``CQ_INITIAL_LIAISON_KEY``. On first boot we insert that exact token as a
+    full-capability agent key owned by a dedicated ``_liaison_service`` agent user
+    — mirroring ``agent_key_routes.mint_agent_key`` but from a PROVIDED token.
+
+    Unlike the admin bootstraps this is NOT mutually exclusive with the founder
+    path — it is a service key, not an admin, so both run. Pins the agent to the
+    L2's own tenancy (``CQ_ENTERPRISE``/``CQ_GROUP``) like the password-admin path.
+
+    Idempotency: skipped when ``CQ_INITIAL_LIAISON_KEY`` is unset or the
+    ``_liaison_service`` user already exists. Never raises — boot must not fail.
+    """
+    token = os.environ.get("CQ_INITIAL_LIAISON_KEY", "").strip()
+    if not token:
+        return
+    pepper = os.environ.get("CQ_API_KEY_PEPPER", "")
+    if not pepper:
+        log.error(
+            "[BOOTSTRAP_LIAISON] CQ_INITIAL_LIAISON_KEY set but CQ_API_KEY_PEPPER "
+            "missing — cannot hash the key; skipping"
+        )
+        return
+
+    try:
+        if await store.get_user(_LIAISON_USERNAME) is not None:
+            log.debug("bootstrap_liaison_key: skipped — _liaison_service already present")
+            return
+    except Exception:  # noqa: BLE001
+        log.exception("bootstrap_liaison_key: user probe failed; skipping")
+        return
+
+    import uuid
+    from datetime import UTC, datetime
+
+    from .api_keys import decode_token, hash_secret, secret_prefix
+    from .auth import hash_password
+    from .ttl import parse_ttl
+
+    try:
+        key_id, secret = decode_token(token)
+    except Exception:  # noqa: BLE001
+        log.error("[BOOTSTRAP_LIAISON] CQ_INITIAL_LIAISON_KEY is not a valid cqa.v1.* token; skipping")
+        return
+
+    # Pin to the L2's tenancy only when BOTH are set (matches password-admin).
+    ent_raw = os.environ.get("CQ_ENTERPRISE", "").strip()
+    grp_raw = os.environ.get("CQ_GROUP", "").strip()
+    enterprise_id: str | None = ent_raw or None
+    group_id: str | None = grp_raw or None
+    if enterprise_id is None or group_id is None:
+        enterprise_id = group_id = None
+
+    ttl = os.environ.get("CQ_INITIAL_LIAISON_KEY_TTL", "").strip() or _DEFAULT_LIAISON_TTL
+    try:
+        expires_at = (datetime.now(UTC) + parse_ttl(ttl)).isoformat()
+    except Exception:  # noqa: BLE001
+        ttl = _DEFAULT_LIAISON_TTL
+        expires_at = (datetime.now(UTC) + parse_ttl(ttl)).isoformat()
+
+    try:
+        await store.create_user(
+            _LIAISON_USERNAME,
+            hash_password(uuid.uuid4().hex),  # unusable password — bearer-only
+            role="user",
+            enterprise_id=enterprise_id,
+            group_id=group_id,
+        )
+        new_user = await store.get_user(_LIAISON_USERNAME)
+        if new_user is None:
+            log.error("bootstrap_liaison_key: service user create returned None")
+            return
+        await store.upsert_persona_assignment(
+            username=_LIAISON_USERNAME,
+            persona="agent",
+            assigned_at=datetime.now(UTC).isoformat(),
+            assigned_by=_LIAISON_USERNAME,
+            audit_action="CREATED",
+            audit_old_persona=None,
+        )
+        await store.create_api_key(
+            key_id=key_id.hex,
+            user_id=int(new_user["id"]),
+            name="liaison-server",
+            labels=["harness:liaison", "persona:agent", "managed-by:provision"],
+            key_prefix=secret_prefix(secret),
+            key_hash=hash_secret(secret, pepper=pepper),
+            ttl=ttl,
+            expires_at=expires_at,
+        )
+    except Exception:  # noqa: BLE001
+        log.exception("bootstrap_liaison_key: seeding failed; skipping")
+        return
+
+    log.warning(
+        "[BOOTSTRAP_LIAISON] Liaison service agent key seeded (key_id=%s, "
+        "enterprise=%s, group=%s, ttl=%s)",
+        key_id.hex,
+        enterprise_id or "default-enterprise",
+        group_id or "default-group",
+        ttl,
+    )
+
+
+async def _users_exist(store: SqliteStore) -> bool:
+    """Return True iff a real user exists (excluding marker rows).
+
+    Excludes both ``_bootstrap_system`` and ``_liaison_service`` — neither is a
+    real principal, so neither must make the founder/password admin bootstrap
+    think the L2 is already onboarded. We let the SqliteStore expose this via raw
+    text since there's no count-users helper today and this is one query at boot.
     """
     from sqlalchemy import text
 
     def _count() -> int:
         with store._engine.connect() as conn:  # noqa: SLF001
             row = conn.execute(
-                text("SELECT COUNT(*) FROM users WHERE username != :sys"),
-                {"sys": _SYSTEM_USERNAME},
+                text("SELECT COUNT(*) FROM users WHERE username NOT IN (:sys, :liaison)"),
+                {"sys": _SYSTEM_USERNAME, "liaison": _LIAISON_USERNAME},
             ).first()
             return int(row[0]) if row else 0
 

--- a/server/backend/tests/test_bootstrap_liaison.py
+++ b/server/backend/tests/test_bootstrap_liaison.py
@@ -1,0 +1,126 @@
+"""Tests for ``bootstrap_liaison_key_if_needed`` (decision 42 / W2).
+
+The Quick-enablement sidecar (Liaison Server) needs a ``cqa.v1.*`` bearer to talk
+to a freshly cold-provisioned L2, but no admin principal exists at cold boot in
+the founder path. The provisioning worker seeds the SAME token here
+(``CQ_INITIAL_LIAISON_KEY``) and into the LS; on first boot we insert it as a
+full-capability agent key owned by a dedicated ``_liaison_service`` user.
+
+Covers: seeds + stored hash matches the verify-path hash; idempotent; no-op when
+unset; invalid token skips without raising; and — critically — the
+``_liaison_service`` marker never blocks the founder/password admin bootstrap.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy import text
+
+from cq_server.api_keys import encode_token, generate_secret, hash_secret
+from cq_server.bootstrap_admin import (
+    _LIAISON_USERNAME,
+    _users_exist,
+    bootstrap_first_admin_if_needed,
+    bootstrap_liaison_key_if_needed,
+)
+from cq_server.store import SqliteStore
+
+_PEPPER = "test-pepper-0123456789abcdef"
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> Iterator[SqliteStore]:
+    from cq_server.migrations import run_migrations
+
+    db = tmp_path / "liaison.db"
+    run_migrations(f"sqlite:///{db}")
+    s = SqliteStore(db_path=db)
+    yield s
+    s.close_sync()
+
+
+def _make_token() -> tuple[uuid.UUID, str, str]:
+    key_id = uuid.uuid4()
+    secret = generate_secret()
+    return key_id, secret, encode_token(key_id=key_id, secret=secret)
+
+
+def _api_key_hash(store: SqliteStore, key_id_hex: str) -> str | None:
+    with store._engine.connect() as conn:  # noqa: SLF001
+        row = conn.execute(
+            text("SELECT key_hash FROM api_keys WHERE id = :id"), {"id": key_id_hex}
+        ).fetchone()
+    return row[0] if row else None
+
+
+async def test_seeds_liaison_key(store: SqliteStore, monkeypatch: pytest.MonkeyPatch) -> None:
+    key_id, secret, token = _make_token()
+    monkeypatch.setenv("CQ_INITIAL_LIAISON_KEY", token)
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", _PEPPER)
+    monkeypatch.setenv("CQ_ENTERPRISE", "acme")
+    monkeypatch.setenv("CQ_GROUP", "engineering")
+
+    await bootstrap_liaison_key_if_needed(store)
+
+    user = await store.get_user(_LIAISON_USERNAME)
+    assert user is not None
+    # The stored hash must equal what the server's verify path computes from the
+    # plaintext secret + pepper — i.e. the seeded key will actually authenticate.
+    assert _api_key_hash(store, key_id.hex) == hash_secret(secret, pepper=_PEPPER)
+
+
+async def test_idempotent(store: SqliteStore, monkeypatch: pytest.MonkeyPatch) -> None:
+    _, _, token = _make_token()
+    monkeypatch.setenv("CQ_INITIAL_LIAISON_KEY", token)
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", _PEPPER)
+
+    await bootstrap_liaison_key_if_needed(store)
+    await bootstrap_liaison_key_if_needed(store)  # second run: must be a no-op
+
+    with store._engine.connect() as conn:  # noqa: SLF001
+        n = conn.execute(
+            text("SELECT COUNT(*) FROM users WHERE username = :u"),
+            {"u": _LIAISON_USERNAME},
+        ).scalar()
+    assert n == 1
+
+
+async def test_noop_when_unset(store: SqliteStore, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("CQ_INITIAL_LIAISON_KEY", raising=False)
+    await bootstrap_liaison_key_if_needed(store)
+    assert await store.get_user(_LIAISON_USERNAME) is None
+
+
+async def test_invalid_token_skips_without_raising(
+    store: SqliteStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CQ_INITIAL_LIAISON_KEY", "not-a-valid-cqa-token")
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", _PEPPER)
+    await bootstrap_liaison_key_if_needed(store)  # must not raise
+    assert await store.get_user(_LIAISON_USERNAME) is None
+
+
+async def test_does_not_block_admin_bootstrap(
+    store: SqliteStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The _liaison_service marker must not make the founder bootstrap skip."""
+    _, _, token = _make_token()
+    monkeypatch.setenv("CQ_INITIAL_LIAISON_KEY", token)
+    monkeypatch.setenv("CQ_API_KEY_PEPPER", _PEPPER)
+    await bootstrap_liaison_key_if_needed(store)
+
+    # _liaison_service exists, but no REAL user does — so the admin bootstraps
+    # must still consider the L2 un-onboarded.
+    assert await _users_exist(store) is False
+
+    monkeypatch.setenv("CQ_INITIAL_ADMIN_EMAIL", "founder@example.com")
+    await bootstrap_first_admin_if_needed(store)
+    with store._engine.connect() as conn:  # noqa: SLF001
+        sys_n = conn.execute(
+            text("SELECT COUNT(*) FROM users WHERE username = '_bootstrap_system'")
+        ).scalar()
+    assert sys_n == 1  # the founder bootstrap ran despite the liaison user


### PR DESCRIPTION
## Why
This session's agent-repo work accumulated on a feature branch and was never landed on `main` — **`main` is 11 commits behind and is missing critical fixes**, including the #155 customer-role grant. The deployed/published artifacts are correct, but a rebuild from `main` would regress them (the same drift class the audit flagged). This PR reconciles `main`. Clean fast-forward (no conflict).

## What it lands (by area)

**Decision 42 — Quick-enable (M1/G1 #150):**
- `6240817` quick-stack CFN (LS on AgentCore + Cognito OAuth)
- `008f537` cq-server first-boot Liaison service-key bootstrap (W2)
- `cc611f8` conditional `CQ_INITIAL_LIAISON_KEY` mount
- `3f93e41` quick-stack private-ECR pull perms
- `fad1e88` TaskExecutionRole `ssm:GetParameters` on liaison_key
- `e970153` **W1**: LS→L2 hop is `http://` the raw ALB (M1 live-run correction)

**Signup audit fixes (2026-06-02):**
- `207b33d` **#155** — customer-role `ssm`+`kms` on `/8th-layer/l2/*` (the silent-hang fix; already republished to S3, this puts it on `main`)
- `7b4338c` customer-role phase-6 Quick grants
- `143d814` **security** — stop logging the founder magic-link bearer token to CloudWatch
- `8401d22` MODIFICATIONS.md → real §4(b) exhaustive coverage

**Decision 43 — A1:**
- `5e6a0f0` optional HTTPS:443 ALB listener on `marketplace-l2.yaml` (backward-compatible; dormant unless a `CertificateArn` is supplied)

## Risk
Low. No auto-deploy from `main` (CodeBuild is triggered, not push-driven). All changes are committed + verified (CFN validates; the directory test suite is green). `marketplace-l2.yaml` change is additive-only (24 insertions, 0 deletions). The customer-role + W1 fixes are already live in their deployed forms; this aligns `main` with reality.