### PR TITLE
fix(decision-43): grant acm:* in customer deploy-role snippet

### DIFF
--- a/docs/marketplace-customer-role-snippet.yaml
+++ b/docs/marketplace-customer-role-snippet.yaml
@@ -136,6 +136,17 @@ Resources:
               - Effect: Allow
                 Action: dlm:*
                 Resource: "*"
+              # Decision 43 (AWS-native L2 edge): when the provisioning service
+              # runs in route53 edge-mode, the L2 terminates its OWN TLS — it
+              # requests an ACM cert for <slug>.enterprise.8th-layer.ai IN THIS
+              # account, polls for DNS-validation + ISSUED, attaches it to the
+              # ALB HTTPS:443 listener, and deletes it on teardown. ACM cert ARNs
+              # aren't knowable at RequestCertificate time, so acm can't be
+              # ARN-scoped — granted on "*", same pattern as dlm. Unused (harmless)
+              # while the service runs in the legacy cloudflare edge-mode.
+              - Effect: Allow
+                Action: acm:*
+                Resource: "*"
               # IAM role lifecycle, scoped to the eighth-layer-l2-* name
               # prefix (see the prefix-matching note above — the names are
               # CFN-auto-generated from the stack name, not explicit). Note


### PR DESCRIPTION
The route53 L2 edge has each L2 terminate its own TLS — phase-3 requests an ACM cert for `<slug>.enterprise.8th-layer.ai` in the customer account and attaches it to the ALB:443 listener. The customer deploy role granted ec2/ecs/elb/dlm/iam but **not acm**, so a real route53-mode provision AccessDenied'd at RequestCertificate.

acm on `*` (cert ARN unknown at request time, same as dlm). Dormant in cloudflare mode. Companion to 8th-layer-directory#50 (matching acm:* in the assume-role session policy — both layers intersect, both needed). Proven by a live cross-account provision serving its own ACM cert with no Cloudflare.