### PR TITLE
fix(template): set AWS_REGION on L2 container (boto3 NoRegionError)

### DIFF
--- a/deploy/aws/marketplace-l2.yaml
+++ b/deploy/aws/marketplace-l2.yaml
@@ -138,11 +138,17 @@ Parameters:
 
   CqServerImage:
     Type: String
-    Default: public.ecr.aws/w2i0e4m6/cq-server:git-b6d4c8747790
+    Default: public.ecr.aws/w2i0e4m6/cq-server:git-d93d080aeaf0
     Description: |
       cq-server image tag the L2 will run. Default points at the public
       ECR mirror of OneZero1ai/8th-layer-agent main, pinned to a known-
       good linux/amd64 build.
+
+      Bump 2026-06-02 to `:git-d93d080aeaf0` — the first build carrying the
+      SSM bootstrap-link handoff (PR #394): the L2 writes the founder
+      magic-link to SSM for the worker to read, replacing the CloudWatch-log
+      delivery a 2026-06-01 audit removed (which had silently broken every
+      cold provision's invite). Without this image the magic_link is empty.
 
       Bump 2026-05-27 from `:fo-2-as-1` (built 2026-05-12, predates
       bootstrap_admin.py at commits aaeaf31+d865a1d) to

--- a/deploy/aws/marketplace-l2.yaml
+++ b/deploy/aws/marketplace-l2.yaml
@@ -827,6 +827,11 @@ Resources:
           Environment:
             - { Name: CQ_PORT, Value: "3000" }
             - { Name: CQ_DB_PATH, Value: /data/cq.db }
+            # boto3 region resolution: ECS-on-EC2 gives the task CREDENTIALS via
+            # IMDS but NOT a region for client construction, so `boto3.client(...)`
+            # with no region raises NoRegionError. The bootstrap-admin SSM write
+            # (and any other in-task boto3 use) needs this set explicitly.
+            - { Name: AWS_REGION, Value: !Ref "AWS::Region" }
             # agent#303 — CQ_ENTERPRISE / CQ_GROUP drive tenancy stamping
             # (tenant_enterprise / tenant_group on activity_log, KUs, agents).
             # CQ_ENTERPRISE must be the *parent Enterprise* id, which for an


### PR DESCRIPTION
The bootstrap SSM write (P1#1) hit NoRegionError — ECS-on-EC2 gives the task creds via IMDS but not a region for boto3 client construction, and AWS_REGION wasn't in the env. Set from AWS::Region. Already republished to 929. (The narrow except + FATAL sentinel correctly caught + surfaced it.)